### PR TITLE
fix(Figure.Image): Reserve expected space while loading and support image resize

### DIFF
--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -1,20 +1,93 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
+import { parse, format } from 'url'
 
 const styles = {
   image: css({
     width: '100%'
+  }),
+  imageLoading: css({
+    backgroundColor: '#eee',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'contain',
+    height: 0
   })
 }
 
-const Image = ({ src, alt, attributes = {} }) => {
-  return <img {...attributes} {...styles.image} src={src} alt={alt} />
+const imageSizeInfo = url => {
+  const urlObject = parse(url, true)
+  const { size } = urlObject.query
+  if (!size) {
+    return null
+  }
+  const [width, height] = size.split('x')
+  return {
+    width,
+    height
+  }
+}
+
+const imageResizeUrl = (url, size) => {
+  if (!url) {
+    return url
+  }
+
+  const urlObject = parse(url, true)
+  if (urlObject.protocol === 'data:') {
+    return url
+  }
+
+  urlObject.query.resize = size
+  // ensure format calculates from query object
+  urlObject.search = undefined
+
+  return format(urlObject)
+}
+
+class Image extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { loadStatus: 'loading' }
+
+    this.handleLoaded = this.handleLoaded.bind(this)
+  }
+
+  handleLoaded() {
+    this.setState({ loadStatus: 'loaded' })
+  }
+
+  render() {
+    const { src, alt, attributes = {}, resize } = this.props
+    const { loadStatus } = this.state
+    const resizedSrc = resize ? imageResizeUrl(src, resize) : src
+    const sizeInfo = imageSizeInfo(src)
+    const aspectRatio =
+      sizeInfo && sizeInfo.width ? sizeInfo.width / sizeInfo.height : undefined
+
+    return (
+      <img
+        {...attributes}
+        {...css(
+          styles.image,
+          aspectRatio && loadStatus === 'loading'
+            ? merge(styles.imageLoading, {
+                paddingBottom: `${100 / aspectRatio}%`
+              })
+            : {}
+        )}
+        onLoad={this.handleLoaded}
+        src={resizedSrc}
+        alt={alt}
+      />
+    )
+  }
 }
 
 Image.propTypes = {
   src: PropTypes.string.isRequired,
-  alt: PropTypes.string
+  alt: PropTypes.string,
+  resize: PropTypes.string
 }
 
 export default Image

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -9,8 +9,6 @@ const styles = {
   }),
   imageLoading: css({
     backgroundColor: '#eee',
-    backgroundRepeat: 'no-repeat',
-    backgroundSize: 'contain',
     height: 0
   })
 }

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -193,3 +193,24 @@ Supports `breakout` sizes:
 </Center>
 ```
 
+#### Placeholder
+
+If the source of a `<FigureImage />` includes `size` information, the image is wrapped in a placeholder that takes up the expected image size before the image is actually loaded. This is great to avoid jumpy layouting while the page loads. For demonstration purposes here's a figure group with one non-existant image source:
+
+```react
+<FigureGroup>
+  <Figure>
+    <FigureImage src='/static/missing-file.jpg?size=974x687' alt='' />
+    <FigureCaption>
+      A placeholder for an image with size information.
+    </FigureCaption>
+  </Figure>
+  <Figure>
+    <FigureImage src='/static/landscape.jpg' alt='' />
+    <FigureCaption>
+      A caption for the right photo.{' '}
+      <FigureByline>Photo: Laurent Burst</FigureByline>
+    </FigureCaption>
+  </Figure>
+</FigureGroup>
+```

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -12,7 +12,8 @@ const styles = {
   figure: css({
     margin: 0,
     marginBottom: 15,
-    padding: 0
+    padding: 0,
+    width: '100%'
   }),
   figureGroup: css({
     margin: 0,


### PR DESCRIPTION
For image URLs with sizing info.

While loading, the image itself is used as a placeholder with gray background and paddingBottom/height:0 sizing. When the image has loaded, we move back to the default image size at 100% width.

While image is loading:
![screen shot 2017-12-08 at 16 55 34](https://user-images.githubusercontent.com/23520051/33773784-5c6d58a2-dc39-11e7-84d4-3e68d7ca3711.png)

Image has loaded:
![screen shot 2017-12-08 at 16 55 40](https://user-images.githubusercontent.com/23520051/33773796-6ae936da-dc39-11e7-8178-bdb22065edac.png)

