### PR TITLE
refactor: CommentTreeCollapse: align the label with the visual depth

### DIFF
--- a/src/components/CommentTree/Collapse.js
+++ b/src/components/CommentTree/Collapse.js
@@ -4,6 +4,7 @@ import {css} from 'glamor'
 
 import colors from '../../theme/colors'
 import {sansSerifRegular14} from '../Typography/styles'
+import {profilePictureSize, profilePictureMargin} from '../Comment/CommentHeader'
 
 const styles = {
   root: css({
@@ -16,12 +17,12 @@ const styles = {
     position: 'absolute',
     top: 0,
     right: 0,
-    transform: 'translateY(-60%)',
+    transform: 'translate(100%, -60%)',
     display: 'block',
     '-webkit-appearance': 'none',
     background: 'white',
     border: 'none',
-    padding: '4px 0 4px 8px',
+    padding: '4px 0 4px 10px',
     cursor: 'pointer',
     whiteSpace: 'nowrap',
 
@@ -31,8 +32,11 @@ const styles = {
   })
 }
 
-const Collapse = ({t, onClick}) => (
-  <div {...styles.root}>
+const width = (visualDepth) =>
+  visualDepth * (profilePictureSize + profilePictureMargin) - profilePictureMargin
+
+const Collapse = ({t, visualDepth, onClick}) => (
+  <div {...styles.root} style={{width: width(visualDepth)}}>
     <button {...styles.button} onClick={onClick}>
       {t('styleguide/CommentTreeCollapse/label')}
     </button>
@@ -41,6 +45,7 @@ const Collapse = ({t, onClick}) => (
 
 Collapse.propTypes = {
   t: PropTypes.func.isRequired,
+  visualDepth: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired
 }
 

--- a/src/components/CommentTree/LoadMore.js
+++ b/src/components/CommentTree/LoadMore.js
@@ -4,7 +4,7 @@ import {css} from 'glamor'
 
 import colors from '../../theme/colors'
 import {sansSerifRegular14} from '../Typography/styles'
-import {profilePictureSize, profilePictureMargin} from '../Comment/CommentHeader'
+import {profilePictureSize} from '../Comment/CommentHeader'
 import {DepthBars} from './DepthBar'
 
 const styles = {
@@ -40,7 +40,6 @@ const styles = {
 }
 
 const marginLeft = (connected) =>
-  // (profilePictureSize + profilePictureMargin) +
   (connected ? (profilePictureSize / 2) : 0)
 
 const LoadMore = ({t, visualDepth, connected, count, onClick}) => (

--- a/src/components/CommentTree/docs.md
+++ b/src/components/CommentTree/docs.md
@@ -68,7 +68,7 @@ If the comments after a certain point can be collapsed, use `<CommentTreeCollaps
 ```react|noSource,plain
 <div>
   <Row t={t} comment={comments.comment1} visualDepth={3} head />
-  <Collapse t={t} onClick={() => {}} />
+  <Collapse t={t} visualDepth={3} onClick={() => {}} />
 </div>
 ```
 


### PR DESCRIPTION
⚠️  BREAKING CHANGE: The CommentTreeCollapse component now requires a visualDepth prop ⚠️ 

![image](https://user-images.githubusercontent.com/34538/32618316-a5670f04-c577-11e7-97b8-74c88795d27f.png)
