### PR TITLE
feat: Show error in when submitComment fails inside a CommentTree

### DIFF
--- a/src/components/CommentComposer/docs.md
+++ b/src/components/CommentComposer/docs.md
@@ -8,6 +8,7 @@
     profilePicture: '/static/profilePicture1.png',
     credential: {description: 'Redaktorin', verified: false}
   }}
+  onEditPreferences={() => {}}
   onCancel={() => {}}
   submitComment={t => {alert(t)}}
 />
@@ -21,6 +22,7 @@
     profilePicture: '/static/profilePicture1.png',
     credential: {description: 'Bundesrat', verified: true}
   }}
+  onEditPreferences={() => {}}
   onCancel={() => {}}
   submitComment={t => {alert(t)}}
 />
@@ -77,6 +79,7 @@ The error message that is shown below the `<CommentComposer />` if creating the 
     credential: {description: 'Redaktorin', verified: false}
   }}
   error='Sie sind zu früh. Bitte warten Sie, 161.446s bevor Sie wieder kommentieren.'
+  onEditPreferences={() => {}}
   onCancel={() => {}}
   submitComment={t => {alert(t)}}
 />

--- a/src/components/CommentTree/Node.js
+++ b/src/components/CommentTree/Node.js
@@ -7,14 +7,21 @@ class Node extends PureComponent {
     super(props)
 
     this.state = {
-      showComposer: false
+      composerState: 'idle', // idle | focused | submitting | error
+      composerError: undefined // or string
     }
 
     this.openComposer = () => {
-      this.setState({showComposer: true})
+      this.setState({
+        composerState: 'focused',
+        composerError: undefined
+      })
     }
     this.dismissComposer = () => {
-      this.setState({showComposer: false})
+      this.setState({
+        composerState: 'idle',
+        composerError: undefined
+      })
     }
 
     this.upvoteComment = () => {
@@ -24,8 +31,21 @@ class Node extends PureComponent {
       this.props.downvoteComment(this.props.comment.id)
     }
     this.submitComment = (content) => {
-      this.props.submitComment(this.props.comment.id, content)
-      this.dismissComposer()
+      this.setState({composerState: 'submitting'})
+      this.props.submitComment(this.props.comment.id, content).then(
+        () => {
+          this.setState({
+            composerState: 'idle',
+            composerError: undefined
+          })
+        },
+        (e) => {
+          this.setState({
+            composerState: 'error',
+            composerError: e
+          })
+        }
+      )
     }
   }
 
@@ -43,7 +63,7 @@ class Node extends PureComponent {
       timeago,
       More
     } = this.props
-    const {showComposer} = this.state
+    const {composerState, composerError} = this.state
 
     const {comments, userVote} = comment
     const hasChildren = comments && comments.totalCount > 0
@@ -121,7 +141,8 @@ class Node extends PureComponent {
         otherChild={otherChild}
         comment={comment}
         displayAuthor={displayAuthor}
-        showComposer={showComposer}
+        showComposer={composerState !== 'idle'}
+        composerError={composerError}
         onAnswer={this.openComposer}
         onUpvote={userVote === 'UP' ? undefined : this.upvoteComment}
         onDownvote={userVote === 'DOWN' ? undefined : this.downvoteComment}

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -16,7 +16,7 @@ const styles = {
   }),
 }
 
-const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, onAnswer, onUpvote, onDownvote, dismissComposer, submitComment, timeago}) => {
+const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, composerError, onAnswer, onUpvote, onDownvote, dismissComposer, submitComment, timeago}) => {
   const {createdAt, score} = comment
 
   return (
@@ -40,6 +40,7 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
           <Composer
             t={t}
             displayAuthor={displayAuthor}
+            error={composerError}
             onCancel={dismissComposer}
             submitComment={submitComment}
           />
@@ -58,6 +59,7 @@ Row.propTypes = {
   comment: PropTypes.object.isRequired,
   displayAuthor: PropTypes.object.isRequired,
   showComposer: PropTypes.bool.isRequired,
+  composerError: PropTypes.string,
   onAnswer: PropTypes.func.isRequired,
   onUpvote: PropTypes.func,
   onDownvote: PropTypes.func,
@@ -76,7 +78,7 @@ class Composer extends PureComponent {
   }
 
   render () {
-    const {t, displayAuthor, onCancel, submitComment} = this.props
+    const {t, displayAuthor, error, onCancel, submitComment} = this.props
     const {isVisible} = this.state
 
     return (
@@ -84,6 +86,7 @@ class Composer extends PureComponent {
         <CommentComposer
           t={t}
           displayAuthor={displayAuthor}
+          error={error}
           onCancel={onCancel}
           submitComment={submitComment}
         />
@@ -95,6 +98,7 @@ class Composer extends PureComponent {
 Composer.propTypes = {
   t: PropTypes.func.isRequired,
   displayAuthor: PropTypes.object.isRequired,
+  error: PropTypes.string,
   onCancel: PropTypes.func.isRequired,
   submitComment: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
BREAKING CHANGE: The submitComment function must return a Promise which rejects with a string upon failure to submit a comment.