### PR TITLE
feat: CommentTeaser

### DIFF
--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import { css, merge } from 'glamor'
+import colors from '../../theme/colors'
+import { serifRegular14 } from '../Typography/styles'
+import CommentHeader from '../Comment/CommentHeader'
+import CommentTeaserHeader from './CommentTeaserHeader'
+import CommentTeaserFooter from './CommentTeaserFooter'
+
+const styles = {
+  root: {
+    marginBottom: '10px',
+    '& + &': {
+      borderTop: `1px solid ${colors.divider}`,
+      paddingTop: '20px'
+    }
+  },
+  body: {
+    ...serifRegular14,
+    margin: '10px 0'
+  },
+  clamp: {
+    // TODO: Replace with a crows-browser JS solution for line-clamping.
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical'
+  },
+  box: {
+    border: `1px solid ${colors.divider}`,
+    padding: '20px'
+  }
+}
+
+export const CommentTeaser = ({
+  t,
+  title,
+  subtitle,
+  displayAuthor,
+  content,
+  timeago,
+  commentUrl,
+  lineClamp,
+  isBox
+}) => (
+  <div {...css(merge(styles.root, isBox ? styles.box : {}))}>
+    {displayAuthor ? (
+      <CommentHeader {...displayAuthor} />
+    ) : (
+      <CommentTeaserHeader title={title} subtitle={subtitle} />
+    )}
+    <div
+      {...css(
+        merge(
+          styles.body,
+          lineClamp ? merge(styles.clamp, { WebkitLineClamp: lineClamp }) : {}
+        )
+      )}
+    >
+      {content}
+    </div>
+    <CommentTeaserFooter commentUrl={commentUrl} timeago={timeago} t={t} />
+  </div>
+)
+
+export default CommentTeaser

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { css, merge } from 'glamor'
+import { merge } from 'glamor'
 import colors from '../../theme/colors'
 import { serifRegular14 } from '../Typography/styles'
 import CommentHeader from '../Comment/CommentHeader'
