### PR TITLE
fix(Tweet): Support playable media and "more" link

### DIFF
--- a/src/components/Social/Tweet.js
+++ b/src/components/Social/Tweet.js
@@ -3,9 +3,14 @@ import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
-import { link, sansSerifRegular15, sansSerifRegular18 } from '../Typography/styles'
-import { Figure, FigureImage } from '../Figure'
+import {
+  link,
+  sansSerifRegular15,
+  sansSerifRegular18
+} from '../Typography/styles'
+import { Figure, FigureImage, FigureCaption } from '../Figure'
 import { Header } from './Header'
+import PlayIcon from 'react-icons/lib/md/play-arrow'
 
 const styles = {
   container: css({
@@ -31,6 +36,18 @@ const styles = {
     '& a': {
       ...link
     }
+  }),
+  mediaContainer: css({
+    display: 'inline-block',
+    position: 'relative'
+  }),
+  playIcon: css({
+    color: '#fff',
+    lineHeight: 0,
+    position: 'absolute',
+    fontSize: '80px',
+    left: 'calc(50% - 40px)',
+    top: 'calc(50% - 40px)'
   })
 }
 
@@ -42,7 +59,9 @@ const Tweet = ({
   userScreenName,
   date,
   userProfileImageUrl,
-  image
+  image,
+  more,
+  playable
 }) => {
   return (
     <div {...styles.container}>
@@ -53,12 +72,20 @@ const Tweet = ({
         handle={userScreenName}
         date={date}
       />
-      <p {...styles.text} dangerouslySetInnerHTML={
-        {__html: html}
-      }/>
+      <p {...styles.text} dangerouslySetInnerHTML={{ __html: html }} />
       {image && (
         <Figure>
-          <FigureImage src={image} alt='' />
+          <a href={url} target="_blank" {...styles.mediaContainer}>
+            {playable && <span {...styles.playIcon}><PlayIcon/></span>}
+            <FigureImage src={image} alt="" />
+          </a>
+          {more && (
+            <FigureCaption>
+              <a href={url} target="_blank" {...css(link)}>
+                {more}
+              </a>
+            </FigureCaption>
+          )}
         </Figure>
       )}
     </div>
@@ -73,7 +100,9 @@ Tweet.propTypes = {
   userName: PropTypes.string.isRequired,
   userScreenName: PropTypes.string.isRequired,
   date: PropTypes.object.isRequired,
-  image: PropTypes.string
+  image: PropTypes.string,
+  more: PropTypes.string,
+  playable: PropTypes.bool
 }
 
 Tweet.defaultProps = {

--- a/src/components/Social/docs.md
+++ b/src/components/Social/docs.md
@@ -7,6 +7,8 @@ Supported props:
 - `userScreenName`: The Twitter userScreenName (with or without @).
 - `date`: The date of the tweet.
 - `image`: The optional URL of an image associated with the content.
+- `more`: A string indicating that there are more media elements available.
+- `playable`: Whether the featured media element is playable (i.e. a video or animated GIF).
 
 
 ```react
@@ -30,6 +32,20 @@ Supported props:
   date={new Date(2017, 11, 15)}
   image='/static/landscape.jpg'
   html='One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.'
+  more='2 weitere Fotos'
+/>
+```
+
+```react
+<Tweet
+  url='https://twitter.com/RepublikMagazin/status/869979987276742656'
+  userProfileImageUrl='/static/profilePicture1.png'
+  userName='Christof Moser'
+  userScreenName='christof_moser'
+  date={new Date(2017, 11, 15)}
+  image='/static/landscape.jpg'
+  html='One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.'
+  playable
 />
 ```
 


### PR DESCRIPTION
Required for
https://github.com/orbiting/publikator-backend/pull/16
https://github.com/orbiting/publikator-frontend/pull/78

`playable` will not play the video/gif inline, but decorate the image with a play icon and link off to the tweet.

<img width="830" alt="screen shot 2017-12-01 at 18 02 34" src="https://user-images.githubusercontent.com/23520051/33493900-dbdd9408-d6c1-11e7-90be-d46fb538eb99.png">
