### PR TITLE
feat: pass onEditPreferences callback through CommentTreeNode to the CommentComposer

### DIFF
--- a/src/components/CommentTree/Node.js
+++ b/src/components/CommentTree/Node.js
@@ -61,6 +61,7 @@ class Node extends PureComponent {
       displayAuthor,
       comment,
       timeago,
+      onEditPreferences,
       More
     } = this.props
     const {composerState, composerError} = this.state
@@ -143,6 +144,7 @@ class Node extends PureComponent {
         displayAuthor={displayAuthor}
         showComposer={composerState !== 'idle'}
         composerError={composerError}
+        onEditPreferences={onEditPreferences}
         onAnswer={this.openComposer}
         onUpvote={userVote === 'UP' ? undefined : this.upvoteComment}
         onDownvote={userVote === 'DOWN' ? undefined : this.downvoteComment}
@@ -216,6 +218,7 @@ Node.propTypes = {
   displayAuthor: PropTypes.object.isRequired,
   comment: PropTypes.object.isRequired,
   timeago: PropTypes.func.isRequired,
+  onEditPreferences: PropTypes.func.isRequired,
   upvoteComment: PropTypes.func.isRequired,
   downvoteComment: PropTypes.func.isRequired,
   submitComment: PropTypes.func.isRequired,

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -16,7 +16,7 @@ const styles = {
   }),
 }
 
-const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, composerError, onAnswer, onUpvote, onDownvote, dismissComposer, submitComment, timeago}) => {
+const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, composerError, onEditPreferences, onAnswer, onUpvote, onDownvote, dismissComposer, submitComment, timeago}) => {
   const {createdAt, score} = comment
 
   return (
@@ -41,6 +41,7 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
             t={t}
             displayAuthor={displayAuthor}
             error={composerError}
+            onEditPreferences={onEditPreferences}
             onCancel={dismissComposer}
             submitComment={submitComment}
           />
@@ -60,6 +61,7 @@ Row.propTypes = {
   displayAuthor: PropTypes.object.isRequired,
   showComposer: PropTypes.bool.isRequired,
   composerError: PropTypes.string,
+  onEditPreferences: PropTypes.func.isRequired,
   onAnswer: PropTypes.func.isRequired,
   onUpvote: PropTypes.func,
   onDownvote: PropTypes.func,
@@ -78,7 +80,7 @@ class Composer extends PureComponent {
   }
 
   render () {
-    const {t, displayAuthor, error, onCancel, submitComment} = this.props
+    const {t, displayAuthor, error, onEditPreferences, onCancel, submitComment} = this.props
     const {isVisible} = this.state
 
     return (
@@ -87,6 +89,7 @@ class Composer extends PureComponent {
           t={t}
           displayAuthor={displayAuthor}
           error={error}
+          onEditPreferences={onEditPreferences}
           onCancel={onCancel}
           submitComment={submitComment}
         />

--- a/src/components/CommentTree/docs.imports.js
+++ b/src/components/CommentTree/docs.imports.js
@@ -21,6 +21,7 @@ export const Row = (props) => (
       credential: {description: 'Journalist', verified: true}
     }}
     showComposer={false}
+    onEditPreferences={() => {}}
     onAnswer={() => {}}
     onUpvote={() => {}}
     onDownvote={() => {}}
@@ -42,6 +43,7 @@ export const Node = ({t, comment}) => (
     }}
     comment={comment}
     timeago={() => '2h'}
+    onEditPreferences={() => {}}
     upvoteComment={() => {}}
     downvoteComment={() => {}}
     submitComment={() => {}}


### PR DESCRIPTION
This is required so that we can open the preference editor when the user clicks the edit icon in the CommentComposer component inside a tree.