@@ -16,6 +16,7 @@ const styles = {
   },
   body: {
     ...serifRegular14,
+    color: colors.text,
     margin: '10px 0'
   },
   clamp: {
@@ -41,18 +42,16 @@ export const CommentTeaser = ({
   lineClamp,
   isBox
 }) => (
-  <div {...css(merge(styles.root, isBox ? styles.box : {}))}>
+  <div {...merge(styles.root, isBox ? styles.box : {})}>
     {displayAuthor ? (
       <CommentHeader {...displayAuthor} />
     ) : (
       <CommentTeaserHeader title={title} subtitle={subtitle} />
     )}
     <div
-      {...css(
-        merge(
-          styles.body,
-          lineClamp ? merge(styles.clamp, { WebkitLineClamp: lineClamp }) : {}
-        )
+      {...merge(
+        styles.body,
+        lineClamp ? merge(styles.clamp, { WebkitLineClamp: lineClamp }) : {}
       )}
     >
       {content}

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -19,7 +19,7 @@ const styles = {
     margin: '10px 0'
   },
   clamp: {
-    // TODO: Replace with a crows-browser JS solution for line-clamping.
+    // TODO: Replace with a cross-browser JS solution for line-clamping.
     overflow: 'hidden',
     display: '-webkit-box',
     WebkitBoxOrient: 'vertical'

--- a/src/components/CommentTeaser/CommentTeaserFooter.js
+++ b/src/components/CommentTeaser/CommentTeaserFooter.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { css } from 'glamor'
+import colors from '../../theme/colors'
+import { link, sansSerifRegular14 } from '../Typography/styles'
+
+const styles = {
+  root: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between'
+  }),
+  default: css({
+    ...sansSerifRegular14,
+    color: colors.lightText
+  }),
+  link: css({
+    ...link
+  })
+}
+
+export const CommentTeaserFooter = ({ t, timeago, commentUrl }) => (
+  <div {...styles.root}>
+    {timeago && <div {...styles.default}>{timeago}</div>}
+    {commentUrl && (
+      <div {...styles.default}>
+        <a href={commentUrl} {...styles.link}>
+          {t('styleguide/CommentTeaser/commentLink')}
+        </a>
+      </div>
+    )}
+  </div>
+)
+
+export default CommentTeaserFooter

--- a/src/components/CommentTeaser/CommentTeaserHeader.js
+++ b/src/components/CommentTeaser/CommentTeaserHeader.js
@@ -17,8 +17,8 @@ const styles = {
   }),
   subtitle: css({
     ...sansSerifRegular14,
-    lineHeight: 1.1,
     color: colors.lightText,
+    lineHeight: 1.1,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'

--- a/src/components/CommentTeaser/CommentTeaserHeader.js
+++ b/src/components/CommentTeaser/CommentTeaserHeader.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { css } from 'glamor'
+import colors from '../../theme/colors'
+import { sansSerifMedium16, sansSerifRegular14 } from '../Typography/styles'
+
+const styles = {
+  root: css({
+    display: 'flex',
+    flexDirection: 'column'
+  }),
+  title: css({
+    ...sansSerifMedium16,
+    color: colors.text,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
+  }),
+  subtitle: css({
+    ...sansSerifRegular14,
+    lineHeight: 1.1,
+    color: colors.lightText,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
+  })
+}
+
+export const CommentTeaserHeader = ({ t, title, subtitle }) => (
+  <div {...styles.root}>
+    <div {...styles.title}>{title}</div>
+    {subtitle && <div {...styles.subtitle}>{subtitle}</div>}
+  </div>
+)
+
+export default CommentTeaserHeader

--- a/src/components/CommentTeaser/docs.imports.js
+++ b/src/components/CommentTeaser/docs.imports.js
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export {default as CommentTeaser} from './CommentTeaser'
+export {default as CommentTeaserHeader} from './CommentTeaserHeader'
+export {default as CommentTeaserFooter} from './CommentTeaserFooter'
+export {default as  CommentHeader} from '../Comment/CommentHeader'

--- a/src/components/CommentTeaser/docs.md
+++ b/src/components/CommentTeaser/docs.md
@@ -1,0 +1,122 @@
+Provides a preview of a comment, featuring either a title/subtitle or a displayAuthor.
+
+```react|noSource,span-3
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitel'
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  t={t}
+/>
+```
+```react|noSource,span-3
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitelee'
+  displayAuthor={{
+    profilePicture: '/static/profilePicture1.png',
+    name: 'Christof Moser',
+    credential: {description: 'Journalist'}
+  }}
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  t={t}
+/>
+```
+
+ The `lineClamp` property currently only supports webkit line-clamping.
+```react|noSource,span-3
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitel'
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  t={t}
+/>
+```
+```react|noSource,span-3
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitelee'
+  displayAuthor={{
+    profilePicture: '/static/profilePicture1.png',
+    name: 'Christof Moser',
+    credential: {description: 'Journalist'}
+  }}
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  t={t}
+/>
+```
+
+
+The `isBox` property triggers a border.
+```react|noSource,span-3
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitel'
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  isBox={true}
+  t={t}
+/>
+```
+```react|noSource,span-3
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitelee'
+  displayAuthor={{
+    profilePicture: '/static/profilePicture1.png',
+    name: 'Christof Moser',
+    credential: {description: 'Journalist'}
+  }}
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  isBox={true}
+  t={t}
+/>
+```
+
+Adjacent `<CommentTeaser />` elements render a divider.
+
+```react|noSource,span-6
+<div>
+<CommentTeaser
+  title='@Der Crowdfunding-Code gegen die Frankenstein-Monster-Strategie'
+  subtitle='Ein kurzer Untertitel'
+  content="Das Tückische beim Crowdfunding ist, dass der Ansturm entweder am Anfang kommt oder nie. Erreicht das Projekt in den ersten Tagen nicht mindestens einen Drittel des Ziels, ist es so gut wie gestorben. Nur ist das auch die Zeit, in der Ihr System am anfälligsten ist. Irgendeine Kinderkrankheit wird es haben, garantiert."
+  timeago='2h'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  t={t}
+/>
+<CommentTeaser
+  title='@Die neusten Neulinge an Bord der «Republik»'
+  subtitle='Ein kurzer Untertitel'
+  content="Sie als Verlegerin oder Verleger der «Republik» wird beruhigen, dass das nicht unsere Absicht ist. (So reizvoll es wäre.) Wir haben einige Fortschritte gemacht: Die Finanzplanung steht, der Prototyp des Publikationssystems läuft – und zwar elegant! – und der Grossteil der Redaktion ist angeheuert. Also sind alle Fundamente für den Start im Januar gelegt."
+  timeago='4h'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  t={t}
+/>
+<CommentTeaser
+  title='@Die Start-Aufstellung der «Republik»-Redaktion steht'
+  subtitle='Ein kurzer Untertitel'
+  content="Wir haben Ihnen als Verlegerin, als Verleger beim Crowdfunding versprochen, dass die Redaktion möglichst gemischt sein soll: nach Erfahrungen, Alter, Fähigkeiten – und etwa 50:50 in Sachen Geschlecht. Denn zusammen mit zu viel ähnlichen Leuten hat man keine Chance, den eigenen blinden Flecken zu entkommen. Egal, wie man sich dreht: Je schärfer man hinsieht, desto unsichtbarer wird, was man nicht sieht."
+  timeago='13. Juli 2017, 12:03 Uhr'
+  commentUrl='https://www.republik.ch/foo'
+  lineClamp={3}
+  t={t}
+/>
+</div>
+```

--- a/src/components/CommentTeaser/index.js
+++ b/src/components/CommentTeaser/index.js
@@ -1,0 +1,1 @@
+export {default as CommentTeaser} from './CommentTeaser'

--- a/src/index.js
+++ b/src/index.js
@@ -147,13 +147,7 @@ ReactDOM.render(
           {
             path: '/components/comment-teaser',
             title: 'CommentTeaser',
-            imports: {
-              t,
-              CommentTeaser: require('./components/CommentTeaser/CommentTeaser'),
-              CommentTeaserHeader: require('./components/CommentTeaser/CommentTeaserHeader'),
-              CommentTeaserFooter: require('./components/CommentTeaser/CommentTeaserFooter'),
-              CommentHeader: require('./components/Comment/CommentHeader')
-            },
+            imports: {t, ...require('./components/CommentTeaser/docs.imports')},
             src: require('./components/CommentTeaser/docs.md')
           },
           {

--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,18 @@ ReactDOM.render(
             src: require('./components/CommentComposer/docs.md')
           },
           {
+            path: '/components/comment-teaser',
+            title: 'CommentTeaser',
+            imports: {
+              t,
+              CommentTeaser: require('./components/CommentTeaser/CommentTeaser'),
+              CommentTeaserHeader: require('./components/CommentTeaser/CommentTeaserHeader'),
+              CommentTeaserFooter: require('./components/CommentTeaser/CommentTeaserFooter'),
+              CommentHeader: require('./components/Comment/CommentHeader')
+            },
+            src: require('./components/CommentTeaser/docs.md')
+          },
+          {
             path: '/components/comment-tree',
             title: 'CommentTree',
             imports: {t, ...require('./components/CommentTree/docs.imports')},

--- a/src/lib.js
+++ b/src/lib.js
@@ -18,6 +18,7 @@ export {default as Loader} from './components/Loader'
 export {Spinner, InlineSpinner} from './components/Spinner'
 export * from './components/Comment'
 export * from './components/CommentComposer'
+export * from './components/CommentTeaser'
 export * from './components/CommentTree'
 
 export {Container, NarrowContainer} from './components/Grid'

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-10-27T11:08:45.201Z",
+  "updated": "2017-11-01T11:30:19.255Z",
   "title": "live",
   "data": [
     {
@@ -13,6 +13,10 @@
     {
       "key": "styleguide/CommentActions/answer",
       "value": "Antworten"
+    },
+    {
+      "key": "styleguide/CommentTeaser/commentLink",
+      "value": "Zum Beitrag"
     },
     {
       "key": "styleguide/CommentTreeLoadMore/label/1",


### PR DESCRIPTION
FYI, we'll need the title/subtitle version for rendering "latestComments" on the profile page. And while I'm at it, I also added support for the displayAuthor header (to be used when highlighting specific user comments in editorial context).

![screen shot 2017-11-01 at 15 48 50](https://user-images.githubusercontent.com/23520051/32280459-38981aa0-bf1c-11e7-971f-fb1f97e08916.png)
