### PR TITLE
fix: Clearfix for floating info box with image and short text

### DIFF
--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -48,6 +48,17 @@ const figureChildStyles = Object.keys(IMAGE_SIZES).reduce((styles, key) => {
       float: 'left',
       margin: '10px 15px 5px 0',
       width: '99px'
+    },
+    // Micro clearfix hack to avoid surrounding text floating into info boxes
+    // with image and very short text.
+    '&::before': {
+      content: ' ',
+      display: 'table'
+    },
+    '&::after': {
+      content: ' ',
+      display: 'table',
+      clear: 'both'
     }
   })
 })


### PR DESCRIPTION
Before:
<img width="883" alt="screen shot 2017-12-28 at 10 36 46" src="https://user-images.githubusercontent.com/23520051/34407488-f44255da-ebbe-11e7-848a-97992230baf6.png">

After:
<img width="906" alt="screen shot 2017-12-28 at 11 00 09" src="https://user-images.githubusercontent.com/23520051/34407499-fd63f934-ebbe-11e7-8bfd-0f4a7eafd774.png">
