### PR TITLE
feat: <Center /> and <Breakout />

### DIFF
--- a/src/components/Center/docs.md
+++ b/src/components/Center/docs.md
@@ -1,0 +1,60 @@
+`<Center />` defines a max-width and ensures a horizontal padding.
+
+`<Breakout />` allows to adjust size (and positioning) of content:
+- `size`: `regular` (default), `narrow`, `tiny`, `breakout`, `breakoutLeft`, `float` and `floatTiny`.
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'regular'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'narrow'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'tiny'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'breakout'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'breakoutLeft'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'float'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'floatSmall'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```
+
+```react
+<Center style={{backgroundColor: 'red'}}>
+  <Breakout size={'floatTiny'} style={{backgroundColor: 'darkgreen', height: 20}}>
+  </Breakout>
+</Center>
+```

--- a/src/components/Center/docs.md
+++ b/src/components/Center/docs.md
@@ -10,58 +10,48 @@
 - `floatSmall`
 - `floatTiny`
 
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'regular'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
+```react|responsive
+<div>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='regular' style={{backgroundColor: 'darkgreen', height: 20}} />
+  </Center>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='narrow' style={{backgroundColor: 'darkgreen', height: 20}} />
+  </Center>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='tiny' style={{backgroundColor: 'darkgreen', height: 20}} />
+  </Center>
+</div>
+
 ```
 
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'narrow'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
+```react|responsive
+<div>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='breakout' style={{backgroundColor: 'darkgreen', height: 20}} />
+  </Center>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='breakoutLeft' style={{backgroundColor: 'darkgreen', height: 20}} />
+  </Center>
+</div>
 ```
 
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'tiny'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
-```
-
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'breakout'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
-```
-
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'breakoutLeft'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
-```
-
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'float'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
-```
-
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'floatSmall'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
-```
-
-```react
-<Center style={{backgroundColor: 'red'}}>
-  <Breakout size={'floatTiny'} style={{backgroundColor: 'darkgreen', height: 20}}>
-  </Breakout>
-</Center>
+```react|responsive
+<div>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='float' style={{backgroundColor: 'darkgreen', height: 20}} />
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</p>
+  </Center>
+  <Center style={{backgroundColor: 'red', 'marginBottom': '20px'}}>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+    <Breakout size='floatTiny' style={{backgroundColor: 'darkgreen', height: 20}} />
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</p>
+  </Center>
+</div>
 ```

--- a/src/components/Center/docs.md
+++ b/src/components/Center/docs.md
@@ -1,7 +1,14 @@
 `<Center />` defines a max-width and ensures a horizontal padding.
 
-`<Breakout />` allows to adjust size (and positioning) of content:
-- `size`: `regular` (default), `narrow`, `tiny`, `breakout`, `breakoutLeft`, `float` and `floatTiny`.
+`<Breakout />` allows to adjust `size` (and positioning) of its content:
+- `regular` (default)
+- `narrow`
+- `tiny`
+- `breakout`
+- `breakoutLeft`
+- `float`
+- `floatSmall`
+- `floatTiny`
 
 ```react
 <Center style={{backgroundColor: 'red'}}>

