### PR TITLE
feat: CommentComposer component

### DIFF
--- a/src/components/CommentComposer/CommentComposer.js
+++ b/src/components/CommentComposer/CommentComposer.js
@@ -1,0 +1,116 @@
+import React, {PureComponent} from 'react'
+import {css} from 'glamor'
+import colors from '../../theme/colors'
+import {serifRegular16, sansSerifRegular16} from '../Typography/styles'
+import {MdClose} from 'react-icons/lib/md'
+
+import CommentComposerHeader from './CommentComposerHeader'
+
+const styles = {
+  form: css({
+    background: colors.whiteSmoke,
+    borderTop: '1px solid white'
+  }),
+  textArea: css({
+    padding: '6px 12px 0',
+    width: '100%',
+    minWidth: '100%',
+    maxWidth: '100%',
+    minHeight: '100px',
+    background: 'transparent',
+    border: 'none',
+    outline: 'none',
+    boxSizing: 'border-box',
+    ...serifRegular16,
+    color: colors.text
+  }),
+  textAreaEmpty: css({
+    color: colors.lightText,
+  }),
+  actions: css({
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    height: '40px'
+  }),
+  cancelButton: css({
+    '-webkit-appearance': 'none',
+    background: 'transparent',
+    border: 'none',
+    padding: '0 6px',
+    cursor: 'pointer',
+
+    alignSelf: 'stretch',
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '20px'
+  }),
+  commitButton: css({
+    '-webkit-appearance': 'none',
+    background: 'transparent',
+    border: 'none',
+    padding: '0 12px 0 6px',
+    cursor: 'pointer',
+
+    ...sansSerifRegular16,
+    color: colors.ocker,
+
+    alignSelf: 'stretch',
+    display: 'flex',
+    alignItems: 'center'
+  })
+}
+
+class CommentComposer extends PureComponent {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      text: ''
+    }
+
+    this.onChange = ev => {
+      this.setState({text: ev.target.value})
+    }
+
+    this.onSubmit = () => {
+      this.props.submitComment(this.state.text)
+    }
+  }
+
+  render () {
+    const {t, displayAuthor, onEditPreferences, onCancel} = this.props
+    const {text} = this.state
+
+    return (
+      <div>
+        <CommentComposerHeader
+          {...displayAuthor}
+          onClick={onEditPreferences}
+        />
+
+        <div {...styles.form}>
+          <textarea
+            {...styles.textArea}
+            {...(text === '' ? styles.textAreaEmpty : {})}
+            placeholder={t('components/CommentComposer/CommentComposer/placeholder')}
+            value={text}
+            rows='5'
+            onChange={this.onChange}
+          />
+
+          <div {...styles.actions}>
+            <button {...styles.cancelButton} onClick={onCancel}>
+              <MdClose />
+            </button>
+            <button {...styles.commitButton} onClick={this.onSubmit}>
+              {t('components/CommentComposer/CommentComposer/answer')}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default CommentComposer

--- a/src/components/CommentComposer/CommentComposerHeader.js
+++ b/src/components/CommentComposer/CommentComposerHeader.js
@@ -1,13 +1,15 @@
 import React from 'react'
 import {css} from 'glamor'
-import {MdCheck} from 'react-icons/lib/md'
+import {MdCheck, MdEdit} from 'react-icons/lib/md'
 import colors from '../../theme/colors'
 import {sansSerifMedium16, sansSerifRegular14} from '../Typography/styles'
 
 const styles = {
   root: css({
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    background: colors.whiteSmoke,
+    padding: '12px'
   }),
   profilePicture: css({
     display: 'block',
@@ -16,10 +18,12 @@ const styles = {
     marginRight: 10
   }),
   meta: css({
+    flex: 1,
     alignSelf: 'stretch',
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    minWidth: 0,
   }),
   name: css({
     ...sansSerifMedium16,
@@ -28,16 +32,12 @@ const styles = {
     overflow: 'hidden',
     textOverflow: 'ellipsis'
   }),
-  timeago: css({
+  description: css({
     ...sansSerifRegular14,
     color: colors.lightText,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'
-  }),
-  description: css({
-    ...sansSerifRegular14,
-    color: colors.lightText
   }),
   verifiedDescription: css({
     color: colors.text
@@ -46,10 +46,24 @@ const styles = {
     display: 'inline-block',
     marginLeft: 4,
     marginTop: -2
+  }),
+  actionButton: css({
+    '-webkit-appearance': 'none',
+    background: 'transparent',
+    border: 'none',
+    flexShrink: 0,
+    alignSelf: 'stretch',
+    display: 'flex',
+    flexDirection: 'center',
+    justifyContent: 'center',
+    margin: '-12px -12px -12px 0',
+    padding: '12px 20px',
+    fontSize: '24px',
+    cursor: 'pointer',
   })
 }
 
-export const CommentHeader = ({t, profilePicture, name, timeago, credential}) => (
+const CommentComposerHeader = ({profilePicture, name, credential, onClick}) => (
   <div {...styles.root}>
     {profilePicture && <img
       {...styles.profilePicture}
@@ -59,14 +73,16 @@ export const CommentHeader = ({t, profilePicture, name, timeago, credential}) =>
     <div {...styles.meta}>
       <div {...styles.name}>
         {name}
-        {timeago && <span {...styles.timeago}>・{timeago}</span>}
       </div>
       {credential && <div {...styles.description} {...(credential.verified ? styles.verifiedDescription : {})}>
         {credential.description}
         {credential.verified && <MdCheck {...styles.verifiedCheck} />}
       </div>}
     </div>
+    <button {...styles.actionButton} onClick={onClick}>
+      <MdEdit />
+    </button>
   </div>
 )
 
-export default CommentHeader
+export default CommentComposerHeader

--- a/src/components/CommentComposer/docs.md
+++ b/src/components/CommentComposer/docs.md
@@ -1,0 +1,41 @@
+### `<CommentComposer />`
+
+```react|noSource,span-4
+<CommentComposer
+  t={t}
+  displayAuthor={{
+    name: 'Adrienne Fichter',
+    profilePicture: '/static/profilePicture.png',
+    credential: {description: 'Redaktorin', verified: false}
+  }}
+  onCancel={() => {}}
+  submitComment={t => {alert(t)}}
+/>
+```
+
+```react|noSource,span-2
+<CommentComposer
+  t={t}
+  displayAuthor={{
+    name: 'Johann N. Schneider-Ammann',
+    profilePicture: '/static/profilePicture.png',
+    credential: {description: 'Bundesrat', verified: true}
+  }}
+  onCancel={() => {}}
+  submitComment={t => {alert(t)}}
+/>
+```
+
+### `<CommentComposerHeader />`
+
+Almost like `<CommentHeader />` but with a button on the right.
+
+```react|noSource
+<CommentComposerHeader
+  {...{
+    name: 'Ueli Maurer',
+    profilePicture: '/static/profilePicture.png',
+    credential: {description: 'Bundesrat', verified: false}
+  }}
+/>
+```

--- a/src/components/CommentComposer/docs.t.js
+++ b/src/components/CommentComposer/docs.t.js
@@ -1,0 +1,10 @@
+export default k => {
+  switch (k) {
+    case 'components/CommentComposer/CommentComposer/placeholder':
+      return 'Einen Kommentar verfassen…'
+    case 'components/CommentComposer/CommentComposer/answer':
+      return 'Antworten'
+    default:
+      return ''
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,16 @@ ReactDOM.render(
             },
             src: require('./components/Comment/docs.md')
           },
+          {
+            path: '/components/comment-composer',
+            title: 'CommentComposer',
+            imports: {
+              t: require('./components/CommentComposer/docs.t'),
+              CommentComposer: require('./components/CommentComposer/CommentComposer'),
+              CommentComposerHeader: require('./components/CommentComposer/CommentComposerHeader'),
+            },
+            src: require('./components/CommentComposer/docs.md')
+          },
         ]
       },
       {


### PR DESCRIPTION
To show these components in the catalog I need a `t()` function. To make it convenient I created a a `docs.t.js` file in the component folder and expose that function to the whole catalog page using imports. But perhaps it would be better to store those strings in JSON files so that they can be used to seed the spreadsheet you have. And it would also allow us to show the required translation keys in the catalog pages.

![image](https://user-images.githubusercontent.com/34538/31605093-a34473a8-b265-11e7-8b1b-4b2839ed7cfa.png)
