### PR TITLE
FigureImage Resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@orbiting/remark-preset": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@orbiting/remark-preset/-/remark-preset-1.2.1.tgz",
+      "integrity": "sha512-E40A4GdRpBHqIWAuZPYUu4h1WKkBRxSu9N6mnhTBucP/C9N1D7cfMS87l9S1bAvBdMIbctXfdCy/uSMtqB03iQ==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0",
+        "parse-entities": "1.1.1",
+        "remark-frontmatter": "1.1.0",
+        "remark-parse": "4.0.0",
+        "remark-stringify": "4.0.0",
+        "stringify-entities": "1.3.1",
+        "unified": "6.1.6"
+      }
+    },
     "@semantic-release/commit-analyzer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1601,6 +1601,32 @@
       "integrity": "sha1-Ffs9NfLEVmlYFevx7Zb+fwFbaIY=",
       "dev": true
     },
+    "babel-tape-runner": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-tape-runner/-/babel-tape-runner-2.0.1.tgz",
+      "integrity": "sha1-nAEv+asPMAIKwR/MjoSPID8iIXM=",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
@@ -4550,6 +4576,55 @@
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
       "dev": true
     },
+    "faucet": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/faucet/-/faucet-0.0.1.tgz",
+      "integrity": "sha1-WX3PHSGJosBiMhtZHo8VHtIDnZw=",
+      "dev": true,
+      "requires": {
+        "defined": "0.0.0",
+        "duplexer": "0.1.1",
+        "minimist": "0.0.5",
+        "sprintf": "0.1.5",
+        "tap-parser": "0.4.3",
+        "tape": "2.3.3",
+        "through2": "0.2.3"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+          "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+          "dev": true
+        },
+        "defined": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+          "dev": true
+        },
+        "tape": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+          "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+          "dev": true,
+          "requires": {
+            "deep-equal": "0.1.2",
+            "defined": "0.0.0",
+            "inherits": "2.0.3",
+            "jsonify": "0.0.0",
+            "resumer": "0.0.0",
+            "through": "2.3.8"
+          }
+        }
+      }
+    },
     "fault": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.1.tgz",
@@ -4868,6 +4943,15 @@
       "requires": {
         "debug": "2.6.9",
         "stream-consume": "0.1.0"
+      }
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
       }
     },
     "for-in": {
@@ -7011,6 +7095,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
       "dev": true
     },
     "is-glob": {
@@ -9203,6 +9293,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
       "integrity": "sha1-KKZZz5h9lqTavnhgKJ87UybEoDw=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
       "dev": true
     },
     "object-keys": {
@@ -12586,6 +12682,15 @@
         "signal-exit": "3.0.2"
       }
     },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "retry": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
@@ -13184,6 +13289,12 @@
         "through": "2.3.8"
       }
     },
+    "sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -13327,6 +13438,17 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -13557,11 +13679,76 @@
         }
       }
     },
+    "tap-parser": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.4.3.tgz",
+      "integrity": "sha1-pOrhkMENdsehEZIf84u+TVjwnuo=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "tapable": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "test-exclude": {
       "version": "4.1.1",
