### PR TITLE
Comment tree refactor

### DIFF
--- a/src/components/Comment/CommentHeader.js
+++ b/src/components/Comment/CommentHeader.js
@@ -37,6 +37,7 @@ const styles = {
   }),
   description: css({
     ...sansSerifRegular14,
+    lineHeight: 1,
     color: colors.lightText
   }),
   verifiedDescription: css({

--- a/src/components/CommentTree/Collapse.js
+++ b/src/components/CommentTree/Collapse.js
@@ -30,12 +30,12 @@ const styles = {
   })
 }
 
-const LoadMore = ({t, visualDepth, count, onClick}) => (
-  <div {...styles.root} style={{marginLeft: (visualDepth - 1) * 15}}>
+const Collapse = ({t, onClick}) => (
+  <div {...styles.root}>
     <button {...styles.button} onClick={onClick}>
-      {t.pluralize('styleguide/CommentTreeLoadMore/label', {count})}
+      {t('styleguide/CommentTreeCollapse/label')}
     </button>
   </div>
 )
 
-export default LoadMore
+export default Collapse

--- a/src/components/CommentTree/Collapse.js
+++ b/src/components/CommentTree/Collapse.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {css} from 'glamor'
 
 import colors from '../../theme/colors'
@@ -37,5 +38,10 @@ const Collapse = ({t, onClick}) => (
     </button>
   </div>
 )
+
+Collapse.propTypes = {
+  t: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired
+}
 
 export default Collapse

--- a/src/components/CommentTree/DepthBar.js
+++ b/src/components/CommentTree/DepthBar.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {css} from 'glamor'
 
 const styles = {
@@ -20,5 +21,28 @@ const styles = {
 
 const range = (n) => Array.from(new Array(n))
 
-export const DepthBar = ({head, tail}) => <div {...styles.depthBar} {...(head ? styles.head : {})} {...(tail ? styles.tail : {})} />
-export const DepthBars = ({count, head, tail}) => range(count).map((_, index) => <DepthBar key={index} head={index === count - 1 && head} tail={index === count - 1 && tail} />)
+export const DepthBar = ({head, tail}) =>
+  <div
+    {...styles.depthBar}
+    {...(head ? styles.head : {})} {...(tail ? styles.tail : {})}
+  />
+
+DepthBar.propTypes = {
+  head: PropTypes.bool.isRequired,
+  tail: PropTypes.bool.isRequired
+}
+
+export const DepthBars = ({count, head, tail}) =>
+  range(count).map((_, index) => (
+    <DepthBar
+      key={index}
+      head={index === count - 1 && head}
+      tail={index === count - 1 && tail}
+    />
+  ))
+
+DepthBars.propTypes = {
+  count: PropTypes.number.isRequired,
+  head: PropTypes.bool.isRequired,
+  tail: PropTypes.bool.isRequired
+}

--- a/src/components/CommentTree/DepthBar.js
+++ b/src/components/CommentTree/DepthBar.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import {css} from 'glamor'
+
+const styles = {
+  depthBar: css({
+    width: 15,
+    flexBasis: '15px',
+    flexShrink: 0,
+    flexGrow: 0,
+    alignSelf: 'stretch',
+    borderLeft: '1px solid #DBDBDB'
+  }),
+  head: css({
+    marginTop: 20
+  }),
+  tail: css({
+    marginBottom: 20
+  })
+}
+
+const range = (n) => Array.from(new Array(n))
+
+export const DepthBar = ({head, tail}) => <div {...styles.depthBar} {...(head ? styles.head : {})} {...(tail ? styles.tail : {})} />
+export const DepthBars = ({count, head, tail}) => range(count).map((_, index) => <DepthBar key={index} head={index === count - 1 && head} tail={index === count - 1 && tail} />)

--- a/src/components/CommentTree/LoadMore.js
+++ b/src/components/CommentTree/LoadMore.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {css} from 'glamor'
 
 import colors from '../../theme/colors'
@@ -37,5 +38,12 @@ const LoadMore = ({t, visualDepth, count, onClick}) => (
     </button>
   </div>
 )
+
+LoadMore.propTypes = {
+  t: PropTypes.func.isRequired,
+  visualDepth: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+  onClick: PropTypes.func.isRequired
+}
 
 export default LoadMore

--- a/src/components/CommentTree/Node.js
+++ b/src/components/CommentTree/Node.js
@@ -1,14 +1,6 @@
 import React, {PureComponent} from 'react'
-import {css} from 'glamor'
 import PropTypes from 'prop-types'
-
-import {Comment, CommentActions} from '../Comment'
-import CommentComposer from '../CommentComposer/CommentComposer'
 import Row from './Row'
-import LoadMore from './LoadMore'
-import {DepthBars} from './DepthBar'
-
-const range = (n) => Array.from(new Array(n))
 
 class Node extends PureComponent {
   constructor (props) {
@@ -53,7 +45,7 @@ class Node extends PureComponent {
     } = this.props
     const {showComposer} = this.state
 
-    const {createdAt, score, comments, userVote} = comment
+    const {comments, userVote} = comment
     const hasChildren = comments && comments.totalCount > 0
 
     // Adjust the visual depth and other options based on the shape of the comment
@@ -143,7 +135,7 @@ class Node extends PureComponent {
       return This
     }
 
-    const {totalCount, pageInfo, nodes} = comments
+    const {nodes} = comments
 
     return [
       This,
@@ -162,7 +154,6 @@ class Node extends PureComponent {
                 head={true}
                 tail={true}
                 otherChild
-                key={i}
                 comment={c}
               />
             )),

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {PureComponent} from 'react'
 import {css} from 'glamor'
 
 import {Comment, CommentActions} from '../Comment'
@@ -10,7 +10,8 @@ const styles = {
     display: 'flex'
   }),
   commentComposerContainer: css({
-    marginTop: '20px'
+    marginTop: '20px',
+    transition: 'opacity .2s'
   }),
 }
 
@@ -49,15 +50,30 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
   )
 }
 
-const Composer = ({t, displayAuthor, onCancel, submitComment}) => (
-  <div {...styles.commentComposerContainer}>
-    <CommentComposer
-      t={t}
-      displayAuthor={displayAuthor}
-      onCancel={onCancel}
-      submitComment={submitComment}
-    />
-  </div>
-)
+class Composer extends PureComponent {
+  constructor (props) {
+    super(props)
+    this.state = {isVisible: false}
+  }
+  componentDidMount () {
+    this.setState({isVisible: true})
+  }
+
+  render () {
+    const {t, displayAuthor, onCancel, submitComment} = this.props
+    const {isVisible} = this.state
+
+    return (
+      <div {...styles.commentComposerContainer} style={{opacity: isVisible ? 1 : 0}}>
+        <CommentComposer
+          t={t}
+          displayAuthor={displayAuthor}
+          onCancel={onCancel}
+          submitComment={submitComment}
+        />
+      </div>
+    )
+  }
+}
 
 export default Row

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import {css} from 'glamor'
+
+import {Comment, CommentActions} from '../Comment'
+import CommentComposer from '../CommentComposer/CommentComposer'
+import {DepthBars} from './DepthBar'
+
+const styles = {
+  root: css({
+    display: 'flex'
+  }),
+  commentComposerContainer: css({
+    marginTop: '20px'
+  }),
+}
+
+const range = (n) => Array.from(new Array(n))
+
+const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, onAnswer, onUpvote, onDownvote, dismissComposer, submitComment, timeago}) => {
+  const {createdAt, score} = comment
+
+  return (
+    <div {...styles.root}>
+      <DepthBars count={visualDepth} head={head} tail={tail} />
+      <div style={{flexGrow: 1, padding: otherChild ? '20px 0 20px 15px' : '20px 0'}}>
+        <Comment
+          timeago={timeago(createdAt)}
+          {...comment}
+        />
+
+        <CommentActions
+          t={t}
+          score={score}
+          onAnswer={onAnswer}
+          onUpvote={onUpvote}
+          onDownvote={onDownvote}
+        />
+
+        {showComposer &&
+          <Composer
+            t={t}
+            displayAuthor={displayAuthor}
+            onCancel={dismissComposer}
+            submitComment={submitComment}
+          />
+        }
+      </div>
+    </div>
+  )
+}
+
+const Composer = ({t, displayAuthor, onCancel, submitComment}) => (
+  <div {...styles.commentComposerContainer}>
+    <CommentComposer
+      t={t}
+      displayAuthor={displayAuthor}
+      onCancel={onCancel}
+      submitComment={submitComment}
+    />
+  </div>
+)
+
+export default Row

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -1,4 +1,5 @@
 import React, {PureComponent} from 'react'