--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -1,0 +1,130 @@
+import React from 'react'
+import { css } from 'glamor'
+import PropTypes from 'prop-types'
+import { PullQuote } from '../../components/PullQuote'
+
+export const BREAKOUT_SIZE = {
+  regular: 'regular',
+  narrow: 'narrow',
+  tiny: 'tiny',
+  breakout: 'breakout',
+  breakoutLeft: 'breakoutLeft',
+  float: 'float',
+  floatSmall: 'floatSmall',
+  floatTiny: 'floatTiny'
+}
+
+const MAX_WIDTH = 665
+const PADDING = 20
+const DEFAULT_MARGIN = 15
+const BREAKOUT = 155 + DEFAULT_MARGIN
+const FLOAT_MARGIN = 100
+const NARROW_WIDTH = 495
+const SMALL_WIDTH = 410
+const TINY_WIDTH = 325
+
+const floatStyle = {
+  float: 'left',
+  minWidth: BREAKOUT,
+  maxWidth: NARROW_WIDTH,
+  marginTop: FLOAT_MARGIN / 2,
+  marginRight: FLOAT_MARGIN,
+  marginBottom: FLOAT_MARGIN / 2,
+  marginLeft: -BREAKOUT,
+  width: '100%'
+}
+
+const styles = {
+  center: css({
+    maxWidth: MAX_WIDTH,
+    margin: '0 auto',
+    padding: PADDING
+  }),
+  narrow: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      margin: '0 auto',
+      maxWidth: NARROW_WIDTH
+    }
+  }),
+  tiny: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      margin: '0 auto',
+      maxWidth: TINY_WIDTH
+    }
+  }),
+  breakout: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      marginLeft: -BREAKOUT,
+      marginRight: -BREAKOUT
+    }
+  }),
+  breakoutLeft: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      marginLeft: -BREAKOUT
+    }
+  }),
+  float: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      ...floatStyle
+    }
+  }),
+  floatSmall: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      ...floatStyle,
+      maxWidth: SMALL_WIDTH
+    }
+  }),
+  floatTiny: css({
+    [`@media only screen and (min-width: ${MAX_WIDTH +
+      BREAKOUT * 2 +
+      PADDING * 2}px)`]: {
+      ...floatStyle,
+      maxWidth: TINY_WIDTH
+    }
+  })
+}
+
+const Center = ({ children, attributes = {}, ...props }) => (
+  <div {...styles.center} {...attributes} {...props}>
+    {children}
+  </div>
+)
+
+export const Breakout = ({ size, children, attributes = {}, ...props }) => (
+  <div {...styles[size]} {...attributes} {...props}>
+    {children}
+  </div>
+)
+
+Breakout.propTypes = {
+  size: PropTypes.oneOf([
+    BREAKOUT_SIZE.regular,
+    BREAKOUT_SIZE.narrow,
+    BREAKOUT_SIZE.tiny,
+    BREAKOUT_SIZE.breakout,
+    BREAKOUT_SIZE.breakoutLeft,
+    BREAKOUT_SIZE.float,
+    BREAKOUT_SIZE.floatSmall,
+    BREAKOUT_SIZE.floatTiny
+  ]).isRequired,
+  children: PropTypes.node.isRequired,
+  attributes: PropTypes.object
+}
+
+Breakout.defaultProps = {
+  size: 'regular'
+}
+
+export default Center

--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -34,6 +34,10 @@ const floatStyle = {
   width: '100%'
 }
 
