### PR TITLE
feat: Social variants of tile and typo front teasers.

### DIFF
--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -29,6 +29,7 @@ const ImageBlock = ({
   children,
   attributes,
   image,
+  alt,
   color,
   bgColor,
   textPosition,
@@ -37,7 +38,7 @@ const ImageBlock = ({
   const background = bgColor || ''
   return (
     <div {...attributes} {...styles.container} style={{ background }}>
-      <Image src={image} alt='' />
+      <Image src={image} alt={alt} />
       <div {...styles.textContainer}>
         <Text position={textPosition} color={color} center={center}>
           {children}
@@ -51,6 +52,7 @@ ImageBlock.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string.isRequired,
+  alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,
   center: PropTypes.bool,
@@ -63,7 +65,8 @@ ImageBlock.propTypes = {
 }
 
 ImageBlock.defaultProps = {
-  textPosition: 'topleft'
+  textPosition: 'topleft',
+  alt: ''
 }
 
 export default ImageBlock

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -64,6 +64,7 @@ const Split = ({
   children,
   attributes,
   image,
+  alt,
   color,
   bgColor,
   center,
@@ -84,7 +85,7 @@ const Split = ({
           portrait ? styles.imageContainerPortrait : {}
         )}
       >
-        <Image src={image} alt='' />
+        <Image src={image} alt={alt} />
       </div>
       <div
         {...css(
@@ -106,10 +107,15 @@ Split.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string.isRequired,
+  alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,
   center: PropTypes.bool,
   reverse: PropTypes.bool
+}
+
+Split.defaultProps = {
+  alt: ''
 }
 
 export default Split

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -110,13 +110,7 @@ TeaserFrontTileRow.defaultProps = {
   columns: 1
 }
 
-const Tile = ({
-  children,
-  attributes,
-  image,
-  color,
-  bgColor
-}) => {
+const Tile = ({ children, attributes, image, color, bgColor }) => {
   const background = bgColor || ''
   return (
     <div
@@ -125,9 +119,11 @@ const Tile = ({
       style={{ background }}
       className="tile"
     >
-      <div {...styles.imageContainer}>
-        <img src={image} alt="" {...styles.image} />
-      </div>
+      {image && (
+        <div {...styles.imageContainer}>
+          <img src={image} alt="" {...styles.image} />
+        </div>
+      )}
       <div {...styles.textContainer}>
         <Text color={color} maxWidth={'600px'}>
           {children}
@@ -140,7 +136,7 @@ const Tile = ({
 Tile.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
-  image: PropTypes.string.isRequired,
+  image: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string
 }

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -110,7 +110,7 @@ TeaserFrontTileRow.defaultProps = {
   columns: 1
 }
 
-const Tile = ({ children, attributes, image, color, bgColor }) => {
+const Tile = ({ children, attributes, image, alt, color, bgColor }) => {
   const background = bgColor || ''
   return (
     <div
@@ -121,7 +121,7 @@ const Tile = ({ children, attributes, image, color, bgColor }) => {
     >
       {image && (
         <div {...styles.imageContainer}>
-          <img src={image} alt="" {...styles.image} />
+          <img src={image} alt={alt} {...styles.image} />
         </div>
       )}
       <div {...styles.textContainer}>
@@ -137,8 +137,13 @@ Tile.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string,
+  alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string
+}
+
+Tile.defaultProps = {
+  alt: ''
 }
 
 export default Tile

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -39,6 +39,28 @@ Supported props:
 ```
 
 ```react
+<TeaserFrontTileRow columns={2}>
+  <TeaserFrontTile image='/static/rothaus_landscape.jpg'
+    color='#fff' bgColor='#000'>
+    <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
+    <TeaserFrontLead>
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+    </TeaserFrontLead>
+    <TeaserFrontCredit>
+      An article by <TeaserFrontAuthorLink href='#'>Christof Moser</TeaserFrontAuthorLink>, 31 December 2017
+    </TeaserFrontCredit>
+  </TeaserFrontTile>
+  <TeaserFrontTile color='#000' bgColor='#fff'>
+    <Editorial.Format>Umfrage</Editorial.Format>
+    <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
+    <TeaserFrontCredit>
+      <TeaserFrontAuthorLink href='#'>Constantin Seibt</TeaserFrontAuthorLink> fragt nach<br />31. December 2017
+    </TeaserFrontCredit>
+  </TeaserFrontTile>
+</TeaserFrontTileRow>
+```
+
+```react
 <TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
     color='#fff' bgColor='#000'>
@@ -63,6 +85,18 @@ Supported props:
     </TeaserFrontLead>
     <TeaserFrontCredit>
       An article by <TeaserFrontAuthorLink href='#' color='#fba'>Christof Moser</TeaserFrontAuthorLink>, 31 December 2017
+    </TeaserFrontCredit>
+  </TeaserFrontTile>
+</TeaserFrontTileRow>
+```
+
+```react
+<TeaserFrontTileRow>
+  <TeaserFrontTile color='#000' bgColor='#fff'>
+    <Editorial.Format>Umfrage</Editorial.Format>
+    <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
+    <TeaserFrontCredit>
+      <TeaserFrontAuthorLink href='#'>Constantin Seibt</TeaserFrontAuthorLink> fragt nach<br />31. December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>

--- a/src/components/TeaserFront/Typo.js
+++ b/src/components/TeaserFront/Typo.js
@@ -4,6 +4,8 @@ import { css } from 'glamor'
 import { mUp, tUp } from './mediaQueries'
 import Text from './Text'
 
+export const MAX_WIDTH_PERCENT = 70
+
 const styles = {
   root: css({
     margin: 0
@@ -12,7 +14,7 @@ const styles = {
     margin: '0 auto',
     padding: '15px',
     [mUp]: {
-      maxWidth: '70%',
+      maxWidth: `${MAX_WIDTH_PERCENT}%`,
       padding: '30px 0'
     },
     [tUp]: {

--- a/src/components/TeaserFront/Typo.md
+++ b/src/components/TeaserFront/Typo.md
@@ -4,9 +4,10 @@ Supported props:
 - `color`: The text color.
 - `bgColor`: The background color to use in stacked mode.
 
-A `<TeaserFrontTypoHeadline />` should be used. The default font size can be bumped with either of these props:
+A `<TeaserFrontTypoHeadline />` should be used. The default font size can be changed with either of these props:
 - `medium`: Whether the font size shoud be increased to medium.
 - `large`: Whether the font size shoud be increased to large.
+- `small`: Whether the font size should be decreased to small. Currently only supported for `<TeaserFrontTypoHeadline.Interaction />`
 
 ```react
 <TeaserFrontTypo bgColor='#fff'>
@@ -76,6 +77,16 @@ A `<TeaserFrontTypoHeadline />` should be used. The default font size can be bum
   </TeaserFrontLead>
   <TeaserFrontCredit>
     An article by <TeaserFrontAuthorLink href='#'>Christof Moser</TeaserFrontAuthorLink>, 31 December 2017
+  </TeaserFrontCredit>
+</TeaserFrontTypo>
+```
+
+```react
+<TeaserFrontTypo color='#000' bgColor='#fff'>
+  <Editorial.Format>Umfrage</Editorial.Format>
+  <TeaserFrontTypoHeadline.Interaction small>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTypoHeadline.Interaction>
+  <TeaserFrontCredit>
+    <TeaserFrontAuthorLink href='#'>Constantin Seibt</TeaserFrontAuthorLink> fragt nach<br />31. December 2017
   </TeaserFrontCredit>
 </TeaserFrontTypo>
 ```

--- a/src/components/TeaserFront/TypoHeadline.js
+++ b/src/components/TeaserFront/TypoHeadline.js
@@ -1,7 +1,16 @@
 import React from 'react'
 import { css } from 'glamor'
 import { mUp, tUp, dUp } from './mediaQueries'
+import { MAX_WIDTH_PERCENT } from './Typo'
 import { serifTitle20, sansSerifMedium20 } from '../Typography/styles'
+
+// Larger headlines should breakout of the parent's maxWidth container slightly
+// so use a fraction of the remaining percentage.
+const horizontalBreakout = `-${(100 - MAX_WIDTH_PERCENT) * 0.25}%`
+const breakoutMargin = {
+  marginLeft: horizontalBreakout,
+  marginRight: horizontalBreakout
+}
 
 const serifSizes = {
   large: css({
@@ -25,7 +34,8 @@ const serifSizes = {
     lineHeight: '43px',
     [mUp]: {
       fontSize: '125px',
-      lineHeight: '135px'
+      lineHeight: '135px',
+      ...breakoutMargin
     }
   })
 }
@@ -47,12 +57,27 @@ const sansSerifSizes = {
       lineHeight: '175px'
     }
   }),
+  small: css({
+    fontSize: '26px',
+    lineHeight: '28px',
+    marginLeft: 0,
+    marginRight: 0,
+    [mUp]: {
+      fontSize: '32px',
+      lineHeight: '38px'
+    },
+    [tUp]: {
+      fontSize: '75px',
+      lineHeight: '85px'
+    }
+  }),
   default: css({
     fontSize: '38px',
     lineHeight: '43px',
     [mUp]: {
       fontSize: '120px',
-      lineHeight: '135px'
+      lineHeight: '135px',
+      ...breakoutMargin
     }
   })
 }
@@ -65,7 +90,7 @@ const styles = {
     }
   }),
   editorial: css({
-    ...serifTitle20,
+    ...serifTitle20
   }),
   interaction: css({
     ...sansSerifMedium20
@@ -85,11 +110,14 @@ export const Editorial = ({ children, large, medium }) => {
   )
 }
 
-export const Interaction = ({ children, large, medium }) => {
+export const Interaction = ({ children, large, medium, small }) => {
   const sizedStyle = css(
     styles.interaction,
     sansSerifSizes.default,
-    (large && sansSerifSizes.large) || (medium && sansSerifSizes.medium) || {}
+    (large && sansSerifSizes.large) ||
+      (medium && sansSerifSizes.medium) ||
+      (small && sansSerifSizes.small) ||
+      {}
   )
   return (
     <h1 {...styles.base} {...sizedStyle}>

--- a/src/components/TeaserFront/TypoHeadline.js
+++ b/src/components/TeaserFront/TypoHeadline.js
@@ -60,8 +60,6 @@ const sansSerifSizes = {
   small: css({
     fontSize: '26px',
     lineHeight: '28px',
-    marginLeft: 0,
-    marginRight: 0,
     [mUp]: {
       fontSize: '32px',
       lineHeight: '38px'


### PR DESCRIPTION
- Makes `image` optional for tile teaser
- Supports a `small` version of `<TeaserFrontTypoHeadline.Interaction />`
- Adds social teaser examples for tile and typo teasers
- Plus an unrelated typographic adjustment for larger headlines in typo teasers.

Previews:
https://r-styleguide-pr-48.herokuapp.com/teaserfronttypo (very bottom)
https://r-styleguide-pr-48.herokuapp.com/teaserfronttile