+import PropTypes from 'prop-types'
 import {css} from 'glamor'
 
 import {Comment, CommentActions} from '../Comment'
@@ -14,8 +15,6 @@ const styles = {
     transition: 'opacity .2s'
   }),
 }
-
-const range = (n) => Array.from(new Array(n))
 
 const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, onAnswer, onUpvote, onDownvote, dismissComposer, submitComment, timeago}) => {
   const {createdAt, score} = comment
@@ -50,6 +49,23 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
   )
 }
 
+Row.propTypes = {
+  t: PropTypes.func.isRequired,
+  visualDepth: PropTypes.number.isRequired,
+  head: PropTypes.bool.isRequired,
+  tail: PropTypes.bool.isRequired,
+  otherChild: PropTypes.bool,
+  comment: PropTypes.object.isRequired,
+  displayAuthor: PropTypes.object.isRequired,
+  showComposer: PropTypes.bool.isRequired,
+  onAnswer: PropTypes.func.isRequired,
+  onUpvote: PropTypes.func,
+  onDownvote: PropTypes.func,
+  dismissComposer: PropTypes.func.isRequired,
+  submitComment: PropTypes.func.isRequired,
+  timeago: PropTypes.func.isRequired,
+}
+
 class Composer extends PureComponent {
   constructor (props) {
     super(props)
@@ -74,6 +90,13 @@ class Composer extends PureComponent {
       </div>
     )
   }
+}
+
+Composer.propTypes = {
+  t: PropTypes.func.isRequired,
+  displayAuthor: PropTypes.object.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  submitComment: PropTypes.func.isRequired,
 }
 
 export default Row

