### PR TITLE
refactor: make overlay look nicer on large screens

### DIFF
--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -2,17 +2,38 @@ import React, {PureComponent} from 'react'
 import PropTypes from 'prop-types'
 import {css} from 'glamor'
 import zIndex from '../../theme/zIndex'
+import {mUp} from '../../theme/mediaQueries'
 
 const styles = {
   root: css({
     position: 'fixed',
     top: 0,
     left: 0,
-    width: '100vw',
-    height: '100vh',
+    bottom: 0,
+    right: 0,
     zIndex: zIndex.overlay,
+    transition: 'opacity .12s ease-in-out',
+    background: 'rgba(0,0,0,.2)',
+
+    [mUp]: {
+      overflowY: 'auto',
+    },
+  }),
+  inner: css({
+    position: 'relative',
+    zIndex: 1, // to establish a stacking context
     background: 'white',
-    transition: 'opacity .12s ease-in-out'
+    height: '100vh',
+    boxShadow: '0 0 6px rgba(0,0,0,.2)',
+    overflowY: 'auto',
+
+    [mUp]: {
+      maxWidth: '600px',
+      minHeight: '60vh',
+      height: 'auto',
+      margin: '20vh auto 20vh',
+      overflowY: 'visible'
+    },
   })
 }
 
@@ -21,6 +42,7 @@ class Overlay extends PureComponent {
     super(props)
     this.state = {isVisible: false}
   }
+
   componentDidMount () {
     // This timeout may not be required, but the fade-in won't work without
     // this inside the catalog.
@@ -28,28 +50,68 @@ class Overlay extends PureComponent {
       this.setState({isVisible: true})
     })
 
+    this.pageYOffset = window.pageYOffset
+    document.documentElement.style.top = `-${this.pageYOffset}px`
+    document.documentElement.style.position = 'relative'
+
     // Add overflow:hidden to the body element to remove any scroll bars. The overlay uses
     // width:100vw and that is the width of the whole viewport /including/ the scroll bar.
     document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
   }
   componentWillUnmount () {
     clearTimeout(this.fadeInTimeout)
     document.body.style.overflow = ''
+    document.body.style.position = ''
+    document.documentElement.style.top = '0'
+    window.scrollTo(0, this.pageYOffset)
   }
-  render () {
-    const {children, ...props} = this.props
-    const {isVisible} = this.state
 
+  render () {
     return (
-      <div {...styles.root} style={{opacity: isVisible ? 1 : 0}} {...props}>
-        {children}
+      <OverlayRenderer
+        {...this.props}
+        isVisible={this.state.isVisible}
+      />
+    )
+  }
+}
+
+Overlay.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClose: PropTypes.func.isRequired,
+}
+
+export default Overlay
+
+// This is the actual Overlay component that is rendered. We export this so we
+// can document the overlay in the catalog without affecting 'document.body'.
+export class OverlayRenderer extends PureComponent {
+  constructor (props) {
+    super(props)
+
+    // This event handler is attached to the background of the overlay.
+    this.close = (e) => {
+      if (e.target === e.currentTarget) {
+        this.props.onClose()
+      }
+    }
+  }
+
+  render () {
+    const {isVisible, children} = this.props
+    return (
+      <div {...styles.root} style={{opacity: isVisible ? 1 : 0}} onClick={this.close}>
+        <div {...styles.inner}>
+          {children}
+        </div>
       </div>
     )
   }
 }
 
 Overlay.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  isVisible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
 }
-
-export default Overlay

--- a/src/components/Overlay/OverlayBody.js
+++ b/src/components/Overlay/OverlayBody.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import {css} from 'glamor'
+import {mUp} from '../../theme/mediaQueries'
+import {height} from './OverlayToolbar'
+
+const overlayBodyStyle = css({
+  padding: `${height + 20}px 12px 20px`,
+
+  [mUp]: {
+    padding: `${height + 20}px 20px 20px`,
+  }
+})
+
+const OverlayBody = props =>
+  <div {...overlayBodyStyle} {...props} />
+
+export default OverlayBody

--- a/src/components/Overlay/OverlayToolbar.js
+++ b/src/components/Overlay/OverlayToolbar.js
@@ -4,18 +4,33 @@ import {css} from 'glamor'
 import {MdClose} from 'react-icons/lib/md'
 
 import colors from '../../theme/colors'
