### PR TITLE
refactor: Use profilePicture{Size,Margin} for the negative left margin in Row

### DIFF
--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -23,7 +23,7 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
   return (
     <div {...styles.root}>
       <DepthBars count={visualDepth - (otherChild ? 1 : 0)} head={head} tail={tail} />
-      <div style={{flexGrow: 1, margin: otherChild ? '20px 0' : '20px 0 20px -50px'}}>
+      <div style={{flexGrow: 1, margin: otherChild ? '20px 0' : `20px 0 20px -${profilePictureSize + profilePictureMargin}px`}}>
         <Comment
           timeago={timeago(createdAt)}
           {...comment}


### PR DESCRIPTION
This makes it easier to tweak the magnitude of the visual depth of discussion rows.

The width of each bar depends on `profilePictureSize` and `profilePictureMargin` which are both defined in CommentHeader. You can tweak those numbers as needed. Here's an example of size=20 and margin=8:

![image](https://user-images.githubusercontent.com/34538/32619363-cd4d85d6-c57a-11e7-922e-2e43b34faba2.png)
