### PR TITLE
feat: breakout property for <PullQuote />

### DIFF
--- a/src/components/PullQuote/PullQuote.js
+++ b/src/components/PullQuote/PullQuote.js
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { mUp } from '../../theme/mediaQueries'
+import { mBreakPoint, mUp } from '../../theme/mediaQueries'
+import { CONTENT_PADDING } from '../Grid'
+import { IMAGE_SIZE } from '../InfoBox/InfoBox'
 
 const styles = {
   flex: css({
@@ -15,30 +17,89 @@ const SIZE = {
   narrow: 495
 }
 
-const PullQuote = ({ children, attributes, textAlign = 'inherit', size }) => {
-  const margin = textAlign === 'center' ? '0 auto' : ''
-  const maxWidth = (size && `${SIZE[size]}px`) || ''
+class PullQuote extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isMobile: false
+    }
 
-  const hasFigure = [...children].some(
-    c => c.props.typeName === 'PullQuoteFigure'
-  )
+    this.onResize = () => {
+      if (this.ref) {
+        const isMobile = window.innerWidth < mBreakPoint
+        if (!isMobile) {
+          this.ref.style.marginLeft = `-${Math.min(
+            IMAGE_SIZE['S'] + CONTENT_PADDING,
+            this.x - CONTENT_PADDING
+          )}px`
+        } else {
+          this.ref.style.marginLeft = 0
+        }
+      }
+    }
+    this.ref = ref => {
+      this.ref = ref
+    }
+    this.measure = () => {
+      if (this.ref) {
+        const rect = this.ref.getBoundingClientRect()
+        const leftMargin = parseInt(this.ref.style.marginLeft || 0)
+        this.x = window.pageXOffset + rect.left - leftMargin
+      }
+      this.onResize()
+    }
+  }
 
-  return (
-    <blockquote
-      {...attributes}
-      {...(hasFigure ? styles.flex : {})}
-      style={{ textAlign, maxWidth, margin }}
-    >
-      {children}
-    </blockquote>
-  )
+  componentDidMount() {
+    if (this.props.breakout) {
+      window.addEventListener('resize', this.measure)
+      this.measure()
+    }
+  }
+  componentDidUpdate() {
+    if (this.props.breakout) {
+      this.measure()
+    }
+  }
+  componentWillUnmount() {
+    if (this.props.breakout) {
+      window.removeEventListener('resize', this.measure)
+    }
+  }
+
+  render() {
+    const { children, attributes, textAlign, size } = this.props
+    const margin = textAlign === 'center' ? '0 auto' : 0
+    const maxWidth = (size && `${SIZE[size]}px`) || ''
+
+    const hasFigure = [...children].some(
+      c => c.props.typeName === 'PullQuoteFigure'
+    )
+
+    return (
+      <blockquote
+        ref={this.ref}
+        {...attributes}
+        {...(hasFigure ? styles.flex : {})}
+        style={{ textAlign, maxWidth, margin }}
+      >
+        {children}
+      </blockquote>
+    )
+  }
 }
 
 PullQuote.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   textAlign: PropTypes.oneOf(['inherit', 'left', 'center', 'right']),
-  size: PropTypes.oneOf(['narrow'])
+  size: PropTypes.oneOf(['narrow']),
+  breakout: PropTypes.bool
+}
+
+PullQuote.defaultProps = {
+  textAlign: 'inherit',
+  breakout: false
 }
 
 export default PullQuote

--- a/src/components/PullQuote/docs.md
+++ b/src/components/PullQuote/docs.md
@@ -3,6 +3,7 @@ A `<PullQuote />` is a key phrase, quotation, or excerpt that has been pulled fr
 Supported props:
 - `textAlign`: The text alignment, `inherit` (default), `left`, `center` or `right`.
 - `size`: `narrow`
+- `breakout`: Break out to the left of the container.
 
 ```react
 <PullQuote>
@@ -52,4 +53,44 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
     <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
   </PullQuoteBody>
 </PullQuote>
+```
+
+The `breakout` prop allows to break out to the left of the container. Here's an example with a regular `<PullQuote />` on top of a `<PullQuote breakout />`:
+
+```react|noSource
+<NarrowContainer style={{backgroundColor: 'red'}}>
+<PullQuote>
+  <PullQuoteFigure>
+    <Image src='/static/profilePicture1.png' alt='' />
+    <Caption>
+      <Byline>Photo: Laurent Burst</Byline>
+    </Caption>
+  </PullQuoteFigure>
+  <PullQuoteBody>
+    <PullQuoteText>
+      Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+    </PullQuoteText>
+    <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+  </PullQuoteBody>
+</PullQuote>
+</NarrowContainer>
+```
+
+```react
+<NarrowContainer style={{backgroundColor: 'red'}}>
+  <PullQuote breakout>
+    <PullQuoteFigure>
+      <Image src='/static/profilePicture1.png' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </PullQuoteFigure>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+</NarrowContainer>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -222,6 +222,7 @@ ReactDOM.render(
               Byline: require('./components/Figure/Byline'),
               Caption: require('./components/Figure/Caption'),
               Image: require('./components/Figure/Image'),
+              NarrowContainer: require('./components/Grid').NarrowContainer,
             },
             src: require('./components/PullQuote/docs.md')
           },


### PR DESCRIPTION
This is a proposal on how to implement the left-side breakout, which 
- shouldn't exceed the size of a small image on wide screens
- should move in while making the screen narrower
- should completely collapse on mobile

Since I need some kind of max()/min() for this, I decided against a CSS calc() solution because it's been deferred for CSS3:
https://www.w3.org/Style/CSS/Tracker/issues/203

<img width="1071" alt="screen shot 2017-11-15 at 17 34 52" src="https://user-images.githubusercontent.com/23520051/32848017-b7077bfa-ca2b-11e7-962d-ed316dd8d4ae.png">
<img width="851" alt="screen shot 2017-11-15 at 17 35 18" src="https://user-images.githubusercontent.com/23520051/32848018-b72bbda8-ca2b-11e7-8eeb-c074e7534456.png">
<img width="399" alt="screen shot 2017-11-15 at 17 35 36" src="https://user-images.githubusercontent.com/23520051/32848019-b7636e2e-ca2b-11e7-9d4e-6d2bd2628c60.png">
