### PR TITLE
Templates Round 2

### DIFF
--- a/src/components/Figure/Caption.js
+++ b/src/components/Figure/Caption.js
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types'
 import { sansSerifRegular14, sansSerifRegular15 } from '../Typography/styles'
 import { css } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
+import { PADDING } from '../Center'
 
 const styles = {
   caption: css({
+    margin: '0 auto',
+    maxWidth: `calc(100vw - ${PADDING * 2}px)`,
     ...sansSerifRegular14,
     [mUp]: {
       ...sansSerifRegular15,

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -8,15 +8,13 @@ const styles = {
   })
 }
 
-const Image = ({ data: { src, alt }, attributes = {} }) => {
+const Image = ({ src, alt, attributes = {} }) => {
   return <img {...attributes} {...styles.image} src={src} alt={alt} />
 }
 
 Image.propTypes = {
-  data: PropTypes.shape({
-    src: PropTypes.string.isRequired,
-    alt: PropTypes.string
-  }).isRequired
+  src: PropTypes.string.isRequired,
+  alt: PropTypes.string
 }
 
 export default Image

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -1,6 +1,6 @@
 ### `<Figure />`
 
-A `<Figure />` contains an `<FigureImage>` and an optional `<FigureCaption>`.
+A `<Figure />` contains a `<FigureImage>` and an optional `<FigureCaption>`.
 
 Properties
 

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -2,6 +2,10 @@
 
 A `<Figure />` contains an `<FigureImage>` and an optional `<FigureCaption>`.
 
+Properties
+
+- `size` string, optional, `breakout`
+
 ```react
 <Figure>
   <FigureImage src='/static/landscape.jpg' alt='' />
@@ -12,9 +16,7 @@ A `<Figure />` contains an `<FigureImage>` and an optional `<FigureCaption>`.
 </Figure>
 ```
 
-#### `size`
-
-Optinal value: `breakout`
+#### Breakout example
 
 ```react|responsive
 <Center style={{backgroundColor: 'red'}}>
@@ -33,8 +35,9 @@ Optinal value: `breakout`
 The `<FigureImage>` component scales the image to 100% of the available space.
 
 Properties
-- `src` - String, the image url, mandatory
-- `alt` - String, the alternative text
+
+- `src` string, the image url, mandatory
+- `alt` string, the alternative text
 
 ### `<FigureGroup />`
 

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -4,7 +4,7 @@ A `<Figure />` contains an `<FigureImage>` and an optional `<FigureCaption>`.
 
 ```react
 <Figure>
-  <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+  <FigureImage src='/static/landscape.jpg' alt='' />
   <FigureCaption>
     Lorem ipsum dolor sit amet consetetur.{' '}
     <FigureByline>Photo: Laurent Burst</FigureByline>
@@ -19,7 +19,7 @@ Optinal value: `breakout`
 ```react|responsive
 <Center style={{backgroundColor: 'red'}}>
   <Figure size='breakout'>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       Lorem ipsum dolor sit amet consetetur.{' '}
       <FigureByline>Photo: Laurent Burst</FigureByline>
@@ -33,9 +33,8 @@ Optinal value: `breakout`
 The `<FigureImage>` component scales the image to 100% of the available space.
 
 Properties
-- `data` - Object with following keys:
-  - `src` - String, the image url, mandatory
-  - `alt` - String, the alternative text
+- `src` - String, the image url, mandatory
+- `alt` - String, the alternative text
 
 ### `<FigureGroup />`
 
@@ -46,14 +45,14 @@ A `<FigureGroup />` containing two side-by-side `<Figure>` elements, each with t
 ```react
 <FigureGroup>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       A caption for the left photo.{' '}
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       A caption for the right photo.{' '}
       <FigureByline>Photo: Laurent Burst</FigureByline>
@@ -67,10 +66,10 @@ A `<FigureGroup />` containing two side-by-side `<Figure>` elements, with one sh
 ```react
 <FigureGroup>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
   </Figure>
   <FigureCaption>
     This is an image caption stretching beautifully over both images as you can see above.{' '}
@@ -83,21 +82,21 @@ A `<FigureGroup />` containing three side-by-side `<Figure>` elements:
 ```react
 <FigureGroup columns={3}>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       Left photo.{' '}
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       Center photo.{' '}
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       Right photo.{' '}
       <FigureByline>Photo: Laurent Burst</FigureByline>
@@ -110,25 +109,25 @@ A `<FigureGroup />` containing four side-by-side `<Figure>` elements:
 ```react
 <FigureGroup columns={4}>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -140,25 +139,25 @@ A `<FigureGroup />` containing four `<Figure>` elements in two columns:
 ```react
 <FigureGroup>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -178,10 +177,10 @@ Supports `breakout` sizes:
 <Center style={{backgroundColor: 'red'}}>
   <FigureGroup size='breakout'>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
     </Figure>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
     </Figure>
     <FigureCaption>
       This is an image caption stretching beautifully over both images as you can see above.{' '}

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -4,7 +4,7 @@ A `<Figure />` contains an `<FigureImage>` and an optional `<FigureCaption>`.
 
 Properties
 
-- `size` string, optional, `breakout`
+- `size` string, optional, `breakout`, `center` (for cover images)
 
 ```react
 <Figure>

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css, merge } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
-import { breakoutStyles } from '../Center'
+import { breakoutStyles, MAX_WIDTH, PADDING } from '../Center'
 
 export { default as FigureImage } from './Image'
 export { default as FigureCaption } from './Caption'
@@ -46,15 +46,26 @@ const styles = {
   })
 }
 
+const figureBreakout = {
+  ...breakoutStyles,
+  center: css({
+    maxWidth: MAX_WIDTH,
+    padding: PADDING,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    marginBottom: 0
+  })
+}
+
 export const Figure = ({ children, attributes, size }) => (
-  <figure {...attributes} {...merge(styles.figure, breakoutStyles[size])}>
+  <figure {...attributes} {...merge(styles.figure, figureBreakout[size])}>
     {children}
   </figure>
 )
 
 Figure.propTypes = {
   children: PropTypes.node.isRequired,
-  size: PropTypes.oneOf(Object.keys(breakoutStyles))
+  size: PropTypes.oneOf(Object.keys(figureBreakout)),
   attributes: PropTypes.object
 }
 

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -54,7 +54,7 @@ export const Figure = ({ children, attributes, size }) => (
 
 Figure.propTypes = {
   children: PropTypes.node.isRequired,
-  size: PropTypes.oneOf(Object.keys(breakoutStyles)),
+  size: PropTypes.oneOf(Object.keys(breakoutStyles))
   attributes: PropTypes.object
 }
 

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -28,6 +28,7 @@ const figureChildStyles = Object.keys(IMAGE_SIZE).reduce((styles, key) => {
   absolute: css({
     [mUp]: {
       position: 'relative',
+      minHeight: IMAGE_SIZE.S,
       '& figure': {
         position: 'absolute',
         left: 0,

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -21,7 +21,7 @@ Supported props:
 <InfoBox figureSize='S'>
   <InfoBoxTitle>This is a box title</InfoBoxTitle>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -36,7 +36,7 @@ Supported props:
 <InfoBox figureSize='S' figureFloat>
   <InfoBoxTitle>This is a box title</InfoBoxTitle>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -51,7 +51,7 @@ Supported props:
 <InfoBox figureSize='M'>
   <InfoBoxTitle>This is a box title</InfoBoxTitle>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -66,7 +66,7 @@ Supported props:
 <InfoBox figureSize='L'>
   <InfoBoxTitle>This is a box title</InfoBoxTitle>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -85,7 +85,7 @@ Supported props:
   <InfoBox size='breakout' figureSize='S'>
     <InfoBoxTitle>This is a breakout info box</InfoBoxTitle>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>
@@ -104,7 +104,7 @@ Supported props:
   <InfoBox size='breakout' figureSize='M'>
     <InfoBoxTitle>This is a breakout info box</InfoBoxTitle>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>
@@ -123,7 +123,7 @@ Supported props:
   <InfoBox size='breakout' figureSize='L'>
     <InfoBoxTitle>This is a breakout info box</InfoBoxTitle>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>
@@ -155,7 +155,7 @@ Supported props:
   <InfoBox size='float' figureSize='XS'>
     <InfoBoxTitle>This is a float info box</InfoBoxTitle>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>

--- a/src/components/PullQuote/docs.md
+++ b/src/components/PullQuote/docs.md
@@ -20,7 +20,7 @@ Add an `hasFigure` flag and use `<Figure />` to include an `<FigureImage />`.
 ```react
 <PullQuote hasFigure>
   <Figure>
-    <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+    <FigureImage src='/static/landscape.jpg' alt='' />
     <FigureCaption>
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
@@ -53,7 +53,7 @@ Add an `hasFigure` flag and use `<Figure />` to include an `<FigureImage />`.
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote hasFigure size={'narrow'}>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>
@@ -85,7 +85,7 @@ Add an `hasFigure` flag and use `<Figure />` to include an `<FigureImage />`.
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote hasFigure size={'breakout'}>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>
@@ -117,7 +117,7 @@ Add an `hasFigure` flag and use `<Figure />` to include an `<FigureImage />`.
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <PullQuote hasFigure size={'float'}>
     <Figure>
-      <FigureImage data={{src: '/static/landscape.jpg', alt: ''}} />
+      <FigureImage src='/static/landscape.jpg' alt='' />
       <FigureCaption>
         <FigureByline>Photo: Laurent Burst</FigureByline>
       </FigureCaption>

--- a/src/components/Social/Tweet.js
+++ b/src/components/Social/Tweet.js
@@ -54,7 +54,7 @@ const Tweet = ({
       <p {...styles.text}>{children}</p>
       {image && (
         <Figure>
-          <FigureImage data={{src: image, alt: ''}} />
+          <FigureImage src={image} alt='' />
         </Figure>
       )}
     </div>

--- a/src/components/TeaserFeed/Format.js
+++ b/src/components/TeaserFeed/Format.js
@@ -4,6 +4,7 @@ import { sansSerifMedium14, sansSerifMedium16 } from '../Typography/styles'
 import { css } from 'glamor'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
+import { underline } from '../../lib/styleMixins'
 
 const styles = {
   main: css({
@@ -13,8 +14,7 @@ const styles = {
       ...sansSerifMedium16,
       margin: '-5px 0 8px 0'
     },
-    textDecoration: 'underline',
-    textDecorationSkip: 'ink'
+    ...underline
   })
 }
 

--- a/src/components/TeaserFeed/Format.js
+++ b/src/components/TeaserFeed/Format.js
@@ -13,7 +13,8 @@ const styles = {
       ...sansSerifMedium16,
       margin: '-5px 0 8px 0'
     },
-    textDecoration: 'underline'
+    textDecoration: 'underline',
+    textDecorationSkip: 'ink'
   })
 }
 

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -37,7 +37,7 @@ const ImageBlock = ({
   const background = bgColor || ''
   return (
     <div {...attributes} {...styles.container} style={{ background }}>
-      <Image data={{ src: image, alt: '' }} />
+      <Image src={image} alt='' />
       <div {...styles.textContainer}>
         <Text position={textPosition} color={color} center={center}>
           {children}

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -84,7 +84,7 @@ const Split = ({
           portrait ? styles.imageContainerPortrait : {}
         )}
       >
-        <Image data={{ src: image, alt: '' }} {...styles.image} />
+        <Image src={image} alt='' />
       </div>
       <div
         {...css(

--- a/src/components/TitleBlock/index.js
+++ b/src/components/TitleBlock/index.js
@@ -8,9 +8,11 @@ const styles = {
   container: css({
     maxWidth: MAX_WIDTH,
     margin: '0 auto 40px auto',
+    paddingTop: 30,
     paddingLeft: PADDING,
     paddingRight: PADDING,
     [mUp]: {
+      paddingTop: 40,
       margin: '0 auto 70px auto'
     }
   })

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -97,7 +97,8 @@ const format = css({
     ...styles.sansSerifMedium20,
     margin: '0 0 28px 0'
   },
-  textDecoration: 'underline'
+  textDecoration: 'underline',
+  textDecorationSkip: 'ink'
 })
 
 export const Format = ({ children, attributes, ...props }) => (
@@ -158,6 +159,7 @@ export const Emphasis = ({ children, attributes, ...props }) => (
 
 const link = css({
   textDecoration: 'underline',
+  textDecorationSkip: 'ink',
   color: colors.text,
   ':hover': {
     color: colors.lightText

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -4,6 +4,7 @@ import { css } from 'glamor'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
 import { fontFamilies } from '../../theme/fonts'
+import { underline } from '../../lib/styleMixins'
 
 const headline = css({
   ...styles.serifTitle30,
@@ -97,8 +98,7 @@ const format = css({
     ...styles.sansSerifMedium20,
     margin: '0 0 28px 0'
   },
-  textDecoration: 'underline',
-  textDecorationSkip: 'ink'
+  ...underline
 })
 
 export const Format = ({ children, attributes, ...props }) => (
@@ -158,8 +158,7 @@ export const Emphasis = ({ children, attributes, ...props }) => (
 )
 
 const link = css({
-  textDecoration: 'underline',
-  textDecorationSkip: 'ink',
+  ...underline,
   color: colors.text,
   ':hover': {
     color: colors.lightText

--- a/src/components/Typography/docs.md
+++ b/src/components/Typography/docs.md
@@ -157,7 +157,12 @@ Long, editorial texts use the serif cuts. With margins, except `:first-child` 0 
 
 ```react
 <Editorial.Format>Neutrum</Editorial.Format>
-  
+```
+
+We use `text-decoration-skip: ink` to avoid `g`-conflicts.
+
+```react
+<Editorial.Format>Garage</Editorial.Format>
 ```
 
 ### Headlines
@@ -221,9 +226,11 @@ Long, editorial texts use the serif cuts. With margins, except `:first-child` 0 
 
 ### Link
 
+We use `text-decoration-skip: ink` to avoid `g`-conflicts.
+
 ```react
 <Editorial.P>
-  <Editorial.A href='https://www.republik.ch/~christof_moser'>Christof Moser</Editorial.A>
+  <Editorial.A href='https://www.republik.ch/~ganster'>Ein Gangster</Editorial.A>
 </Editorial.P>
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,7 @@ ReactDOM.render(
             path: '/templates/editorial',
             title: 'Editorial',
             imports: {
-              schema: require('./templates/Editorial'),
+              schema: require('./templates/Editorial').default(),
               ...require('./templates/docs'),
               renderMdast: require('mdast-react-render').renderMdast,
               serializer: new Serializer()
@@ -289,7 +289,7 @@ ReactDOM.render(
             path: '/templates/meta',
             title: 'Meta',
             imports: {
-              schema: require('./templates/Meta'),
+              schema: require('./templates/Meta').default(),
               ...require('./templates/docs'),
               renderMdast: require('mdast-react-render').renderMdast,
               serializer: new Serializer()

--- a/src/index.js
+++ b/src/index.js
@@ -284,6 +284,17 @@ ReactDOM.render(
               serializer: new Serializer()
             },
             src: require('./templates/Editorial/docs.md')
+          },
+          {
+            path: '/templates/meta',
+            title: 'Meta',
+            imports: {
+              schema: require('./templates/Meta'),
+              ...require('./templates/docs'),
+              renderMdast: require('mdast-react-render').renderMdast,
+              serializer: new Serializer()
+            },
+            src: require('./templates/Meta/docs.md')
           }
         ]
       },

--- a/src/lib/styleMixins.js
+++ b/src/lib/styleMixins.js
@@ -3,3 +3,8 @@ export const ellipsize = {
   overflow: 'hidden',
   textOverflow: 'ellipsis'
 }
+
+export const underline = {
+  textDecoration: 'underline',
+  textDecorationSkip: 'ink'
+}

--- a/src/templates/Editorial/Container.js
+++ b/src/templates/Editorial/Container.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { css } from 'glamor'
+
+const styles = {
+  container: css({
+    backgroundColor: '#fff'
+  })
+}
+
+export default ({children}) => (
+  <div {...styles.container}>
+    {children}
+  </div>
+)

--- a/src/templates/Editorial/docs.md
+++ b/src/templates/Editorial/docs.md
@@ -1,4 +1,18 @@
-# Example with All Elemente
+```
+import createEditorialSchema from '@project-r/styleguide/lib/templates/Editorial'
+
+const schema = createEditorialSchema({
+  titleBlockAppend: <div>Share Actions</div>
+})
+```
+
+`createEditorialSchema` take an optional options object with follow keys:
+
+- `TitelBlockHeadline`, the title react component
+- `documentEditorOptions`, forward options to the document editor module
+- `titleBlockAppend`, append React elements—e.g. share icons—to the title block
+
+# Example
 
 ```react|noSource
 <Markdown schema={schema}>{`

--- a/src/templates/Editorial/docs.md
+++ b/src/templates/Editorial/docs.md
@@ -1,4 +1,4 @@
-# Alle Elemente in der Standard Version
+# Example with All Elemente
 
 ```react|noSource
 <Markdown schema={schema}>{`

--- a/src/templates/Editorial/docs.md
+++ b/src/templates/Editorial/docs.md
@@ -8,7 +8,7 @@ const schema = createEditorialSchema({
 
 `createEditorialSchema` take an optional options object with follow keys:
 
-- `TitelBlockHeadline`, the title react component
+- `TitleBlockHeadline`, the title react component
 - `documentEditorOptions`, forward options to the document editor module
 - `titleBlockAppend`, append React elements—e.g. share icons—to the title block
 

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -101,7 +101,28 @@ const figure = {
   }),
   editorModule: 'figure',
   editorOptions: {
-    afterType: 'PARAGRAPH'
+    afterType: 'PARAGRAPH',
+    pixelNote: 'Anzeigegrössen: min. 1200x, für E2E min. 2000x (proportionaler Schnitt)',
+    sizes: [
+      {
+        label: 'Edge to Edge',
+        props: {size: undefined},
+        parent: {kinds: ['document', 'block'], types: ['CENTER']},
+        unwrap: true
+      },
+      {
+        label: 'Gross',
+        props: {size: 'breakout'},
+        parent: {kinds: ['document', 'block'], types: ['CENTER']},
+        wrap: 'CENTER'
+      },
+      {
+        label: 'Normal',
+        props: {size: undefined},
+        parent: {kinds: ['document', 'block'], types: ['CENTER']},
+        wrap: 'CENTER'
+      }
+    ]
   },
   rules: [
     {

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -119,7 +119,9 @@ const figure = {
   ]
 }
 
-const schema = {
+export const createSchema = ({
+  TitelBlockHeadline = Editorial.Headline
+} = {}) => ({
   rules: [
     {
       matchMdast: matchType('root'),
@@ -143,7 +145,7 @@ const schema = {
           rules: [
             {
               matchMdast: matchHeading(1),
-              component: Editorial.Headline,
+              component: TitelBlockHeadline,
               editorModule: 'headline',
               editorOptions: {
                 type: 'H1',
@@ -297,9 +299,12 @@ const schema = {
             }
           ]
         },
+        {
+          editorModule: 'specialchars'
+        }
       ]
     }
   ]
-}
+})
 
-export default schema
+export default createSchema()

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -120,14 +120,17 @@ const figure = {
   ]
 }
 
-export const createSchema = ({
-  TitelBlockHeadline = Editorial.Headline
+const createSchema = ({
+  TitelBlockHeadline = Editorial.Headline,
+  documentEditorOptions = {},
+  titleBlockAppend = null
 } = {}) => ({
   rules: [
     {
       matchMdast: matchType('root'),
       component: Container,
       editorModule: 'documentPlain',
+      editorOptions: documentEditorOptions,
       rules: [
         {
           matchMdast: () => false,
@@ -135,7 +138,12 @@ export const createSchema = ({
         },
         {
           matchMdast: matchZone('TITLE'),
-          component: TitleBlock,
+          component: ({children, ...props}) => (
+            <TitleBlock {...props}>
+              {children}
+              {titleBlockAppend}
+            </TitleBlock>
+          ),
           props: node => ({
             center: node.data.center // undefined, false, true
           }),
@@ -308,4 +316,4 @@ export const createSchema = ({
   ]
 })
 
-export default createSchema()
+export default createSchema

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -181,7 +181,7 @@ const cover = {
 }
 
 const createSchema = ({
-  TitelBlockHeadline = Editorial.Headline,
+  TitleBlockHeadline = Editorial.Headline,
   documentEditorOptions = {},
   titleBlockAppend = null
 } = {}) => ({
@@ -215,7 +215,7 @@ const createSchema = ({
           rules: [
             {
               matchMdast: matchHeading(1),
-              component: TitelBlockHeadline,
+              component: TitleBlockHeadline,
               editorModule: 'headline',
               editorOptions: {
                 type: 'H1',

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -111,15 +111,23 @@ const figure = {
         unwrap: true
       },
       {
+        label: 'Zentriert',
+        props: {size: 'center'},
+        parent: {kinds: ['document']},
+        unwrap: true
+      },
+      {
         label: 'Gross',
         props: {size: 'breakout'},
         parent: {kinds: ['document', 'block'], types: ['CENTER']},
+        cover: false,
         wrap: 'CENTER'
       },
       {
         label: 'Normal',
         props: {size: undefined},
         parent: {kinds: ['document', 'block'], types: ['CENTER']},
+        cover: false,
         wrap: 'CENTER'
       }
     ]
@@ -168,9 +176,9 @@ const createSchema = ({
           props: node => ({
             center: node.data.center // undefined, false, true
           }),
-          editorModule: 'block',
+          editorModule: 'title',
           editorOptions: {
-            type: 'TITLE'
+            coverType: 'FIGURE'
           },
           rules: [
             {

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -97,12 +97,13 @@ const figure = {
   matchMdast: matchZone('FIGURE'),
   component: Figure,
   props: node => ({
-    size: node.data.size // values: undefined, 'breakout'
+    size: node.data.size
   }),
   editorModule: 'figure',
   editorOptions: {
     afterType: 'PARAGRAPH',
-    pixelNote: 'Anzeigegrössen: min. 1200x, für E2E min. 2000x (proportionaler Schnitt)',
+    pixelNote: 'Auflösung: min. 1200x, für E2E min. 2000x (proportionaler Schnitt)',
+    insertButtonText: 'Bild',
     sizes: [
       {
         label: 'Edge to Edge',
@@ -111,23 +112,15 @@ const figure = {
         unwrap: true
       },
       {
-        label: 'Zentriert',
-        props: {size: 'center'},
-        parent: {kinds: ['document']},
-        unwrap: true
-      },
-      {
         label: 'Gross',
         props: {size: 'breakout'},
         parent: {kinds: ['document', 'block'], types: ['CENTER']},
-        cover: false,
         wrap: 'CENTER'
       },
       {
         label: 'Normal',
         props: {size: undefined},
         parent: {kinds: ['document', 'block'], types: ['CENTER']},
-        cover: false,
         wrap: 'CENTER'
       }
     ]
@@ -137,10 +130,48 @@ const figure = {
       matchMdast: matchImageParagraph,
       component: FigureImage,
       props: node => ({
-        data: {
-          src: node.children[0].url,
-          alt: node.children[0].alt
-        }
+        src: node.children[0].url,
+        alt: node.children[0].alt
+      }),
+      editorModule: 'figureImage',
+      isVoid: true
+    },
+    figureCaption
+  ]
+}
+
+const cover = {
+  matchMdast: (node, index) => (
+    matchZone('FIGURE')(node) &&
+    index === 0
+  ),
+  component: Figure,
+  props: node => ({
+    size: node.data.size
+  }),
+  editorModule: 'figure',
+  editorOptions: {
+    type: 'COVERFIGURE',
+    afterType: 'PARAGRAPH',
+    pixelNote: 'Auflösung: min. 2000x (proportionaler Schnitt)',
+    sizes: [
+      {
+        label: 'Edge to Edge',
+        props: {size: undefined}
+      },
+      {
+        label: 'Zentriert',
+        props: {size: 'center'}
+      }
+    ]
+  },
+  rules: [
+    {
+      matchMdast: matchImageParagraph,
+      component: FigureImage,
+      props: node => ({
+        src: node.children[0].url,
+        alt: node.children[0].alt
       }),
       editorModule: 'figureImage',
       isVoid: true
@@ -165,6 +196,7 @@ const createSchema = ({
           matchMdast: () => false,
           editorModule: 'meta'
         },
+        cover,
         {
           matchMdast: matchZone('TITLE'),
           component: ({children, ...props}) => (
@@ -174,11 +206,11 @@ const createSchema = ({
             </TitleBlock>
           ),
           props: node => ({
-            center: node.data.center // undefined, false, true
+            center: node.data.center
           }),
           editorModule: 'title',
           editorOptions: {
-            coverType: 'FIGURE'
+            coverType: cover.editorOptions.type
           },
           rules: [
             {
@@ -242,7 +274,7 @@ const createSchema = ({
               component: FigureGroup,
               props: node => ({
                 size: 'breakout',
-                columns: node.data.columns // values: 2, 3, 4
+                columns: node.data.columns
               }),
               rules: [
                 figure,
@@ -253,11 +285,11 @@ const createSchema = ({
               matchMdast: matchZone('INFOBOX'),
               component: InfoBox,
               props: node => ({
-                size: node.data.size, // values: undefined, 'float', 'breakout'
+                size: node.data.size,
                 figureSize: node.children.find(matchZone('FIGURE'))
-                  ? node.data.figureSize || 'S' // values: 'XS', 'S', 'M', 'L'
+                  ? node.data.figureSize || 'S'
                   : undefined,
-                figureFloat: node.data.figureFloat // values: undefined, false, true
+                figureFloat: node.data.figureFloat
               }),
               editorModule: 'infobox',
               editorOptions: {
@@ -291,7 +323,7 @@ const createSchema = ({
               matchMdast: matchZone('QUOTE'),
               component: PullQuote,
               props: node => ({
-                size: node.data.size, // values: undefined, 'narrow', 'float', 'breakout'
+                size: node.data.size,
                 hasFigure: !!node.children.find(matchZone('FIGURE'))
               }),
               editorModule: 'quote',

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -259,11 +259,9 @@ const createSchema = ({
                   : undefined,
                 figureFloat: node.data.figureFloat // values: undefined, false, true
               }),
-              editorModule: 'block',
+              editorModule: 'infobox',
               editorOptions: {
-                type: 'INFOBOX',
-                insertButtonText: 'Infobox',
-                defaultProps: {figureSize: 'S'}
+                insertButtonText: 'Infobox'
               },
               rules: [
                 {
@@ -283,7 +281,7 @@ const createSchema = ({
                   editorModule: 'paragraph',
                   editorOptions: {
                     type: 'INFOP',
-                    placeholder: 'Text'
+                    placeholder: 'Infotext'
                   },
                   rules: paragraph.rules
                 }
@@ -296,11 +294,9 @@ const createSchema = ({
                 size: node.data.size, // values: undefined, 'narrow', 'float', 'breakout'
                 hasFigure: !!node.children.find(matchZone('FIGURE'))
               }),
-              editorModule: 'block',
+              editorModule: 'quote',
               editorOptions: {
-                type: 'QUOTE',
-                insertButtonText: 'Quote',
-                defaultProps: {hasFigure: true}
+                insertButtonText: 'Zitat'
               },
               rules: [
                 figure,

--- a/src/templates/Editorial/index.js
+++ b/src/templates/Editorial/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import Container from './Container'
 import Center from '../../components/Center'
 import TitleBlock from '../../components/TitleBlock'
 import * as Editorial from '../../components/Typography/Editorial'
@@ -125,7 +126,7 @@ export const createSchema = ({
   rules: [
     {
       matchMdast: matchType('root'),
-      component: ({children}) => <div>{children}</div>,
+      component: Container,
       editorModule: 'documentPlain',
       rules: [
         {

--- a/src/templates/Meta/docs.md
+++ b/src/templates/Meta/docs.md
@@ -1,0 +1,77 @@
+The meta template is mostly equivalent to the editorial template. The main difference is the sans-serif title block headline.
+
+# Example
+
+```react|noSource
+<Markdown schema={schema}>{`
+
+<section><h6>TITLE</h6>
+
+# Gregor Samsa eines Morgens aus unruhigen Träumen
+
+Jemand musste Josef K. verleumdet haben, denn ohne dass er etwas Böses getan hätte, wurde er eines Morgens verhaftet. «Wie ein Hund!» sagte er, es war, als sollte die Scham ihn überleben.
+
+Von [Franz Kafka](<>) (Text) und [Laurent Burst](<>) (Bilder), 13. Juli 2017
+
+<hr /></section>
+
+<section><h6>CENTER</h6>
+
+Und es war ihnen wie eine Bestätigung ihrer neuen Träume und guten Absichten, als am Ziele ihrer Fahrt die Tochter als erste sich erhob und ihren jungen Körper dehnte. «Es ist ein eigentümlicher Apparat», sagte der Offizier zu dem Forschungsreisenden und überblickte mit einem gewissermaßen bewundernden Blick den ihm doch wohlbekannten Apparat.
+
+## Wie ein Hund!
+
+In den letzten Jahrzehnten ist das Interesse an Hungerkünstlern sehr zurückgegangen.
+
+<section><h6>FIGURE</h6>
+
+![](/static/landscape.jpg)
+
+Etwas Böses _Foto: Laurent Burst_
+
+<hr /></section>
+
+«Es ist ein eigentümlicher Apparat», sagte der Offizier zu dem Forschungsreisenden und überblickte mit einem gewissermaßen bewundernden Blick den ihm doch wohlbekannten Apparat.
+
+<hr /></section>
+
+`}</Markdown>
+```
+
+## Title Block
+
+```react|noSource
+<Markdown schema={schema}>{`
+<section><h6>TITLE</h6>
+
+# Gregor Samsa eines Morgens aus unruhigen Träumen
+
+Jemand musste Josef K. verleumdet haben, denn ohne dass er etwas Böses getan hätte, wurde er eines Morgens verhaftet. «Wie ein Hund!» sagte er, es war, als sollte die Scham ihn überleben.
+
+Von [Franz Kafka](<>) (Text) und [Everett Collection](<>) (Bilder), 13. Juli 2017
+
+<hr /></section>
+`}</Markdown>
+```
+
+### `center`
+
+Values: `falsy` (default), `true`
+
+```react|noSource
+<Markdown schema={schema}>{`
+<section><h6>TITLE</h6>
+
+\`\`\`
+{"center": true}
+\`\`\`
+
+# Gregor Samsa eines Morgens aus unruhigen Träumen
+
+Jemand musste Josef K. verleumdet haben, denn ohne dass er etwas Böses getan hätte, wurde er eines Morgens verhaftet. «Wie ein Hund!» sagte er, es war, als sollte die Scham ihn überleben.
+
+Von [Franz Kafka](<>) (Text) und [Everett Collection](<>) (Bilder), 13. Juli 2017
+
+<hr /></section>
+`}</Markdown>
+```

--- a/src/templates/Meta/docs.md
+++ b/src/templates/Meta/docs.md
@@ -1,5 +1,15 @@
 The meta template is mostly equivalent to the editorial template. The main difference is the sans-serif title block headline.
 
+```
+import createMetaSchema from '@project-r/styleguide/lib/templates/Meta'
+
+const schema = createMetaSchema({
+  titleBlockAppend: <div>Share Actions</div>
+})
+```
+
+`createMetaSchema` forwards to `createEditorialSchema`. See [editorial documentation for arguments](/templates/editorial).
+
 # Example
 
 ```react|noSource

--- a/src/templates/Meta/index.js
+++ b/src/templates/Meta/index.js
@@ -3,6 +3,6 @@ import createEditorialSchema from '../Editorial'
 import { Headline } from '../../components/Typography/Interaction'
 
 export default (options = {}) => createEditorialSchema({
-  TitelBlockHeadline: Headline,
+  TitleBlockHeadline: Headline,
   ...options
 })

--- a/src/templates/Meta/index.js
+++ b/src/templates/Meta/index.js
@@ -1,8 +1,9 @@
 import {
-  matchType,
-  matchZone,
-  matchHeading,
-  matchParagraph,
-  matchImageParagraph
-} from 'mdast-react-render/lib/utils'
+  createSchema
+} from '../Editorial'
 
+import { Headline } from '../../components/Typography/Interaction'
+
+export default createSchema({
+  TitelBlockHeadline: Headline
+})

--- a/src/templates/Meta/index.js
+++ b/src/templates/Meta/index.js
@@ -1,9 +1,8 @@
-import {
-  createSchema
-} from '../Editorial'
+import createEditorialSchema from '../Editorial'
 
 import { Headline } from '../../components/Typography/Interaction'
 
-export default createSchema({
-  TitelBlockHeadline: Headline
+export default (options = {}) => createEditorialSchema({
+  TitelBlockHeadline: Headline,
+  ...options
 })

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -8,7 +8,7 @@ export const Markdown = ({children, schema}) => {
   return (
     <div>
       {renderMdast(serializer.parse(children), schema)}
-      <pre style={{backgroundColor: '#fff', padding: 20, margin: '0 -20px -20px -20px', overflow: 'auto'}}>
+      <pre style={{backgroundColor: '#fff', padding: 20, margin: '20px -20px -20px -20px', overflow: 'auto'}}>
         <code style={{fontFamily: '"Roboto Mono", monospace'}}>
           {children.trim()}
         </code>


### PR DESCRIPTION
Notable Changes
- template creators
- add Meta template
- `FigureImage` props are now flat: `data={{src: '', alt: ''}}` becomes `src={''} alt={''}`
- add `center` size to `Figure` (essay template with figure in front of title, center wrap would be impractical here)