+import {mUp} from '../../theme/mediaQueries'
 import {sansSerifRegular16} from '../Typography/styles'
+
+export const height = 48
 
 const styles = {
   root: css({
     display: 'flex',
-    height: 48,
-    borderBottom: `1px solid ${colors.divider}`
+    height: `${height}px`,
+    background: 'white',
+    borderBottom: `1px solid ${colors.divider}`,
+
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    right: '0',
+    zIndex: 100,
+
+    [mUp]: {
+      position: 'absolute'
+    }
   }),
   close: css({
     fontSize: '24px',
-    height: '48px',
-    width: '48px',
+    height: `${height}px`,
+    width: '38px',
+    flexBasis: '38px',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
@@ -24,9 +39,20 @@ const styles = {
     outline: 'none',
     padding: '0',
     background: 'transparent',
+
+    // For some reason 'justify-content' doesn't work in iOS, so
+    // use auto margin to center the icon inside the button.
+    '& > svg': {
+      margin: '0 auto'
+    },
+
+    [mUp]: {
+      width: '48px',
+      flexBasis: '48px',
+    }
   }),
   confirm: css({
-    height: '48px',
+    height: `${height}px`,
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
@@ -38,14 +64,16 @@ const styles = {
     ...sansSerifRegular16,
     color: colors.primary,
     margin: '0 0 0 auto',
-    padding: '0 12px'
+    padding: '0 12px',
+
+    [mUp]: {
+      padding: '0 20px',
+    }
   })
 }
 
 export const OverlayToolbar = ({children}) => (
-  <div {...styles.root}>
-    {children}
-  </div>
+  <div {...styles.root}>{children}</div>
 )
 OverlayToolbar.propTypes = {
   children: PropTypes.node.isRequired

--- a/src/components/Overlay/docs.imports.js
+++ b/src/components/Overlay/docs.imports.js
@@ -1,9 +1,12 @@
 import React, {PureComponent} from 'react'
 import Button from '../Button'
-import Overlay from './Overlay'
 
-export {default as Overlay} from './Overlay'
+export {default as Overlay, OverlayRenderer} from './Overlay'
 export {OverlayToolbar, OverlayToolbarClose, OverlayToolbarConfirm} from './OverlayToolbar'
+export {default as OverlayBody} from './OverlayBody'
+export {default as Field} from '../Form/Field'
+export {default as Checkbox} from '../Form/Checkbox'
+export {Interaction} from '../Typography'
 
 export class OverlayExample extends PureComponent {
   constructor (props) {
@@ -20,17 +23,10 @@ export class OverlayExample extends PureComponent {
   }
 
   render () {
-    const {isOpen} = this.state
-
-    if (isOpen) {
-      return (
-        <Overlay onClick={this.close}>{this.props.children}</Overlay>
-      )
-    }
-
     return (
-      <div style={{height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
+      <div style={{height: '260px', display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
         <Button primary onClick={this.open}>Open Overlay</Button>
+        {this.state.isOpen && this.props.children({onClose: this.close})}
       </div>
     )
   }

--- a/src/components/Overlay/docs.md
+++ b/src/components/Overlay/docs.md
@@ -1,6 +1,6 @@
-The overlay covers the whole screen (100vw, 100vh). It opens with a short fade-in animation upon being mounted.
+On small devices the overlay covers the whole screen, has a sticky toolbar and the content below scrolls. On larger devices the overlay is centered and scrolls whole.
 
-Below are two examples in different viewport sizes. Click on the button to open the overlay, click anywhere in the overlay to close it again.
+The overlay blocks scrolling of the underlying page through `overflow:hidden` and `position:fixed` on the body element. The later is required on touch devices. Setting `position:fixed` on the body element scrolls the page to the top. To counter that we shift the whole page up (`top: -Npx`) while the overlay is open.
 
 ```react
 noSource: true
@@ -8,25 +8,59 @@ plain: true
 responsive: Klein
 span: 2
 ---
-<OverlayExample>
+<OverlayRenderer isVisible onClose={() => {}}>
   <OverlayToolbar>
     <OverlayToolbarClose onClick={() => {}} />
     <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
   </OverlayToolbar>
-</OverlayExample>
+</OverlayRenderer>
 ```
-
 ```react
 noSource: true
 plain: true
 responsive: Gross
 span: 4
 ---
-<OverlayExample>
+<OverlayRenderer isVisible onClose={() => {}}>
   <OverlayToolbar>
     <OverlayToolbarClose onClick={() => {}} />
     <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
   </OverlayToolbar>
+</OverlayRenderer>
+```
+
+The overlay opens with a short fade-in animation upon being mounted. Click on the button to open the overlay, click anywhere on the background scroll block element, the close icon or the *save* button to close it again.
+
+Note that due to limitations of the catalog the sidebar is always above the overlay.
+
+```react
+noSource: true
+plain: true
+---
+<OverlayExample>
+  {({onClose}) => (
+    <Overlay onClose={onClose}>
+      <OverlayToolbar>
+        <OverlayToolbarClose onClick={onClose} />
+        <OverlayToolbarConfirm label='Speichern' onClick={onClose} />
+      </OverlayToolbar>
+
+      <OverlayBody>
+        <div style={{marginBottom: 12}}>
+          <Checkbox checked onChange={() => {}}>
+            Anonym kommentieren
+          </Checkbox>
+        </div>
+
+        <Field label='Name' value='Christof Moser' />
+
+        <Interaction.P style={{height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
+          This is a placeholder to make the overlay content taller than the viewport
+          so that we can test the overflow behavior.
+        </Interaction.P>
+      </OverlayBody>
+    </Overlay>
+  )}
 </OverlayExample>
 ```
 
@@ -34,19 +68,46 @@ span: 4
 
 The `<OverlayToolbar />` serves as a container for `<OverlayToolbarClose />` and `<OverlayToolbarConfirm />`. Both inner elements are optional.
 
-```react|noSource,plain,span-2
-<OverlayToolbar>
-  <OverlayToolbarClose onClick={() => {}} />
-  <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
-</OverlayToolbar>
+```react|noSource,plain,frame,span-2
+<div style={{height: 48}}>
+  <OverlayToolbar>
+    <OverlayToolbarClose onClick={() => {}} />
+    <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
+  </OverlayToolbar>
+</div>
 ```
-```react|noSource,plain,span-2
-<OverlayToolbar>
-  <OverlayToolbarClose onClick={() => {}} />
-</OverlayToolbar>
+```react|noSource,plain,frame,span-2
+<div style={{height: 48}}>
+  <OverlayToolbar>
+    <OverlayToolbarClose onClick={() => {}} />
+  </OverlayToolbar>
+</div>
 ```
-```react|noSource,plain,span-2
-<OverlayToolbar>
-  <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
-</OverlayToolbar>
+```react|noSource,plain,frame,span-2
+<div style={{height: 48}}>
+  <OverlayToolbar>
+    <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
+  </OverlayToolbar>
+</div>
+```
+
+## `<OverlayBody />`
+
+Wrap the content in a `<OverlayBody />`. It adds appropriate amount of padding and leaves enough space at the top for the `<OverlayToolbar />`.
+
+```react
+responsive: Gross
+---
+<OverlayRenderer isVisible onClose={() => {}}>
+  <OverlayToolbar>
+    <OverlayToolbarClose onClick={() => {}} />
+    <OverlayToolbarConfirm label='Speichern' onClick={() => {}} />
+  </OverlayToolbar>
+
+  <OverlayBody>
+    <Interaction.P>
+      The overlay body be here.
+    </Interaction.P>
+  </OverlayBody>
+</OverlayRenderer>
 ```

--- a/src/components/Overlay/index.js
+++ b/src/components/Overlay/index.js
@@ -4,3 +4,4 @@ export {
   OverlayToolbarClose,
   OverlayToolbarConfirm
 } from './OverlayToolbar'
+export {default as OverlayBody} from './OverlayBody'

--- a/src/lib.js
+++ b/src/lib.js
@@ -44,7 +44,8 @@ export {
   Overlay,
   OverlayToolbar,
   OverlayToolbarClose,
-  OverlayToolbarConfirm
+  OverlayToolbarConfirm,
+  OverlayBody
 } from './components/Overlay'
 
 export {Container, NarrowContainer} from './components/Grid'


### PR DESCRIPTION
As discussed last week, make the overlay not full-viewport on larger devices. Overflow behavior can also be tested in the catalog.

![image](https://user-images.githubusercontent.com/34538/32497451-eda0b6aa-c3cc-11e7-8d44-eea20be7760a.png)
