### PR TITLE
feat: RawHtml

### DIFF
--- a/src/components/RawHtml/docs.md
+++ b/src/components/RawHtml/docs.md
@@ -1,4 +1,4 @@
-The `RawHtml` component allows to (dangerously) render raw HTML.
+The `RawHtml` component allows to (dangerously) render raw HTML with styleguide-compliant typography. Typical use cases are links and `<br />` tags inside translation strings.
 
 By default the HTML is rendered inside a `<span>` element. The `type` property can be either a tag name string (such as 'div' or 'h1'), or a React component type.
 

--- a/src/components/RawHtml/docs.md
+++ b/src/components/RawHtml/docs.md
@@ -1,0 +1,29 @@
+The `RawHtml` component allows to (dangerously) render raw HTML.
+
+By default the HTML is rendered inside a `<span>` element. The `type` property can be either a tag name string (such as 'div' or 'h1'), or a React component type.
+
+```react|span-6
+<RawHtml
+  dangerouslySetInnerHTML={{
+    __html: '<b>Bold</b> und <a href="#">Link</a>'
+  }}
+/>
+```
+
+```react|span-6
+<RawHtml
+  type={'h1'}
+  dangerouslySetInnerHTML={{
+    __html: '<b>Bold</b> und <a href="#">Link</a>'
+  }}
+/>
+```
+
+```react|span-6
+<RawHtml
+  type={Interaction.H1}
+  dangerouslySetInnerHTML={{
+    __html: '<b>Bold</b> und <a href="#">Link</a>'
+  }}
+/>
+```

--- a/src/components/RawHtml/index.js
+++ b/src/components/RawHtml/index.js
@@ -1,0 +1,30 @@
+import { createElement } from 'react'
+import { css } from 'glamor'
+import { link } from '../Typography/styles'
+import PropTypes from 'prop-types'
+
+const styles = {
+  default: css({
+    '& a': {
+      ...link
+    },
+    '& ul, & ol': {
+      overflow: 'hidden'
+    }
+  })
+}
+
+const RawHtml = ({type, dangerouslySetInnerHTML}) => createElement(type, {
+  ...styles.default,
+  dangerouslySetInnerHTML
+})
+
+RawHtml.defaultProps = {
+  type: 'span'
+}
+
+RawHtml.propTypes = {
+  type: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+}
+
+export default RawHtml

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,15 @@ ReactDOM.render(
             imports: {t, ...require('./components/Overlay/docs.imports')},
             src: require('./components/Overlay/docs.md')
           },
+          {
+            path: '/components/raw-html',
+            title: 'RawHtml',
+            imports: {
+              ...require('./components/Typography'),
+              RawHtml: require('./components/RawHtml')
+            },
+            src: require('./components/RawHtml/docs.md')
+          },
         ]
       },
       {

--- a/src/lib.js
+++ b/src/lib.js
@@ -16,6 +16,7 @@ export {default as FieldSet} from './components/Form/FieldSet'
 export {default as Radio} from './components/Form/Radio'
 export {default as Checkbox} from './components/Form/Checkbox'
 export {default as Loader} from './components/Loader'
+export {default as RawHtml} from './components/RawHtml'
 export {
   Spinner,
   InlineSpinner


### PR DESCRIPTION
Note that I've  removed most of the styles from the crowdfunding implementation, including the serif/sansSerif switch. I may add that back if we find a use case in publikator or republik frontends.

<img width="994" alt="screen shot 2017-11-06 at 17 26 52" src="https://user-images.githubusercontent.com/23520051/32451687-c11a6898-c317-11e7-8dda-8b6aba05922f.png">
