### PR TITLE
feat: Export raw font styles

### DIFF
--- a/src/components/Typography/docs.md
+++ b/src/components/Typography/docs.md
@@ -21,17 +21,70 @@ import {fontFamilies} from '@project-r/styleguide'
 </pre>
 ```
 
-A helper function to generate the `@font-face` css is available as `fontFaces`. 
+A helper function to generate the `@font-face` css is available as `fontFaces`.
 
 ### Next.js example
 
 1. Copy the font files to `/static/fonts`
 2. Include the following in your `pages/_document.js`:
 
-```
+```code|lang-js
 import {fontFaces} from '@project-r/styleguide'
 
 <style dangerouslySetInnerHTML={{ __html: fontFaces() }} />
+```
+
+## Font styles
+
+A font style combines a font cut with a font size, line height, letter spacing, text transform etc. The styles are made available as plain JavaScript objects which can be mixed into glamor css objects, or used directly in inline styles.
+
+Font styles don't include colors, margins, nor do they make use of media queries.
+
+```code|lang-js
+import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguide'
+
+<div {...css({...serifRegular21, color: text})}>…</div>
+```
+
+#### `serifBold{52,24}`
+```react|noSource,plain
+<div {...css(styles.serifBold52)}>The quick brown fox jumps over</div>
+```
+```react|noSource,plain
+<div {...css(styles.serifBold24)}>The quick brown fox jumps over the lazy dog</div>
+```
+
+#### `serifRegular{25,21,16}`
+```react|noSource,plain
+<div {...css(styles.serifRegular25)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.serifRegular21)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.serifRegular16)}>The quick brown fox jumps over the lazy dog</div>
+```
+
+#### `sansSerifMedium{40,22}`
+```react|noSource,plain
+<div {...css(styles.sansSerifMedium40)}>The quick brown fox jumps over</div>
+```
+```react|noSource,plain
+<div {...css(styles.sansSerifMedium22)}>The quick brown fox jumps over the lazy dog</div>
+```
+
+#### `sansSerifRegular{30,21,16,14}`
+```react|noSource,plain
+<div {...css(styles.sansSerifRegular30)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.sansSerifRegular21)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.sansSerifRegular16)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.sansSerifRegular14)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
 ## Editorial Content

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import * as styles from './styles'
 import {css} from 'glamor'
 
+export const fontStyles = styles
+
 export const linkRule = css(styles.link)
 export const A = ({children, ...props}) => (
   <a {...props} {...linkRule}>{children}</a>

--- a/src/components/Typography/styles.js
+++ b/src/components/Typography/styles.js
@@ -13,13 +13,82 @@ export const link = {
   }
 }
 
-export const h1 = {
-  color: colors.text,
+// serifRegular
+export const serifRegular25 = {
+  fontFamily: fontFamilies.serifRegular,
+  fontSize: 25,
+  lineHeight: '33px'
+}
+export const serifRegular21 = {
+  fontFamily: fontFamilies.serifRegular,
+  fontSize: 21,
+  lineHeight: '32px'
+}
+export const serifRegular16 = {
+  fontFamily: fontFamilies.serifRegular,
+  fontSize: 16,
+  lineHeight: '25px'
+}
+
+// serifBold
+export const serifBold52 = {
   fontFamily: fontFamilies.serifBold,
   fontWeight: 'normal',
   fontSize: 52,
   lineHeight: '56px',
-  letterSpacing: -0.45,
+  letterSpacing: -0.45
+}
+export const serifBold24 = {
+  fontFamily: fontFamilies.serifBold,
+  fontWeight: 'normal',
+  fontSize: 24,
+  lineHeight: '26px',
+  letterSpacing: -0.21
+}
+
+// sansSerifRegular
+export const sansSerifRegular30 = {
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontWeight: 'normal',
+  fontSize: 30,
+  lineHeight: '35px',
+  letterSpacing: -0.26,
+}
+export const sansSerifRegular21 = {
+  fontFamily: fontFamilies.serifRegular,
+  fontSize: 21,
+  lineHeight: '32px'
+}
+export const sansSerifRegular16 = {
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontSize: 16,
+  lineHeight: '25px',
+}
+export const sansSerifRegular14 = {
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontSize: 14,
+  lineHeight: '19px'
+}
+
+// sansSerifMedium
+export const sansSerifMedium40 = {
+  fontFamily: fontFamilies.sansSerifMedium,
+  fontWeight: 'normal',
+  fontSize: 40,
+  lineHeight: '46px',
+  letterSpacing: -0.35,
+}
+export const sansSerifMedium22 = {
+  fontFamily: fontFamilies.sansSerifMedium,
+  fontWeight: 'normal',
+  fontSize: 22,
+  lineHeight: '28px',
+  letterSpacing: 'normal'
+}
+
+export const h1 = {
+  ...serifBold52,
+  color: colors.text,
   margin: '30px 0 20px 0',
   ':first-child': {
     marginTop: 0
@@ -30,12 +99,8 @@ export const h1 = {
 }
 
 export const h2 = {
+  ...serifBold24,
   color: colors.text,
-  fontFamily: fontFamilies.serifBold,
-  fontWeight: 'normal',
-  fontSize: 24,
-  lineHeight: '26px',
-  letterSpacing: -0.21,
   margin: '30px 0 20px 0',
   ':first-child': {
     marginTop: 0
@@ -46,21 +111,16 @@ export const h2 = {
 }
 
 export const lead = {
+  ...serifRegular25,
   color: colors.text,
-  fontFamily: fontFamilies.serifRegular,
-  fontSize: 25,
-  lineHeight: '33px',
   margin: '20px 0 20px 0'
 }
 
 export const p = {
   color: colors.text,
-  fontFamily: fontFamilies.serifRegular,
-  fontSize: 16,
-  lineHeight: '25px',
+  ...serifRegular16,
   [mUp]: {
-    fontSize: 21,
-    lineHeight: '32px'
+    ...serifRegular21,
   },
   margin: '20px 0 20px 0',
   ':first-child': {
@@ -72,60 +132,41 @@ export const p = {
 }
 
 export const label = {
-  fontSize: 14,
-  lineHeight: '19px',
-  fontFamily: fontFamilies.sansSerifRegular,
+  ...sansSerifRegular14,
   color: colors.secondary
 }
 
 export const quote = {
+  ...sansSerifRegular21,
   color: colors.text,
-  fontSize: 21,
-  lineHeight: '32px',
-  fontFamily: fontFamilies.serifRegular
 }
 export const quoteText = {
 
 }
 
 export const interactionH1 = {
+  ...sansSerifMedium40,
   color: colors.text,
-  fontFamily: fontFamilies.sansSerifMedium,
-  fontWeight: 'normal',
-  fontSize: 40,
-  lineHeight: '46px',
-  letterSpacing: -0.35,
   margin: 0
 }
 
 export const interactionH2 = {
+  ...sansSerifRegular30,
   color: colors.text,
-  fontFamily: fontFamilies.sansSerifRegular,
-  fontWeight: 'normal',
-  fontSize: 30,
-  lineHeight: '35px',
-  letterSpacing: -0.26,
   margin: 0
 }
 
 export const interactionH3 = {
+  ...sansSerifMedium22,
   color: colors.text,
-  fontFamily: fontFamilies.sansSerifMedium,
-  fontWeight: 'normal',
-  fontSize: 22,
-  lineHeight: '28px',
-  letterSpacing: 'normal',
   margin: 0
 }
 
 export const interactionP = {
   color: colors.text,
-  fontFamily: fontFamilies.sansSerifRegular,
-  fontSize: 16,
-  lineHeight: '25px',
+  ...sansSerifRegular16,
   [mUp]: {
-    fontSize: 21,
-    lineHeight: '32px'
+    ...sansSerifRegular21
   },
   margin: 0
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {Catalog} from 'catalog'
 import {simulations, css} from 'glamor'
 import theme from './catalogTheme'
 import './catalogTheme.css'
+import {fontStyles} from './components/Typography'
 
 import 'core-js/fn/array/from'
 import 'core-js/fn/array/find'
@@ -48,6 +49,8 @@ ReactDOM.render(
             title: 'Typography',
             imports: {
               ...require('./components/Typography'),
+              css,
+              styles: JSON.parse(JSON.stringify(fontStyles)),
               fontFamilies: require('./theme/fonts').fontFamilies
             },
             src: require('./components/Typography/docs.md')

--- a/src/lib.js
+++ b/src/lib.js
@@ -16,6 +16,7 @@ export {Spinner, InlineSpinner} from './components/Spinner'
 
 export {Container, NarrowContainer} from './components/Grid'
 export {
+  fontStyles,
   linkRule, A,
   H1, H2,
   Lead,


### PR DESCRIPTION
Export all raw font styles and document in the catalog.

Font style is a combination of font cut, size, line height etc. By collecting the list I already noticed that we use a few slightly-different sizes, eg. `sansSerifMedium22` and `sansSerifRegular21`.

In the Sketch file I have I also saw some use of font with size 15. I didn't add that style yet, because then we'd have sizes 14, 15, and 16 – three sizes which are very close together.

If I plot the font sizes which are currently used, then they follow quite closely the Major Third scale (each size is 1.25 times larger than the next smaller size). We might want to make that more explicit in the future.

![image](https://user-images.githubusercontent.com/34538/31421917-a7473fae-ae4a-11e7-9210-d9459f7ce616.png)
