### PR TITLE
fix: bump node version to be compatible with publikator-backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@project-r/styleguide",
   "version": "0.0.0-development",
   "engines": {
-    "node": "8.4.0"
+    "node": "8.9.3"
   },
   "peerDependencies": {
     "d3-color": "^1.0.3",


### PR DESCRIPTION
See error:
```
~/work/publikator-backend [newsletter]$ yarn install
...
error @project-r/styleguide@5.23.0: The engine "node" is incompatible with this module. Expected version "8.4.0".
```
