### PR TITLE
refactor: Upgrade react to 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10595,12 +10595,11 @@
       }
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.0.0.tgz",
+      "integrity": "sha1-zn348ZQbA28Cssyp29DLHw6FXi0=",
       "dev": true,
       "requires": {
-        "create-react-class": "15.6.2",
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
@@ -10683,9 +10682,9 @@
       }
     },
     "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",
+      "integrity": "sha1-nMMHnD3NcNTG4BuEqrKn40wwP1g=",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -10704,8 +10703,8 @@
         "babel-code-frame": "6.22.0",
         "babel-runtime": "6.26.0",
         "html-entities": "1.2.1",
-        "react": "15.6.2",
-        "react-dom": "15.6.2",
+        "react": "16.0.0",
+        "react-dom": "16.0.0",
         "settle-promise": "1.0.0",
         "source-map": "0.5.6"
       },
@@ -10730,12 +10729,13 @@
       }
     },
     "react-maskedinput": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/react-maskedinput/-/react-maskedinput-3.3.4.tgz",
-      "integrity": "sha1-dztuBqOE7L7lxSYQWX/OO823/S0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-maskedinput/-/react-maskedinput-4.0.0.tgz",
+      "integrity": "sha512-S1eqDnCQuerXIdbTaE4+mCV99Bp106E/GBHlxuSD2KyV7zVlqfHyW/K+mCbBeoaju3NZhPXc34OjwzAcUq5U2g==",
       "dev": true,
       "requires": {
-        "inputmask-core": "2.2.0"
+        "inputmask-core": "2.2.0",
+        "prop-types": "15.6.0"
       }
     },
     "react-router": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "peerDependencies": {
     "glamor": "^2.20.37",
-    "react": "^15.4.2",
+    "react": "^16.0.0",
     "prop-types": "^15.5.7"
   },
   "devDependencies": {
@@ -20,10 +20,10 @@
     "glamor": "^2.20.37",
     "husky": "^0.14.3",
     "prop-types": "^15.5.7",
-    "react": "^15.4.2",
+    "react": "^16.0.0",
     "react-autocomplete": "^1.4.1",
-    "react-dom": "^15.4.2",
-    "react-maskedinput": "^3.3.4",
+    "react-dom": "^16.0.0",
+    "react-maskedinput": "^4.0.0",
     "react-scripts": "1.0.10",
     "react-textarea-autosize": "^5.1.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
One really nice feature of react v16 is that [components can return lists of elements](https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings), without the need to wrap the elements in a container (eg. a div). I'd like to make use of that feature in the Discussion components.

Note that this is potentially a breaking change:

BREAKING CHANGE: Since react is a peer dependency, you may have to upgrade react in your own
project.