+const breakoutUp = `@media only screen and (min-width: ${MAX_WIDTH +
+  BREAKOUT * 2 +
+  PADDING * 2}px)`
+
 const styles = {
   center: css({
     maxWidth: MAX_WIDTH,
@@ -41,55 +45,41 @@ const styles = {
     padding: PADDING
   }),
   narrow: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       margin: '0 auto',
       maxWidth: NARROW_WIDTH
     }
   }),
   tiny: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       margin: '0 auto',
       maxWidth: TINY_WIDTH
     }
   }),
   breakout: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       marginLeft: -BREAKOUT,
       marginRight: -BREAKOUT
     }
   }),
   breakoutLeft: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       marginLeft: -BREAKOUT
     }
   }),
   float: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       ...floatStyle
     }
   }),
   floatSmall: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       ...floatStyle,
       maxWidth: SMALL_WIDTH
     }
   }),
   floatTiny: css({
-    [`@media only screen and (min-width: ${MAX_WIDTH +
-      BREAKOUT * 2 +
-      PADDING * 2}px)`]: {
+    [breakoutUp]: {
       ...floatStyle,
       maxWidth: TINY_WIDTH
     }

--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -3,17 +3,6 @@ import { css } from 'glamor'
 import PropTypes from 'prop-types'
 import { PullQuote } from '../../components/PullQuote'
 
-export const BREAKOUT_SIZE = {
-  regular: 'regular',
-  narrow: 'narrow',
-  tiny: 'tiny',
-  breakout: 'breakout',
-  breakoutLeft: 'breakoutLeft',
-  float: 'float',
-  floatSmall: 'floatSmall',
-  floatTiny: 'floatTiny'
-}
-
 const MAX_WIDTH = 665
 const PADDING = 20
 const DEFAULT_MARGIN = 15
@@ -100,14 +89,14 @@ export const Breakout = ({ size, children, attributes = {}, ...props }) => (
 
 Breakout.propTypes = {
   size: PropTypes.oneOf([
-    BREAKOUT_SIZE.regular,
-    BREAKOUT_SIZE.narrow,
-    BREAKOUT_SIZE.tiny,
-    BREAKOUT_SIZE.breakout,
-    BREAKOUT_SIZE.breakoutLeft,
-    BREAKOUT_SIZE.float,
-    BREAKOUT_SIZE.floatSmall,
-    BREAKOUT_SIZE.floatTiny
+    'regular',
+    'narrow',
+    'tiny',
+    'breakout',
+    'breakoutLeft',
+    'float',
+    'floatSmall',
+    'floatTiny'
   ]).isRequired,
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object

--- a/src/components/InfoBox/Figure.js
+++ b/src/components/InfoBox/Figure.js
@@ -22,6 +22,11 @@ const imageContainerStyles = {
 }
 
 const sizeStyles = {
+  '[data-image-size="XS"] > &': {
+    [mUp]: {
+      width: `${IMAGE_SIZE['XS']}px`
+    }
+  },
   '[data-image-size="S"] > &': {
     [mUp]: {
       width: `${IMAGE_SIZE['S']}px`

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
+import { mUp } from '../../theme/mediaQueries'
+import { BREAKOUT_SIZE, Breakout } from '../Center'
 
 const styles = {
   container: css({
@@ -9,40 +11,59 @@ const styles = {
 }
 
 export const IMAGE_SIZE = {
+  XS: 120,
   S: 155,
   M: 240,
   L: 325
 }
 
-const InfoBox = ({
-  children,
-  attributes,
-  imageSize = 'S',
-  float = false,
-  ...props
-}) => {
+const getBreakoutSize = (size, hasFigure) => {
+  if (size === 'float') {
+    return hasFigure ? BREAKOUT_SIZE.floatSmall : BREAKOUT_SIZE.floatTiny
+  }
+  if (size === 'breakout') {
+    return BREAKOUT_SIZE.breakoutLeft
+  }
+  return size
+}
+
+const InfoBox = ({ children, attributes, size, imageSize, imageFloat }) => {
   const hasFigure = [...children].some(
     c => c.props.typeName === 'InfoBoxFigure'
   )
-  const floatProp = float ? { 'data-image-float': true } : {}
+  const imageFloatProp =
+    imageFloat || (hasFigure && size === 'float')
+      ? { 'data-image-float': true }
+      : {}
+  const computedImageSize = hasFigure
+    ? size === 'float' ? 'XS' : imageSize
+    : null
 
   return (
-    <section
-      {...attributes}
-      {...styles.container}
-      data-image-size={hasFigure && imageSize}
-      {...floatProp}
-    >
-      {children}
-    </section>
+    <Breakout attributes={attributes} size={getBreakoutSize(size, hasFigure)}>
+      <section
+        {...styles.container}
+        data-image-size={computedImageSize}
+        {...imageFloatProp}
+      >
+        {children}
+      </section>
+    </Breakout>
   )
 }
 
 InfoBox.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
-  imageSize: PropTypes.oneOf(['S', 'M', 'L']),
-  float: PropTypes.bool
+  size: PropTypes.oneOf(['regular', 'float', 'breakout']).isRequired,
+  imageSize: PropTypes.oneOf(['XS', 'S', 'M', 'L']).isRequired,
+  imageFloat: PropTypes.bool.isRequired
+}
+
+InfoBox.defaultProps = {
+  size: 'regular',
+  imageSize: 'S',
+  imageFloat: false
 }
 
 export default InfoBox

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
-import { BREAKOUT_SIZE, Breakout } from '../Center'
+import { Breakout } from '../Center'
 
 const styles = {
   container: css({
@@ -19,10 +19,10 @@ export const IMAGE_SIZE = {
 
 const getBreakoutSize = (size, hasFigure) => {
   if (size === 'float') {
-    return hasFigure ? BREAKOUT_SIZE.floatSmall : BREAKOUT_SIZE.floatTiny
+    return hasFigure ? 'floatSmall' : 'floatTiny'
   }
   if (size === 'breakout') {
-    return BREAKOUT_SIZE.breakoutLeft
+    return 'breakoutLeft'
   }
   return size
 }

--- a/src/components/InfoBox/Text.js
+++ b/src/components/InfoBox/Text.js
@@ -13,6 +13,11 @@ const styles = {
       ...sansSerifRegular18
     },
     color: colors.text,
+    ':not([data-image-float])[data-image-size="XS"] > &': {
+      [mUp]: {
+        marginLeft: `${IMAGE_SIZE['XS'] + 20}px`
+      }
+    },
     ':not([data-image-float])[data-image-size="S"] > &': {
       [mUp]: {
         marginLeft: `${IMAGE_SIZE['S'] + 20}px`

--- a/src/components/InfoBox/Title.js
+++ b/src/components/InfoBox/Title.js
@@ -15,6 +15,11 @@ const styles = {
       ...sansSerifMedium19
     },
     color: colors.text,
+    ':not([data-image-float])[data-image-size="XS"] > &': {
+      [mUp]: {
+        marginLeft: `${IMAGE_SIZE['XS'] + 20}px`
+      }
+    },
     ':not([data-image-float])[data-image-size="S"] > &': {
       [mUp]: {
         marginLeft: `${IMAGE_SIZE['S'] + 20}px`

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -79,7 +79,7 @@ Supported props:
 
 ### Sizes in context
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size={'breakout'} imageSize={'S'}>
@@ -98,7 +98,7 @@ Supported props:
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size={'breakout'} imageSize={'M'}>
@@ -117,7 +117,7 @@ Supported props:
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size={'breakout'} imageSize={'L'}>
@@ -136,7 +136,7 @@ Supported props:
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size={'float'}>
@@ -149,7 +149,7 @@ Supported props:
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size={'float'}>

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -1,9 +1,12 @@
 An `<InfoBox />` features informational content interspersed into the main editorial content.
 
 Supported props:
-- `float`: Enforce floating image on desktop. On mobile the image floats, while on desktop the image is rendered in a 2-column layout.
-- `imageSize`: The image size, `S` (default), `M` or `L`.
-
+- `size`:
+  - `regular` (default): Use full container width.
+  - `breakout`: Break out to the left and use full container width.
+  - `float`: Break out to the left and let other elements flow around.
+- `imageFloat`: Enforce floating image on desktop. On mobile the image floats, while on desktop the image is rendered in a 2-column layout.
+- `imageSize`: The image size, `S` (default), `M` or `L`. Ignored when `size` is `float`.
 
 ```react
 <InfoBox>
@@ -30,7 +33,7 @@ Supported props:
 ```
 
 ```react
-<InfoBox float>
+<InfoBox imageFloat>
   <InfoBoxTitle>This is a box title</InfoBoxTitle>
   <InfoBoxFigure>
     <Image src='/static/landscape.jpg' alt='' />
@@ -72,4 +75,95 @@ Supported props:
     One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls.
   </InfoBoxText>
 </InfoBox>
+```
+
+### Sizes in context
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <InfoBox size={'breakout'} imageSize={'S'}>
+    <InfoBoxTitle>This is a breakout info box</InfoBoxTitle>
+    <InfoBoxFigure>
+      <Image src='/static/landscape.jpg' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </InfoBoxFigure>
+    <InfoBoxText>
+      One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls.
+    </InfoBoxText>
+  </InfoBox>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <InfoBox size={'breakout'} imageSize={'M'}>
+    <InfoBoxTitle>This is a breakout info box</InfoBoxTitle>
+    <InfoBoxFigure>
+      <Image src='/static/landscape.jpg' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </InfoBoxFigure>
+    <InfoBoxText>
+      One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls.
+    </InfoBoxText>
+  </InfoBox>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <InfoBox size={'breakout'} imageSize={'L'}>
+    <InfoBoxTitle>This is a breakout info box</InfoBoxTitle>
+    <InfoBoxFigure>
+      <Image src='/static/landscape.jpg' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </InfoBoxFigure>
+    <InfoBoxText>
+      One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls.
+    </InfoBoxText>
+  </InfoBox>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <InfoBox size={'float'}>
+    <InfoBoxTitle>This is a float info box</InfoBoxTitle>
+    <InfoBoxText>
+      One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.
+    </InfoBoxText>
+  </InfoBox>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <InfoBox size={'float'}>
+    <InfoBoxTitle>This is a float info box</InfoBoxTitle>
+    <InfoBoxFigure>
+      <Image src='/static/landscape.jpg' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </InfoBoxFigure>
+    <InfoBoxText>
+      One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.
+    </InfoBoxText>
+  </InfoBox>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
 ```

--- a/src/components/PullQuote/PullQuote.js
+++ b/src/components/PullQuote/PullQuote.js
@@ -2,8 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
+import { BREAKOUT_SIZE, Breakout } from '../Center'
 
 const styles = {
+  container: css({
+    margin: '0 auto'
+  }),
   flex: css({
     [mUp]: {
       display: 'flex'
@@ -11,34 +15,43 @@ const styles = {
   })
 }
 
-const SIZE = {
-  narrow: 495
+const getBreakoutSize = (size, hasFigure) => {
+  if (size === 'float') {
+    return hasFigure ? BREAKOUT_SIZE.float : BREAKOUT_SIZE.floatTiny
+  }
+  if (size === 'breakout') {
+    return BREAKOUT_SIZE.breakoutLeft
+  }
+  return size
 }
 
-const PullQuote = ({ children, attributes, textAlign = 'inherit', size }) => {
-  const margin = textAlign === 'center' ? '0 auto' : ''
-  const maxWidth = (size && `${SIZE[size]}px`) || ''
-
+const PullQuote = ({ children, attributes, size }) => {
   const hasFigure = [...children].some(
     c => c.props.typeName === 'PullQuoteFigure'
   )
+  const textAlign = !hasFigure && size === 'narrow' ? 'center' : 'inherit'
 
   return (
-    <blockquote
-      {...attributes}
-      {...(hasFigure ? styles.flex : {})}
-      style={{ textAlign, maxWidth, margin }}
-    >
-      {children}
-    </blockquote>
+    <Breakout attributes={attributes} size={getBreakoutSize(size, hasFigure)}>
+      <blockquote
+        {...styles.container}
+        {...(hasFigure ? styles.flex : {})}
+        style={{ textAlign }}
+      >
+        {children}
+      </blockquote>
+    </Breakout>
   )
 }
 
 PullQuote.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
-  textAlign: PropTypes.oneOf(['inherit', 'left', 'center', 'right']),
-  size: PropTypes.oneOf(['narrow'])
+  size: PropTypes.oneOf(['regular', 'narrow', 'float', 'breakout']).isRequired
+}
+
+PullQuote.defaultProps = {
+  size: 'regular'
 }
 
 export default PullQuote

--- a/src/components/PullQuote/PullQuote.js
+++ b/src/components/PullQuote/PullQuote.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
-import { BREAKOUT_SIZE, Breakout } from '../Center'
+import { Breakout } from '../Center'
 
 const styles = {
   container: css({
@@ -17,10 +17,10 @@ const styles = {
 
 const getBreakoutSize = (size, hasFigure) => {
   if (size === 'float') {
-    return hasFigure ? BREAKOUT_SIZE.float : BREAKOUT_SIZE.floatTiny
+    return hasFigure ? 'float' : 'floatTiny'
   }
   if (size === 'breakout') {
-    return BREAKOUT_SIZE.breakoutLeft
+    return 'breakoutLeft'
   }
   return size
 }

--- a/src/components/PullQuote/docs.md
+++ b/src/components/PullQuote/docs.md
@@ -48,7 +48,7 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
 
 ### Sizes in context
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote size={'narrow'}>
@@ -63,7 +63,7 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote size={'narrow'}>
@@ -84,7 +84,7 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote size={'breakout'}>
@@ -99,7 +99,7 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote size={'breakout'}>
@@ -120,7 +120,7 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote size={'float'}>
@@ -135,7 +135,7 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
 </Center>
 ```
 
-```react
+```react|responsive
 <Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote size={'float'}>

--- a/src/components/PullQuote/docs.md
+++ b/src/components/PullQuote/docs.md
@@ -1,8 +1,10 @@
 A `<PullQuote />` is a key phrase, quotation, or excerpt that has been pulled from an article and used as a graphic element. It typically contains a `<PullQuoteText />` and an optional `<PullQuoteSource />`.
 
-Supported props:
-- `textAlign`: The text alignment, `inherit` (default), `left`, `center` or `right`.
-- `size`: `narrow`
+Supported sizes:
+- `regular` (default): Use full container width.
+- `narrow`: Reduced max-width and centered.
+- `breakout`: Use full container width and break out to the left.
+- `float`: Break out to the left and let other elements flow around.
 
 ```react
 <PullQuote>
@@ -18,17 +20,6 @@ You can suppress quotation marks using `<PullQuoteText isQuoted={false} />`.
 ```react
 <PullQuote>
   <PullQuoteText isQuoted={false}>
-    Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
-  </PullQuoteText>
-  <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
-</PullQuote>
-```
-
-```react
-<PullQuote
- textAlign='center'
- size='narrow'>
-  <PullQuoteText>
     Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
   </PullQuoteText>
   <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
@@ -52,4 +43,115 @@ Use `<PullQuoteFigure />` to include an `<Image />`. In this case, text and sour
     <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
   </PullQuoteBody>
 </PullQuote>
+```
+
+
+### Sizes in context
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <PullQuote size={'narrow'}>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+ <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <PullQuote size={'narrow'}>
+    <PullQuoteFigure>
+      <Image src='/static/profilePicture1.png' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </PullQuoteFigure>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+ <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <PullQuote size={'breakout'}>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <PullQuote size={'breakout'}>
+    <PullQuoteFigure>
+      <Image src='/static/profilePicture1.png' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </PullQuoteFigure>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <PullQuote size={'float'}>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
+```
+
+```react
+<Center>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+  <PullQuote size={'float'}>
+    <PullQuoteFigure>
+      <Image src='/static/profilePicture1.png' alt='' />
+      <Caption>
+        <Byline>Photo: Laurent Burst</Byline>
+      </Caption>
+    </PullQuoteFigure>
+    <PullQuoteBody>
+      <PullQuoteText>
+        Ich bin sicher, eine kleine Rebellion hie und da ist eine gute Sache; sie ist in der Politik so notwendig, um die Dinge zu klären, wie ein Sturm für das Wetter.
+      </PullQuoteText>
+      <PullQuoteSource>Thomas Jefferson</PullQuoteSource>
+    </PullQuoteBody>
+  </PullQuote>
+  <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
+</Center>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,9 @@ ReactDOM.render(
     theme={theme}
     useBrowserHistory
     responsiveSizes={[
-      {name: 'Klein', width: 320, height: 480},
-      {name: 'Gross', width: 800, height: 480}
+      {name: 'Desktop large', width: 1045, height: 480},
+      {name: 'Desktop small', width: 800, height: 480},
+      {name: 'Mobile', width: 320, height: 480}
     ]}
     pages={[
       {

--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,15 @@ ReactDOM.render(
         title: 'Templates',
         pages: [
           {
+            path: '/center',
+            title: 'Center',
+            imports: {
+              Center: require('./components/Center'),
+              Breakout: require('./components/Center').Breakout,
+            },
+            src: require('./components/Center/docs.md')
+          },
+          {
             path: '/titleblock',
             title: 'TitleBlock',
             imports: {
@@ -222,6 +231,7 @@ ReactDOM.render(
               Byline: require('./components/Figure/Byline'),
               Caption: require('./components/Figure/Caption'),
               Image: require('./components/Figure/Image'),
+              Center: require('./components/Center'),
             },
             src: require('./components/PullQuote/docs.md')
           },
@@ -238,6 +248,7 @@ ReactDOM.render(
               Byline: require('./components/Figure/Byline'),
               Caption: require('./components/Figure/Caption'),
               Image: require('./components/Figure/Image'),
+              Center: require('./components/Center'),
             },
             src: require('./components/InfoBox/docs.md')
           },

--- a/src/lib.js
+++ b/src/lib.js
@@ -19,6 +19,7 @@ export {default as Loader} from './components/Loader'
 export {default as RawHtml} from './components/RawHtml'
 export {default as Dropdown} from './components/Form/Dropdown'
 export {default as TitleBlock} from './components/TitleBlock'
+export { Center, Breakout } from './components/Center'
 export {
   InfoBox,
   InfoBoxFigure,


### PR DESCRIPTION
Breakout defines all generic sizes, while PullQuote and InfoBox only support a limited set of sizes while enforcing some combinatory restrictions.

<img width="1090" alt="screen shot 2017-11-16 at 15 46 50" src="https://user-images.githubusercontent.com/23520051/32897366-aca65b9e-cae5-11e7-90f6-8c587688bad1.png">
<img width="1083" alt="screen shot 2017-11-16 at 15 47 02" src="https://user-images.githubusercontent.com/23520051/32897367-acc695d0-cae5-11e7-9d47-aedf0011622b.png">
<img width="1083" alt="screen shot 2017-11-16 at 15 47 38" src="https://user-images.githubusercontent.com/23520051/32897368-ace2eb90-cae5-11e7-8680-6eaf8d36baa0.png">
<img width="1077" alt="screen shot 2017-11-16 at 15 48 29" src="https://user-images.githubusercontent.com/23520051/32897369-ad064a0e-cae5-11e7-8cdb-8612a07ba8aa.png">
