### PR TITLE
Comment header overflow fix

### DIFF
--- a/src/components/Comment/CommentHeader.js
+++ b/src/components/Comment/CommentHeader.js
@@ -17,7 +17,7 @@ const styles = {
   profilePicture: css({
     display: 'block',
     width: `${profilePictureSize + 2 * profilePictureBorderSize}px`,
-    flexBasis: `${profilePictureSize + 2 * profilePictureBorderSize}px`,
+    flexGrow: 0,
     flexShrink: 0,
     height: `${profilePictureSize + 2 * profilePictureBorderSize}px`,
     margin: `${-profilePictureBorderSize}px ${-profilePictureBorderSize + profilePictureMargin}px ${-profilePictureBorderSize}px ${-profilePictureBorderSize}px`,

--- a/src/components/Comment/CommentHeader.js
+++ b/src/components/Comment/CommentHeader.js
@@ -3,6 +3,7 @@ import {css} from 'glamor'
 import {MdCheck} from 'react-icons/lib/md'
 import colors from '../../theme/colors'
 import {sansSerifMedium16, sansSerifRegular14} from '../Typography/styles'
+import {ellipsize} from '../../lib/styleMixins'
 
 export const profilePictureSize = 40
 export const profilePictureMargin = 10
@@ -16,6 +17,8 @@ const styles = {
   profilePicture: css({
     display: 'block',
     width: `${profilePictureSize + 2 * profilePictureBorderSize}px`,
+    flexBasis: `${profilePictureSize + 2 * profilePictureBorderSize}px`,
+    flexShrink: 0,
     height: `${profilePictureSize + 2 * profilePictureBorderSize}px`,
     margin: `${-profilePictureBorderSize}px ${-profilePictureBorderSize + profilePictureMargin}px ${-profilePictureBorderSize}px ${-profilePictureBorderSize}px`,
     border: `${profilePictureBorderSize}px solid white`
@@ -24,31 +27,40 @@ const styles = {
     alignSelf: 'stretch',
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    width: `calc(100% - ${profilePictureSize + profilePictureMargin}px)`
   }),
   name: css({
     ...sansSerifMedium16,
+    lineHeight: '20px',
     color: colors.text,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    display: 'flex',
+    alignItems: 'center'
+  }),
+  nameText: css({
+    ...ellipsize
   }),
   timeago: css({
     ...sansSerifRegular14,
+    lineHeight: '20px',
     color: colors.lightText,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    flexShrink: 0
   }),
   description: css({
     ...sansSerifRegular14,
-    lineHeight: 1,
-    color: colors.lightText
+    lineHeight: '20px',
+    color: colors.lightText,
+    display: 'flex',
+    alignItems: 'center'
+  }),
+  descriptionText: css({
+    ...ellipsize,
   }),
   verifiedDescription: css({
     color: colors.text
   }),
   verifiedCheck: css({
+    flexShrink: 0,
     display: 'inline-block',
     marginLeft: 4,
     marginTop: -2
@@ -66,11 +78,11 @@ export const CommentHeader = ({t, profilePicture, name, timeago, credential}) =>
     />
     <div {...styles.meta}>
       <div {...styles.name}>
-        {name}
+        <div {...styles.nameText}>{name}</div>
         {timeago && <span {...styles.timeago}>・{timeago}</span>}
       </div>
       {credential && <div {...styles.description} {...(credential.verified ? styles.verifiedDescription : {})}>
-        {credential.description}
+        <div {...styles.descriptionText} >{credential.description}</div>
         {credential.verified && <MdCheck {...styles.verifiedCheck} />}
       </div>}
     </div>

--- a/src/components/Comment/docs.md
+++ b/src/components/Comment/docs.md
@@ -72,6 +72,14 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
 />
 ```
 
+```react|noSource,span-2
+<CommentHeader
+  timeago='2h'
+  name='Agent Seymour Rutherford Simmons'
+  credential={{description: 'Member of Sector 7 Advanced Research Division', verified: true}}
+/>
+```
+
 ### `<CommentActions />`
 
 ```react|noSource,span-3

--- a/src/components/CommentComposer/CommentComposerHeader.js
+++ b/src/components/CommentComposer/CommentComposerHeader.js
@@ -57,11 +57,8 @@ const styles = {
     border: 'none',
     flexShrink: 0,
     alignSelf: 'stretch',
-    display: 'flex',
-    flexDirection: 'center',
-    justifyContent: 'center',
     margin: '-12px -12px -12px 0',
-    padding: '12px 20px',
+    padding: '15px 20px',
     fontSize: '24px',
     cursor: 'pointer',
   })

--- a/src/components/CommentComposer/CommentComposerHeader.js
+++ b/src/components/CommentComposer/CommentComposerHeader.js
@@ -28,19 +28,25 @@ const styles = {
   }),
   name: css({
     ...sansSerifMedium16,
+    lineHeight: '20px',
     color: colors.text,
     ...ellipsize
   }),
   description: css({
     ...sansSerifRegular14,
+    lineHeight: '20px',
     color: colors.lightText,
-    lineHeight: 1,
+    display: 'flex',
+    alignItems: 'center'
+  }),
+  descriptionText: css({
     ...ellipsize,
   }),
   verifiedDescription: css({
     color: colors.text
   }),
   verifiedCheck: css({
+    flexShrink: 0,
     display: 'inline-block',
     marginLeft: 4,
     marginTop: -2
@@ -73,7 +79,7 @@ const CommentComposerHeader = ({profilePicture, name, credential, onClick}) => (
         {name}
       </div>
       {credential && <div {...styles.description} {...(credential.verified ? styles.verifiedDescription : {})}>
-        {credential.description}
+        <div {...styles.descriptionText}>{credential.description}</div>
         {credential.verified && <MdCheck {...styles.verifiedCheck} />}
       </div>}
     </div>

--- a/src/components/CommentComposer/CommentComposerHeader.js
+++ b/src/components/CommentComposer/CommentComposerHeader.js
@@ -3,6 +3,7 @@ import {css} from 'glamor'
 import {MdCheck, MdEdit} from 'react-icons/lib/md'
 import colors from '../../theme/colors'
 import {sansSerifMedium16, sansSerifRegular14} from '../Typography/styles'
+import {ellipsize} from '../../lib/styleMixins'
 
 const styles = {
   root: css({
@@ -28,17 +29,13 @@ const styles = {
   name: css({
     ...sansSerifMedium16,
     color: colors.text,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    ...ellipsize
   }),
   description: css({
     ...sansSerifRegular14,
     color: colors.lightText,
     lineHeight: 1,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    ...ellipsize,
   }),
   verifiedDescription: css({
     color: colors.text

--- a/src/components/CommentTeaser/CommentTeaserHeader.js
+++ b/src/components/CommentTeaser/CommentTeaserHeader.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { css } from 'glamor'
 import colors from '../../theme/colors'
 import { sansSerifMedium16, sansSerifRegular14 } from '../Typography/styles'
+import { ellipsize } from '../../lib/styleMixins'
 
 const styles = {
   root: css({
@@ -11,17 +12,13 @@ const styles = {
   title: css({
     ...sansSerifMedium16,
     color: colors.text,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    ...ellipsize
   }),
   subtitle: css({
     ...sansSerifRegular14,
     color: colors.lightText,
     lineHeight: 1.1,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    ...ellipsize
   })
 }
 

--- a/src/components/CommentTeaser/CommentTeaserHeader.js
+++ b/src/components/CommentTeaser/CommentTeaserHeader.js
@@ -11,13 +11,14 @@ const styles = {
   }),
   title: css({
     ...sansSerifMedium16,
+    lineHeight: '20px',
     color: colors.text,
     ...ellipsize
   }),
   subtitle: css({
     ...sansSerifRegular14,
     color: colors.lightText,
-    lineHeight: 1.1,
+    lineHeight: '20px',
     ...ellipsize
   })
 }

--- a/src/lib/styleMixins.js
+++ b/src/lib/styleMixins.js
@@ -1,0 +1,5 @@
+export const ellipsize = {
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+}


### PR DESCRIPTION
I noticed that we have a few places where we use the three css declaration to ellipsize text (white-space, overflow, text-overflow) so I extracted them into an 'ellipsize' mixin.

Descenders in the CommentComposerHeaders were cut off due to combination of ellipsize and line-height: 1. See screenshot below.

![screen shot 2017-11-09 at 13 49 31](https://user-images.githubusercontent.com/34538/32606614-447c53f0-c556-11e7-9442-8736b8288ec6.png)

And I refactored CommentHeader and CommentComposerHeader to make sure the ellipsis only shortens the name/description and leaves the timeago and verified check always visible. There's now an example of an overflowing CommentHeader in the catalog.

![image](https://user-images.githubusercontent.com/34538/32606662-6f912624-c556-11e7-87b1-c62e8e0acdfb.png)