--- a/src/components/CommentTree/comments.js
+++ b/src/components/CommentTree/comments.js
@@ -1,6 +1,6 @@
 const profilePicture = '/static/profilePicture1.png'
 
-export const mkComment = (n, children) => ({
+export const mkComment = (n, children, pageInfo) => ({
   id: n,
   displayAuthor: {
     profilePicture,
@@ -11,41 +11,41 @@ export const mkComment = (n, children) => ({
   userVote: 'DOWN',
   content: 'Journalismus strebt nach Klarheit, er ist der Feind der uralten Angst vor dem Neuen.',
   comments: children.length === 0
-    ? undefined
-    : {totalCount: children.length, nodes: children}
+    ? (pageInfo ? {totalCount: 27, pageInfo, nodes: []} : undefined)
+    : {totalCount: 27, pageInfo, nodes: children}
 })
 
 export const comment1 = mkComment('1', [])
 
 export const comment2 = mkComment('2', [
   mkComment('2.1', [])
-])
+], {hasNextPage: true})
 
 export const comment3 = mkComment('3', [
   mkComment('3.1', []),
   mkComment('3.2', [])
-])
+], {hasNextPage: true})
 
 export const comment4 = mkComment('4', [
   mkComment('4.1', []),
   mkComment('4.2', []),
   mkComment('4.3', [])
-])
+], {hasNextPage: true})
 
 export const comment5 = mkComment('5', [
   mkComment('5.1', [
     mkComment('5.1.1', [])
   ]),
-  mkComment('5.2', [])
-])
+  mkComment('5.2', [], {hasNextPage: true})
+], {hasNextPage: true})
 
 export const comment6 = mkComment('6', [
   mkComment('6.1', [
-    mkComment('6.1.1', []),
+    mkComment('6.1.1', [], {hasNextPage: true}),
     mkComment('6.1.2', [])
-  ]),
+  ], {hasNextPage: true}),
   mkComment('6.2', [])