@@ -13668,6 +13855,57 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "0.4.0"
+          }
+        }
+      }
     },
     "thunky": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "downshift": "^1.16.1"
   },
   "devDependencies": {
+    "@orbiting/remark-preset": "^1.2.1",
     "babel-cli": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-2": "^6.22.0",
+    "babel-tape-runner": "^2.0.1",
     "catalog": "^3.1.2",
     "commitizen": "^2.9.6",
     "core-js": "^2.4.1",
@@ -26,6 +27,7 @@
     "d3-color": "^1.0.3",
     "d3-time-format": "^2.1.1",
     "downshift": "^1.16.1",
+    "faucet": "0.0.1",
     "glamor": "^2.20.37",
     "gsheets": "^2.0.0",
     "husky": "^0.14.3",
@@ -42,6 +44,7 @@
     "semantic-release": "^6.3.6",
     "slate": "^0.31.2",
     "slate-mdast-serializer": "^0.1.2",
+    "tape": "^4.8.0",
     "validate-commit-msg": "^2.14.0"
   },
   "files": [
@@ -63,7 +66,7 @@
     "build": "npm run build:lib && react-scripts build",
     "start": "react-scripts start",
     "dev": "babel -w src --out-dir lib & PORT=3003 react-scripts start",
-    "test": "react-scripts test --env=jsdom",
+    "test": "babel-tape-runner src/**/*.test.js | faucet",
     "eject": "react-scripts eject",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "commitmsg": "validate-commit-msg",

--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -53,12 +53,14 @@ export const breakoutStyles = {
   breakout: css({
     [breakoutUp]: {
       marginLeft: -BREAKOUT,
-      marginRight: -BREAKOUT
+      marginRight: -BREAKOUT,
+      width: `calc(100% + ${BREAKOUT * 2}px)`
     }
   }),
   breakoutLeft: css({
     [breakoutUp]: {
-      marginLeft: -BREAKOUT
+      marginLeft: -BREAKOUT,
+      width: `calc(100% + ${BREAKOUT}px)`
     }
   }),
   float: css({

--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -31,6 +31,9 @@ const styles = {
     maxWidth: MAX_WIDTH,
     margin: '0 auto',
     padding: PADDING
+  }),
+  clear: css({
+    clear: 'both'
   })
 }
 
@@ -80,6 +83,7 @@ export const breakoutStyles = {
 const Center = ({ children, attributes = {}, ...props }) => (
   <div {...styles.center} {...attributes} {...props}>
     {children}
+    <div {...styles.clear} />
   </div>
 )
 

--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -2,10 +2,16 @@ import React from 'react'
 import { css } from 'glamor'
 import PropTypes from 'prop-types'
 
-export const MAX_WIDTH = 665
+
 export const PADDING = 20
+
+export const MAX_WIDTH = 625
+// iPhone Plus, for max image sizes
+export const MAX_WIDTH_MOBILE = 414 - PADDING * 2
+
 const DEFAULT_MARGIN = 15
 export const BREAKOUT = 155 + DEFAULT_MARGIN
+
 const FLOAT_MARGIN = 100
 const NARROW_WIDTH = 495
 const SMALL_WIDTH = 410
@@ -22,19 +28,31 @@ const floatStyle = {
   width: '100%'
 }
 
-const breakoutUp = `@media only screen and (min-width: ${MAX_WIDTH +
+const breakoutUp = `@media only screen and (min-width: ${
+  MAX_WIDTH +
   BREAKOUT * 2 +
-  PADDING * 2}px)`
+  PADDING * 2 + 
+  PADDING}px)`
 
 const styles = {
   center: css({
-    maxWidth: MAX_WIDTH,
+    maxWidth: MAX_WIDTH + PADDING * 2,
     margin: '0 auto',
     padding: PADDING
   }),
   clear: css({
     clear: 'both'
   })
+}
+
+export const BREAKOUT_SIZES = {
+  narrow: NARROW_WIDTH,
+  tiny: TINY_WIDTH,
+  breakout: MAX_WIDTH + BREAKOUT * 2,
+  breakoutLeft: MAX_WIDTH + BREAKOUT,
+  float: NARROW_WIDTH,
+  floatSmall: SMALL_WIDTH,
+  floatTiny: TINY_WIDTH
 }
 
 export const breakoutStyles = {

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -15,6 +15,9 @@ const styles = {
     backgroundColor: '#eee',
     display: 'block',
     position: 'relative'
+  }),
+  maxWidth: css({
+    display: 'block',
   })
 }
 
@@ -34,16 +37,16 @@ class Image extends Component {
 
     if (isFinite(aspectRatio)) {
       return (
-        <span
-          {...styles.aspectRatio}
-          style={{ paddingBottom: `${100 / aspectRatio}%` }}
-        >
-          <img
-            {...attributes}
-            {...styles.wrappedImage}
-            src={resizedSrc}
-            alt={alt}
-          />
+        <span {...styles.maxWidth} style={{maxWidth: +sizeInfo.width}}>
+          <span
+            {...styles.aspectRatio}
+            style={{paddingBottom: `${100 / aspectRatio}%`}}>
+            <img
+              {...attributes}
+              {...styles.wrappedImage}
+              src={resizedSrc}
+              alt={alt} />
+          </span>
         </span>
       )
     }

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { imageSizeInfo, imageResizeUrl } from 'mdast-react-render/lib/utils'
+import { imageSizeInfo } from 'mdast-react-render/lib/utils'
+import { getSrcSizes } from './utils'
 
 const styles = {
   image: css({
@@ -22,44 +23,58 @@ const styles = {
 }
 
 class Image extends Component {
-  // This will eventually become a stateful component.
-
   render() {
     const {
-      src = '', // protect from exception in image helpers
+      src,
+      srcSet,
       alt,
       attributes = {},
-      resize
+      maxWidth,
+      size: sizeProp
     } = this.props
-    const resizedSrc = resize ? imageResizeUrl(src, resize) : src
-    const sizeInfo = imageSizeInfo(src)
-    const aspectRatio = sizeInfo ? sizeInfo.width / sizeInfo.height : undefined
 
-    if (isFinite(aspectRatio)) {
+    const size = sizeProp || (sizeProp === undefined && imageSizeInfo(src))
+    const aspectRatio = size ? size.width / size.height : undefined
+
+    const image = isFinite(aspectRatio)
+      ? (
+        <span
+          {...attributes}
+          {...styles.aspectRatio}
+          style={{paddingBottom: `${100 / aspectRatio}%`}}>
+          <img
+            {...styles.wrappedImage}
+            src={src}
+            srcSet={srcSet}
+            alt={alt} />
+        </span>
+      )
+      : <img {...attributes} {...styles.image} src={src} srcSet={srcSet} alt={alt} />
+
+    if (maxWidth) {
       return (
-        <span {...styles.maxWidth} style={{maxWidth: +sizeInfo.width}}>
-          <span
-            {...styles.aspectRatio}
-            style={{paddingBottom: `${100 / aspectRatio}%`}}>
-            <img
-              {...attributes}
-              {...styles.wrappedImage}
-              src={resizedSrc}
-              alt={alt} />
-          </span>
+        <span {...styles.maxWidth} style={{maxWidth}}>
+          {image}
         </span>
       )
     }
-    return (
-      <img {...attributes} {...styles.image} src={resizedSrc} alt={alt} />
-    )
+    return image
   }
 }
 
 Image.propTypes = {
   src: PropTypes.string.isRequired,
+  srcSet: PropTypes.string,
   alt: PropTypes.string,
-  resize: PropTypes.string
+  size: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number
+  }),
+  maxWidth: PropTypes.number
+}
+
+Image.utils = {
+  getSrcSizes: getSrcSizes
 }
 
 export default Image

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { imageSizeInfo } from 'mdast-react-render/lib/utils'
-import { getSrcSizes } from './utils'
+import { getResizedSrcs } from './utils'
 
 const styles = {
   image: css({
@@ -74,7 +74,7 @@ Image.propTypes = {
 }
 
 Image.utils = {
-  getSrcSizes: getSrcSizes
+  getResizedSrcs
 }
 
 export default Image

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -41,24 +41,38 @@ Properties
 
 #### Placeholder
 
-If the source of a `<FigureImage />` includes `size` information, the image is wrapped in a placeholder that takes up the expected image size before the image is actually loaded. This is great to avoid jumpy layouting while the page loads. For demonstration purposes here's a figure with a non-existant image source:
+If `size` is provided or the `src` of a `<FigureImage />` includes `size` information in the query string, the image is wrapped in a placeholder that takes up the expected image size before the image is actually loaded. This is great to avoid jumpy layouting while the page loads.
 
 ```react|span-3
 <Figure>
-  <FigureImage src='/static/missing-file.jpg?size=974x687' alt='' />
+  <FigureImage
+    src='/static/missing-file.jpg'
+    size={{width: 974, height: 687}}
+    alt='' />
   <FigureCaption>
-    A placeholder for an image with size information.
+    Placeholder from explicit size information.
+  </FigureCaption>
+</Figure>
+```
+
+```react|span-3
+<Figure>
+  <FigureImage
+    src='/static/missing-file.jpg?size=974x687'
+    alt='' />
+  <FigureCaption>
+    Placeholder from automatic size information.
   </FigureCaption>
 </Figure>
 ```
 
 #### Max Width
 
-If the source of a `<FigureImage />` includes `size` information, the image will never be displayed larger than it actually is.
+You may provide an `maxWidth`, e.g. the resolution of the file.
 
 ```react
 <Figure>
-  <FigureImage src='/static/profilePicture1.png?size=200x200' alt='' />
+  <FigureImage src='/static/profilePicture1.png' maxWidth={200} alt='' />
 </Figure>
 ```
 

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -37,7 +37,10 @@ The `<FigureImage>` component scales the image to 100% of the available space.
 Properties
 
 - `src` string, the image url, mandatory
+- `srcSet` string, alt src, e.g. retina
 - `alt` string, the alternative text
+- `maxWidth` number, e.g. the src width you don't want to exceed
+- `size` object, pre-calculated `width` and `height`
 
 #### Placeholder
 
@@ -74,6 +77,30 @@ You may provide an `maxWidth`, e.g. the resolution of the file.
 <Figure>
   <FigureImage src='/static/profilePicture1.png' maxWidth={200} alt='' />
 </Figure>
+```
+
+#### Utils
+
+`FigureImage.utils.getResizedSrcs(src, displayWidth)`
+Tries to get size information from the url and if successful returns a resized `src`, a `srcSet` with retina resolution, `size` and `maxWidth`.
+
+You can directly pass the result as props to `FigureImage`:
+
+```react|span-3
+<FigureImage
+  {...FigureImage.utils.getResizedSrcs(
+    '/static/desert.jpg?size=4323x2962',
+    1500
+  )} />
+```
+
+```react|no-source,span-3
+<pre style={{backgroundColor: '#fff', padding: 20, margin: -20, overflow: 'auto'}}>
+  {JSON.stringify(FigureImage.utils.getResizedSrcs(
+    '/static/desert.jpg?size=4323x2962',
+    1500
+  ), null, 2)}
+</pre>
 ```
 
 ### `<FigureGroup />`

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -39,6 +39,29 @@ Properties
 - `src` string, the image url, mandatory
 - `alt` string, the alternative text
 
+#### Placeholder
+
+If the source of a `<FigureImage />` includes `size` information, the image is wrapped in a placeholder that takes up the expected image size before the image is actually loaded. This is great to avoid jumpy layouting while the page loads. For demonstration purposes here's a figure with a non-existant image source:
+
+```react|span-3
+<Figure>
+  <FigureImage src='/static/missing-file.jpg?size=974x687' alt='' />
+  <FigureCaption>
+    A placeholder for an image with size information.
+  </FigureCaption>
+</Figure>
+```
+
+#### Max Width
+
+If the source of a `<FigureImage />` includes `size` information, the image will never be displayed larger than it actually is.
+
+```react
+<Figure>
+  <FigureImage src='/static/profilePicture1.png?size=200x200' alt='' />
+</Figure>
+```
+
 ### `<FigureGroup />`
 
 A `<FigureGroup />` arranges multiple `<Figure />` elements in columns. Use the `columns` prop to specify `2` to `4` columns, defaults to `2`. There's no auto-cropping magic in place, so image files should already be cropped to the same aspect ratio.
@@ -191,26 +214,4 @@ Supports `breakout` sizes:
     </FigureCaption>
   </FigureGroup>
 </Center>
-```
-
-#### Placeholder
-
-If the source of a `<FigureImage />` includes `size` information, the image is wrapped in a placeholder that takes up the expected image size before the image is actually loaded. This is great to avoid jumpy layouting while the page loads. For demonstration purposes here's a figure group with one non-existant image source:
-
-```react
-<FigureGroup>
-  <Figure>
-    <FigureImage src='/static/missing-file.jpg?size=974x687' alt='' />
-    <FigureCaption>
-      A placeholder for an image with size information.
-    </FigureCaption>
-  </Figure>
-  <Figure>
-    <FigureImage src='/static/landscape.jpg' alt='' />
-    <FigureCaption>
-      A caption for the right photo.{' '}
-      <FigureByline>Photo: Laurent Burst</FigureByline>
-    </FigureCaption>
-  </Figure>
-</FigureGroup>
 ```

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -2,7 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css, merge } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
-import { breakoutStyles, MAX_WIDTH, PADDING } from '../Center'
+import {
+  breakoutStyles,
+  MAX_WIDTH,
+  PADDING,
+  BREAKOUT_SIZES
+} from '../Center'
 
 export { default as FigureImage } from './Image'
 export { default as FigureCaption } from './Caption'
@@ -50,12 +55,17 @@ const styles = {
 const figureBreakout = {
   ...breakoutStyles,
   center: css({
-    maxWidth: MAX_WIDTH,
+    maxWidth: MAX_WIDTH + PADDING * 2,
     padding: PADDING,
     marginLeft: 'auto',
     marginRight: 'auto',
     marginBottom: 0
   })
+}
+
+export const FIGURE_SIZES = {
+  ...BREAKOUT_SIZES,
+  center: MAX_WIDTH
 }
 
 export const Figure = ({ children, attributes, size }) => (

--- a/src/components/Figure/utils.js
+++ b/src/components/Figure/utils.js
@@ -6,7 +6,7 @@ import {
   MAX_WIDTH_MOBILE
 } from '../Center'
 
-export const getSrcSizes = (src, displayWidth) => {
+export const getResizedSrcs = (src, displayWidth) => {
   const sizeInfo = imageSizeInfo(src)
   if (!sizeInfo) {
     return {

--- a/src/components/Figure/utils.js
+++ b/src/components/Figure/utils.js
@@ -42,7 +42,7 @@ export const getResizedSrcs = (src, displayWidth) => {
       : maxWidth
     ]
       .map(size => [
-        imageResizeUrl(src, size),
+        imageResizeUrl(src, `${size}x`),
         `${size}w`
       ].join(' '))
       .join(',')

--- a/src/components/Figure/utils.js
+++ b/src/components/Figure/utils.js
@@ -1,0 +1,57 @@
+import {
+  imageSizeInfo,
+  imageResizeUrl
+} from 'mdast-react-render/lib/utils'
+import {
+  MAX_WIDTH_MOBILE
+} from '../Center'
+
+export const getSrcSizes = (src, displayWidth) => {
+  const sizeInfo = imageSizeInfo(src)
+  if (!sizeInfo) {
+    return {
+      src,
+      size: null
+    }
+  }
+  const size = {
+    width: +sizeInfo.width,
+    height: +sizeInfo.height
+  }
+
+  const maxWidth = size.width
+  const defaultWidth = Math.min(
+    Math.max(
+      displayWidth,
+      // images could always be shown full width on mobile
+      MAX_WIDTH_MOBILE
+    ),
+    maxWidth
+  )
+
+  const resizedSrc = imageResizeUrl(
+    src,
+    `${defaultWidth}x`
+  )
+
+  let srcSet
+  if (defaultWidth < maxWidth) {
+    // add high res image
+    srcSet = [defaultWidth * 2 <= maxWidth
+      ? defaultWidth * 2
+      : maxWidth
+    ]
+      .map(size => [
+        imageResizeUrl(src, size),
+        `${size}w`
+      ].join(' '))
+      .join(',')
+  }
+
+  return {
+    src: resizedSrc,
+    srcSet,
+    maxWidth,
+    size
+  }
+}

--- a/src/components/Figure/utils.test.js
+++ b/src/components/Figure/utils.test.js
@@ -1,0 +1,54 @@
+import test from 'tape'
+
+import { getResizedSrcs } from './utils'
+
+test('getResizedSrcs: no size info', assert => {
+  const props = getResizedSrcs('image.jpg', 2000)
+  assert.equal(props.src, 'image.jpg')
+  assert.equal(props.size, null)
+  assert.equal(props.srcSet, undefined)
+  assert.equal(props.maxWidth, undefined)
+
+  assert.end()
+})
+
+test('getResizedSrcs: size info', assert => {
+  const props = getResizedSrcs('image.jpg?size=4500x2500', 2000)
+  assert.equal(props.src, 'image.jpg?size=4500x2500&resize=2000x')
+  assert.deepEqual(props.size, {
+    width: 4500,
+    height: 2500
+  })
+  assert.equal(props.srcSet, 'image.jpg?size=4500x2500&resize=4000x 4000w')
+  assert.equal(props.maxWidth, 4500)
+
+  assert.end()
+})
+
+test('getResizedSrcs: skip retina if src is too small', assert => {
+  const props = getResizedSrcs('image.jpg?size=2000x1500', 2000)
+  assert.equal(props.src, 'image.jpg?size=2000x1500&resize=2000x')
+  assert.deepEqual(props.size, {
+    width: 2000,
+    height: 1500
+  })
+  // no retina if it would be bigger or equal to the source
+  assert.equal(props.srcSet, undefined)
+  assert.equal(props.maxWidth, 2000)
+
+  assert.end()
+})
+
+test('getResizedSrcs: add semi retina if src is too small for full retina', assert => {
+  const props = getResizedSrcs('image.jpg?size=3000x1500', 2000)
+  assert.equal(props.src, 'image.jpg?size=3000x1500&resize=2000x')
+  assert.deepEqual(props.size, {
+    width: 3000,
+    height: 1500
+  })
+  // no retina if it would be bigger or equal to the source
+  assert.equal(props.srcSet, 'image.jpg?size=3000x1500&resize=3000x 3000w')
+  assert.equal(props.maxWidth, 3000)
+
+  assert.end()
+})

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -1,21 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { Breakout } from '../Center'
-import { mUp } from '../../theme/mediaQueries'
+import { Breakout, MAX_WIDTH_MOBILE } from '../Center'
+import { mUp, onlyS } from '../../theme/mediaQueries'
 
-export const IMAGE_SIZE = {
+export const IMAGE_SIZES = {
   XS: 120,
   S: 155,
   M: 240,
   L: 325
 }
+export const DEFAULT_IMAGE_SIZE = 'S'
 
 export const textAttributes = {'data-infobox-text': true}
 const textSelector = '[data-infobox-text]'
 
-const figureChildStyles = Object.keys(IMAGE_SIZE).reduce((styles, key) => {
-  const size = IMAGE_SIZE[key]
+const figureChildStyles = Object.keys(IMAGE_SIZES).reduce((styles, key) => {
+  const size = IMAGE_SIZES[key]
   styles[key] = css({
     [mUp]: {
       '& figure': {
@@ -26,9 +27,14 @@ const figureChildStyles = Object.keys(IMAGE_SIZE).reduce((styles, key) => {
   return styles
 }, {
   absolute: css({
+    [onlyS]: {
+      '& figure': {
+        maxWidth: MAX_WIDTH_MOBILE
+      }
+    },
     [mUp]: {
       position: 'relative',
-      minHeight: IMAGE_SIZE.S,
+      minHeight: IMAGE_SIZES.S,
       '& figure': {
         position: 'absolute',
         left: 0,
@@ -45,8 +51,8 @@ const figureChildStyles = Object.keys(IMAGE_SIZE).reduce((styles, key) => {
     }
   })
 })
-const textChildStyles = Object.keys(IMAGE_SIZE).reduce((styles, key) => {
-  const size = IMAGE_SIZE[key]
+const textChildStyles = Object.keys(IMAGE_SIZES).reduce((styles, key) => {
+  const size = IMAGE_SIZES[key]
   styles[key] = css({
     [mUp]: {
       [`& ${textSelector}`]: {
@@ -97,7 +103,7 @@ InfoBox.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   size: PropTypes.oneOf(['float', 'breakout']),
-  figureSize: PropTypes.oneOf(Object.keys(IMAGE_SIZE)),
+  figureSize: PropTypes.oneOf(Object.keys(IMAGE_SIZES)),
   figureFloat: PropTypes.bool.isRequired
 }
 

--- a/src/components/InfoBox/index.js
+++ b/src/components/InfoBox/index.js
@@ -1,3 +1,7 @@
-export { default as InfoBox } from './InfoBox'
+export {
+  default as InfoBox,
+  IMAGE_SIZES as INFOBOX_IMAGE_SIZES,
+  DEFAULT_IMAGE_SIZE as INFOBOX_DEFAULT_IMAGE_SIZE
+} from './InfoBox'
 export { default as InfoBoxText } from './Text'
 export { default as InfoBoxTitle } from './Title'

--- a/src/components/PullQuote/PullQuote.js
+++ b/src/components/PullQuote/PullQuote.js
@@ -4,6 +4,8 @@ import { css } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
 import { Breakout } from '../Center'
 
+export const IMAGE_SIZE = 155
+
 const styles = {
   container: css({
     margin: '0 auto'
@@ -15,7 +17,7 @@ const styles = {
         marginLeft: -170,
         marginRight: 15,
         float: 'left',
-        width: '155px'
+        width: IMAGE_SIZE
       }
     }
   }),

--- a/src/components/PullQuote/index.js
+++ b/src/components/PullQuote/index.js
@@ -1,3 +1,6 @@
-export { default as PullQuote } from './PullQuote'
+export {
+  default as PullQuote,
+  IMAGE_SIZE as PULLQUOTE_IMAGE_SIZE
+} from './PullQuote'
 export { default as PullQuoteSource } from './Source'
 export { default as PullQuoteText } from './Text'

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -42,7 +42,7 @@ const ImageBlock = ({
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
-      <FigureImage {...FigureImage.utils.getSrcSizes(image, 1500)} alt={alt} />
+      <FigureImage {...FigureImage.utils.getResizedSrcs(image, 1500)} alt={alt} />
       <div {...styles.textContainer}>
         <Text position={textPosition} color={color} center={center}>
           {children}

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp, dUp } from './mediaQueries'
-import Image from '../Figure/Image'
+import { FigureImage } from '../Figure'
 import Text from './Text'
 
 const styles = {
@@ -42,7 +42,7 @@ const ImageBlock = ({
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
-      <Image src={image} alt={alt} />
+      <FigureImage {...FigureImage.utils.getSrcSizes(image, 1500)} alt={alt} />
       <div {...styles.textContainer}>
         <Text position={textPosition} color={color} center={center}>
           {children}

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -11,7 +11,7 @@ A `<TeaserFrontImageHeadline />` should be used.
 
 ```react
 <TeaserFrontImage
-  image='/static/desert.jpg'
+  image='/static/desert.jpg?size=4323x2962'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontImageHeadline.Editorial>The sand is near</TeaserFrontImageHeadline.Editorial>

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -93,7 +93,7 @@ const Split = ({
           portrait ? styles.imageContainerPortrait : {}
         )}
       >
-        <FigureImage {...FigureImage.utils.getSrcSizes(image, 750)} alt={alt} />
+        <FigureImage {...FigureImage.utils.getResizedSrcs(image, 750)} alt={alt} />
       </div>
       <div
         {...css(

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp, dUp } from './mediaQueries'
-import Image from '../Figure/Image'
+import { FigureImage } from '../Figure'
 import Text from './Text'
 
 const styles = {
@@ -93,7 +93,7 @@ const Split = ({
           portrait ? styles.imageContainerPortrait : {}
         )}
       >
-        <Image src={image} alt={alt} />
+        <FigureImage {...FigureImage.utils.getSrcSizes(image, 750)} alt={alt} />
       </div>
       <div
         {...css(

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -10,7 +10,7 @@ Supported props:
 A `<TeaserFrontSplitHeadline />` should be used.
 
 ```react
-<TeaserFrontSplit image='/static/rothaus_portrait.jpg'
+<TeaserFrontSplit image='/static/rothaus_portrait.jpg?size=945x1331'
   portrait
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>

--- a/src/components/TitleBlock/index.js
+++ b/src/components/TitleBlock/index.js
@@ -7,7 +7,7 @@ import { Editorial } from '../Typography'
 
 const styles = {
   container: css({
-    maxWidth: MAX_WIDTH,
+    maxWidth: MAX_WIDTH + PADDING * 2,
     margin: '0 auto 40px auto',
     paddingTop: 30,
     paddingLeft: PADDING,

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,6 @@ import 'core-js/es6'
 import {fontFaces} from './theme/fonts'
 import {createFormatter} from './lib/translate'
 
-import Serializer from 'slate-mdast-serializer'
-
 simulations(true)
 // prevent speedy in catalog
 // - iframe rendering (e.g. responsive preview)
@@ -361,8 +359,7 @@ ReactDOM.render(
             imports: {
               schema: require('./templates/Article').default(),
               ...require('./templates/docs'),
-              renderMdast: require('mdast-react-render').renderMdast,
-              serializer: new Serializer()
+              renderMdast: require('mdast-react-render').renderMdast
             },
             src: require('./templates/Article/docs.md')
           },
@@ -372,8 +369,7 @@ ReactDOM.render(
             imports: {
               schema: require('./templates/Front').default(),
               ...require('./templates/docs'),
-              renderMdast: require('mdast-react-render').renderMdast,
-              serializer: new Serializer()
+              renderMdast: require('mdast-react-render').renderMdast
             },
             src: require('./templates/Front/docs.md')
           }

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -36,7 +36,7 @@ In den letzten Jahrzehnten ist das Interesse an Hungerkünstlern sehr zurückgeg
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 Etwas Böses _Foto: Laurent Burst_
 
@@ -112,7 +112,7 @@ Von [Franz Kafka](<>) (Text) und [Everett Collection](<>) (Bilder), 13. Juli 201
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 Etwas Böses _Foto: Laurent Burst_
 
@@ -130,7 +130,7 @@ Simpy unwrap from center
 <Markdown schema={schema}>{`
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 Etwas Böses _Foto: Laurent Burst_
 
@@ -154,7 +154,7 @@ Values: `undefined` (default), `breakout`
 {"size": "breakout"}
 \`\`\`
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 Etwas Böses _Foto: Laurent Burst_
 
@@ -176,13 +176,13 @@ Etwas Böses _Foto: Laurent Burst_
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 <hr /></section>
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 <hr /></section>
 
@@ -212,7 +212,7 @@ Values: `2` (default), `3`, `4`
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 Ein Monster
 
@@ -220,7 +220,7 @@ Ein Monster
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 Wirklich
 
@@ -228,7 +228,7 @@ Wirklich
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 MONSTER!
 
@@ -300,7 +300,7 @@ Genau zu diesem Zwecke erschaffen, immer im Schatten meines großen Bruders «Lo
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 _Foto: Laurent Burst_
 
@@ -374,7 +374,7 @@ Was für eine Erleichterung. Standards sparen Zeit bei den Entwicklungskosten un
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 _Foto: Laurent Burst_
 
@@ -406,7 +406,7 @@ Values: `XS`, `S` (default), `M`, `L`
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 _Foto: Laurent Burst_
 
@@ -438,7 +438,7 @@ Values: `falsy` (default), `true`
 
 <section><h6>FIGURE</h6>
 
-![](/static/landscape.jpg)
+![](/static/landscape.jpg?size=2000x1411)
 
 _Foto: Laurent Burst_
 

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -19,8 +19,7 @@ import {
 import {
   PullQuote,
   PullQuoteText,
-  PullQuoteSource,
-  PULLQUOTE_IMAGE_SIZE
+  PullQuoteSource
 } from '../../components/PullQuote'
 import {
   List,
@@ -30,7 +29,6 @@ import {
   InfoBox,
   InfoBoxTitle,
   InfoBoxText,
-  INFOBOX_IMAGE_SIZES,
   INFOBOX_DEFAULT_IMAGE_SIZE
 } from '../../components/InfoBox'
 import {
@@ -46,6 +44,12 @@ import {
   matchParagraph,
   matchImageParagraph
 } from 'mdast-react-render/lib/utils'
+import {
+  matchInfoBox,
+  matchQuote,
+  matchFigure,
+  getDisplayWidth
+} from './utils'
 
 const matchLast = (node, index, parent) => index === parent.children.length - 1
 
@@ -125,34 +129,6 @@ const figureCaption = {
     link,
     ...globalInlines
   ]
-}
-
-const matchInfoBox = matchZone('INFOBOX')
-const matchQuote = matchZone('QUOTE')
-const matchFigure = matchZone('FIGURE')
-
-const getDisplayWidth = ancestors => {
-  const infobox = ancestors.find(matchInfoBox)
-  if (infobox) {
-    return INFOBOX_IMAGE_SIZES[
-      infobox.data.figureSize || INFOBOX_DEFAULT_IMAGE_SIZE
-    ]
-  }
-  const quote = ancestors.find(matchQuote)
-  if (quote) {
-    return PULLQUOTE_IMAGE_SIZE
-  }
-  const figure = ancestors.find(matchFigure)
-  if (figure) {
-    if (figure.data.size) {
-      return FIGURE_SIZES[figure.data.size]
-    }
-    // child of root === e2e, root === ancestor[-1]
-    if (ancestors.indexOf(figure) === ancestors.length - 2) {
-      return 1200
-    }
-  }
-  return FIGURE_SIZES.center
 }
 
 const figure = {

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -196,7 +196,7 @@ const figure = {
         const displayWidth = getDisplayWidth(ancestors)
 
         return {
-          ...FigureImage.utils.getSrcSizes(
+          ...FigureImage.utils.getResizedSrcs(
             src,
             displayWidth
           ),
@@ -244,7 +244,7 @@ const cover = {
         const displayWidth = FIGURE_SIZES[parent.data.size] || 1500
 
         return {
-          ...FigureImage.utils.getSrcSizes(
+          ...FigureImage.utils.getResizedSrcs(
             src,
             displayWidth
           ),

--- a/src/templates/Article/utils.js
+++ b/src/templates/Article/utils.js
@@ -1,0 +1,42 @@
+import {
+  matchZone
+} from 'mdast-react-render/lib/utils'
+
+import {
+  FIGURE_SIZES
+} from '../../components/Figure'
+import {
+  PULLQUOTE_IMAGE_SIZE
+} from '../../components/PullQuote'
+import {
+  INFOBOX_IMAGE_SIZES,
+  INFOBOX_DEFAULT_IMAGE_SIZE
+} from '../../components/InfoBox'
+
+export const matchInfoBox = matchZone('INFOBOX')
+export const matchQuote = matchZone('QUOTE')
+export const matchFigure = matchZone('FIGURE')
+
+export const getDisplayWidth = ancestors => {
+  const infobox = ancestors.find(matchInfoBox)
+  if (infobox) {
+    return INFOBOX_IMAGE_SIZES[
+      infobox.data.figureSize || INFOBOX_DEFAULT_IMAGE_SIZE
+    ]
+  }
+  const quote = ancestors.find(matchQuote)
+  if (quote) {
+    return PULLQUOTE_IMAGE_SIZE
+  }
+  const figure = ancestors.find(matchFigure)
+  if (figure) {
+    if (figure.data.size) {
+      return FIGURE_SIZES[figure.data.size]
+    }
+    // child of root === e2e, root === ancestor[-1]
+    if (ancestors.indexOf(figure) === ancestors.length - 2) {
+      return 1200
+    }
+  }
+  return FIGURE_SIZES.center
+}

--- a/src/templates/Article/utils.test.js
+++ b/src/templates/Article/utils.test.js
@@ -1,0 +1,159 @@
+import test from 'tape'
+import { parse } from '@orbiting/remark-preset'
+
+import {
+  INFOBOX_IMAGE_SIZES,
+  INFOBOX_DEFAULT_IMAGE_SIZE
+} from '../../components/InfoBox'
+
+import {
+  PULLQUOTE_IMAGE_SIZE
+} from '../../components/PullQuote'
+
+import {
+  FIGURE_SIZES
+} from '../../components/Figure'
+
+import {
+  getDisplayWidth
+} from './utils'
+
+const parseFirst = string => parse(string).children[0]
+
+test('article.utils.getDisplayWidth: infobox', assert => {
+  const regularInfobox = parseFirst(`
+<section><h6>INFOBOX</h6>
+
+![](/static/landscape.jpg?size=2000x1411)
+
+<hr /></section>
+  `)
+
+  assert.equal(
+    getDisplayWidth(
+      [regularInfobox]
+    ),
+    INFOBOX_IMAGE_SIZES[INFOBOX_DEFAULT_IMAGE_SIZE]
+  )
+
+  const mInfobox = parseFirst(`
+<section><h6>INFOBOX</h6>
+
+\`\`\`
+{"figureSize": "M"}
+\`\`\`
+
+<section><h6>FIGURE</h6>
+
+![](/static/landscape.jpg?size=2000x1411)
+
+<hr /></section>
+
+<hr /></section>
+  `)
+
+  assert.equal(
+    getDisplayWidth(
+      [mInfobox]
+    ),
+    INFOBOX_IMAGE_SIZES['M']
+  )
+
+  assert.end()
+})
+
+
+test('article.utils.getDisplayWidth: pull quote', assert => {
+  const pullQuote = parseFirst(`
+<section><h6>QUOTE</h6>
+
+<section><h6>FIGURE</h6>
+
+![](/static/landscape.jpg?size=2000x1411)
+
+_Foto: Laurent Burst_
+
+<hr /></section>
+
+<hr /></section>
+  `)
+
+  assert.equal(
+    getDisplayWidth(
+      [pullQuote]
+    ),
+    PULLQUOTE_IMAGE_SIZE
+  )
+
+  assert.end()
+})
+
+
+test('article.utils.getDisplayWidth: figure', assert => {
+  const rootNode = parse(`
+<section><h6>CENTER</h6>
+
+<section><h6>FIGURE</h6>
+
+![](/static/landscape.jpg?size=2000x1411)
+
+_Foto: Laurent Burst_
+
+<hr /></section>
+
+<hr /></section>
+  `)
+  const center = rootNode.children[0]
+  const figure = center.children[0]
+
+  assert.equal(
+    getDisplayWidth(
+      [figure, center, rootNode]
+    ),
+    FIGURE_SIZES.center,
+    'center figure'
+  )
+
+
+  const breakoutFigure = parseFirst(`
+<section><h6>FIGURE</h6>
+
+\`\`\`
+{"size": "breakout"}
+\`\`\`
+
+![](/static/landscape.jpg?size=2000x1411)
+
+Etwas Böses _Foto: Laurent Burst_
+
+<hr /></section>
+  `)
+  assert.equal(
+    getDisplayWidth(
+      [breakoutFigure, center, rootNode]
+    ),
+    FIGURE_SIZES.breakout,
+    'center figure'
+  )
+
+  const e2eFigureRootNode = parse(`
+<section><h6>FIGURE</h6>
+
+![](/static/landscape.jpg?size=2000x1411)
+
+_Foto: Laurent Burst_
+
+<hr /></section>
+  `)
+  const e2eFigure = e2eFigureRootNode.children[0]
+
+  assert.equal(
+    getDisplayWidth(
+      [e2eFigure, e2eFigureRootNode]
+    ),
+    1200,
+    'e2e figure'
+  )
+
+  assert.end()
+})

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import Serializer from 'slate-mdast-serializer'
 import { renderMdast } from 'mdast-react-render'
-
-const serializer = new Serializer()
+import { parse } from '@orbiting/remark-preset'
 
 export const Markdown = ({children, schema}) => {
   return (
     <div>
-      {renderMdast(serializer.parse(children), schema)}
+      {renderMdast(parse(children), schema)}
       <pre style={{backgroundColor: '#fff', padding: 20, margin: '20px -20px -20px -20px', overflow: 'auto'}}>
         <code style={{fontFamily: '"Roboto Mono", monospace'}}>
           {children.trim()}


### PR DESCRIPTION
Add resize urls to article template (mdast context dependant) and front image and split (static sizes). Includes `srcSet` for retina and `maxWidth` handling to avoid displaying larger than source.

Also includes other fixes:
- fix breakout width after figure placeholder intro
- fix float left overflow

<img width="1067" alt="screen shot 2017-12-13 at 22 33 14" src="https://user-images.githubusercontent.com/410211/33963565-a569291c-e055-11e7-8acb-c1b6513c578d.png">