-])
+], {hasNextPage: true})
 
 export const comment7 = mkComment('7', [
   mkComment('7.1', [

--- a/src/components/CommentTree/docs.imports.js
+++ b/src/components/CommentTree/docs.imports.js
@@ -1,9 +1,27 @@
 import React from 'react'
+
+import SomeRow from './Row'
 import SomeNode from './Node'
+
 import * as allComments from './comments'
+import LoadMore from './LoadMore'
 
 export {default as LoadMore} from './LoadMore'
+export {default as Collapse} from './Collapse'
+
 export const comments = {...allComments}
+
+export const Row = (props) => (
+  <SomeRow
+    displayAuthor={{
+      profilePicture: '/static/profilePicture1.png',
+      name: `Christof Moser`,
+      credential: {description: 'Journalist', verified: true}
+    }}
+    timeago={() => '2h'}
+    {...props}
+  />
+)
 
 export const Node = ({t, comment}) => (
   <SomeNode
@@ -19,6 +37,14 @@ export const Node = ({t, comment}) => (
     upvoteComment={() => {}}
     downvoteComment={() => {}}
     submitComment={() => {}}
-    fetchMore={() => {}}
+    More={({visualDepth, comment: {comments}}) => {
+      if (comments && comments.pageInfo && comments.pageInfo.hasNextPage) {
+        return (
+          <LoadMore t={t} depth={visualDepth} count={comments.totalCount - (comments.nodes || []).length} />
+        )
+      } else {
+        return null
+      }
+    }}
   />
 )

--- a/src/components/CommentTree/docs.imports.js
+++ b/src/components/CommentTree/docs.imports.js
@@ -13,11 +13,19 @@ export const comments = {...allComments}
 
 export const Row = (props) => (
   <SomeRow
+    head={false}
+    tail={false}
     displayAuthor={{
       profilePicture: '/static/profilePicture1.png',
       name: `Christof Moser`,
       credential: {description: 'Journalist', verified: true}
     }}
+    showComposer={false}
+    onAnswer={() => {}}
+    onUpvote={() => {}}
+    onDownvote={() => {}}
+    dismissComposer={() => {}}
+    submitComment={() => {}}
     timeago={() => '2h'}
     {...props}
   />
@@ -40,7 +48,12 @@ export const Node = ({t, comment}) => (
     More={({visualDepth, comment: {comments}}) => {
       if (comments && comments.pageInfo && comments.pageInfo.hasNextPage) {
         return (
-          <LoadMore t={t} visualDepth={visualDepth} count={comments.totalCount - (comments.nodes || []).length} />
+          <LoadMore
+            t={t}
+            visualDepth={visualDepth}
+            count={comments.totalCount - (comments.nodes || []).length}
+            onClick={() => {}}
+          />
         )
       } else {
         return null

--- a/src/components/CommentTree/docs.imports.js
+++ b/src/components/CommentTree/docs.imports.js
@@ -40,7 +40,7 @@ export const Node = ({t, comment}) => (
     More={({visualDepth, comment: {comments}}) => {
       if (comments && comments.pageInfo && comments.pageInfo.hasNextPage) {
         return (
-          <LoadMore t={t} depth={visualDepth} count={comments.totalCount - (comments.nodes || []).length} />
+          <LoadMore t={t} visualDepth={visualDepth} count={comments.totalCount - (comments.nodes || []).length} />
         )
       } else {
         return null

--- a/src/components/CommentTree/docs.md
+++ b/src/components/CommentTree/docs.md
@@ -1,6 +1,6 @@
 A discussion is logically a tree structure, but is displayed more like a list. This is so that we can display a sequence of direct replies without increasing indentation.
 
-Each comment is shown as a full-width div, with an appropriate number of vertical bars on its left to indicate its depth (`visualDepth`). Additional amount of left padding an be added with the `otherChild` flag. Below are three examples with varying visual depths, the last one has the `otherChild` flag set to true.
+Each comment is shown as a full-width div, with an appropriate number of vertical bars on its left to indicate its depth (`visualDepth`). Additional amount of left padding an be added with the `otherChild` flag.
 
 ```react|noSource,span-3,plain
 <Row t={t} comment={comments.comment1} visualDepth={2} />

--- a/src/components/CommentTree/docs.md
+++ b/src/components/CommentTree/docs.md
@@ -1,61 +1,98 @@
-### `<CommentTreeLoadMore />`
+A discussion is logically a tree structure, but is displayed more like a list. This is so that we can display a sequence of direct replies without increasing indentation.
 
-```react|noSource
-<LoadMore t={t} count={128} onClick={() => {}} />
+Each comment is shown as a full-width div, with an appropriate number of vertical bars on its left to indicate its depth (`visualDepth`). Additional amount of left padding an be added with the `otherChild` flag. Below are three examples with varying visual depths, the last one has the `otherChild` flag set to true.
+
+```react|noSource,span-3,plain
+<Row t={t} comment={comments.comment1} visualDepth={2} />
 ```
+```react|noSource,span-3,plain
+<Row t={t} comment={comments.comment1} visualDepth={4} otherChild />
+```
+
+The right-most vertical bar can be made shorter at the top or bottom to indicate it's the first (`head`) or last (`tail`) comment of a sequence.
+
+```react|noSource,span-2,plain
+<Row t={t} comment={comments.comment1} visualDepth={3} head />
+```
+```react|noSource,span-2,plain
+<Row t={t} comment={comments.comment1} visualDepth={3} head tail />
+```
+```react|noSource,span-2,plain
+<Row t={t} comment={comments.comment1} visualDepth={3} tail />
+```
+
+### `<CommentTreeLoadMore />`, `<CommentTreeCollapse />`
+
+To indicate that there are more comments which can be loaded at a particular depth, use `<CommentTreeLoadMore />`. Inversely, if the comments after a certain point can be collapsed, use `<CommentTreeCollapse />`. This element is always shown full-width, there is no way to indent it. Don't forget to set `tail=false` on the `<Row />` immediately preceding these elements.
+
+```react|noSource,span-3,plain
+<div>
+  <Row t={t} comment={comments.comment1} visualDepth={3} head />
+  <LoadMore t={t} visualDepth={3} count={128} onClick={() => {}} />
+</div>
+```
+```react|noSource,span-3,plain
+<div>
+  <Row t={t} comment={comments.comment1} visualDepth={3} head />
+  <Collapse t={t} onClick={() => {}} />
+</div>
+```
+
 
 ### `<CommentTreeNode />`
 
+The `<CommentTreeNode />` shows a comment and its children. It is up to the user of this component to define what should be shown in places where more comments can be loaded (using the `More` prop). Every node has a `visualDepth` (number of bars) and also a `logicalDepth` (how many parents one must walk to get to the root).
+
 #### Example 1
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment1} />
 ```
 
 #### Example 2
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment2} />
 ```
 
 #### Example 3
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment3}  />
 ```
 
 #### Example 4
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment4}  />
 ```
 
 #### Example 5
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment5}  />
 ```
 
 #### Example 6
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment6} />
 ```
 
 #### Example 7
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment7} />
 ```
 
 #### Example 8
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment8} />
 ```
 
 #### Example 9
 
-```react|noSource
+```react|noSource,plain
 <Node t={t} comment={comments.comment9} />
 ```

--- a/src/components/CommentTree/index.js
+++ b/src/components/CommentTree/index.js
@@ -1,2 +1,3 @@
 export {default as CommentTreeNode} from './Node'
 export {default as CommentTreeLoadMore} from './LoadMore'
+export {default as CommentTreeCollapse} from './Collapse'

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-10-25T08:58:17.700Z",
+  "updated": "2017-10-27T11:08:45.201Z",
   "title": "live",
   "data": [
     {
@@ -16,11 +16,15 @@
     },
     {
       "key": "styleguide/CommentTreeLoadMore/label/1",
-      "value": "Eine weiterer Kommentar"
+      "value": "Ein weiterer Kommentar"
     },
     {
       "key": "styleguide/CommentTreeLoadMore/label/other",
       "value": "{count} weitere Kommentare"
+    },
+    {
+      "key": "styleguide/CommentTreeCollapse/label",
+      "value": "ausblenden"
     }
   ]
 }


### PR DESCRIPTION
I had to change the structure of the CommentTree components because the tree-like structure didn't work well with the sections that decrease the indentation when they are expanded. Now it's more list-like, where each comment is shown in a separate row. That works well thanks to the React 16 feature where render functions can return lists of element that don't need to be wrapped in an anonymous container (usually a div).

This is technically a breaking change (since the `CommentTreeComponent` API has changed), but nobody was using that component yet.

![comment-tree-refactor](https://user-images.githubusercontent.com/34538/32215192-906bb1a2-be21-11e7-83ad-8b6ea7c4cf66.png)
