### PR TITLE
fix(Article): Don't set maxWidth on an edge-to-edge cover image.

### DIFF
--- a/src/components/Figure/utils.js
+++ b/src/components/Figure/utils.js
@@ -6,7 +6,7 @@ import {
   MAX_WIDTH_MOBILE
 } from '../Center'
 
-export const getResizedSrcs = (src, displayWidth, fillMaxWidth = true) => {
+export const getResizedSrcs = (src, displayWidth, setMaxWidth = true) => {
   if (!src) {
     return {
       size: null
@@ -56,7 +56,7 @@ export const getResizedSrcs = (src, displayWidth, fillMaxWidth = true) => {
   return {
     src: resizedSrc,
     srcSet,
-    maxWidth: fillMaxWidth ? maxWidth : undefined,
+    maxWidth: setMaxWidth ? maxWidth : undefined,
     size
   }
 }

--- a/src/components/Figure/utils.js
+++ b/src/components/Figure/utils.js
@@ -6,7 +6,7 @@ import {
   MAX_WIDTH_MOBILE
 } from '../Center'
 
-export const getResizedSrcs = (src, displayWidth) => {
+export const getResizedSrcs = (src, displayWidth, fillMaxWidth = true) => {
   if (!src) {
     return {
       size: null
@@ -56,7 +56,7 @@ export const getResizedSrcs = (src, displayWidth) => {
   return {
     src: resizedSrc,
     srcSet,
-    maxWidth,
+    maxWidth: fillMaxWidth ? maxWidth : undefined,
     size
   }
 }

--- a/src/components/Figure/utils.test.js
+++ b/src/components/Figure/utils.test.js
@@ -43,7 +43,7 @@ test('getResizedSrcs: size info', assert => {
   assert.end()
 })
 
-test('getResizedSrcs: undefined maxWidth if fillMaxWidth is false', assert => {
+test('getResizedSrcs: undefined maxWidth if setMaxWidth is false', assert => {
   const props = getResizedSrcs('image.jpg?size=4500x2500', 2000, false)
   assert.equal(props.src, 'image.jpg?size=4500x2500&resize=2000x')
   assert.deepEqual(props.size, {

--- a/src/components/Figure/utils.test.js
+++ b/src/components/Figure/utils.test.js
@@ -43,6 +43,19 @@ test('getResizedSrcs: size info', assert => {
   assert.end()
 })
 
+test('getResizedSrcs: undefined maxWidth if fillMaxWidth is false', assert => {
+  const props = getResizedSrcs('image.jpg?size=4500x2500', 2000, false)
+  assert.equal(props.src, 'image.jpg?size=4500x2500&resize=2000x')
+  assert.deepEqual(props.size, {
+    width: 4500,
+    height: 2500
+  })
+  assert.equal(props.srcSet, 'image.jpg?size=4500x2500&resize=4000x 4000w')
+  assert.equal(props.maxWidth, undefined)
+
+  assert.end()
+})
+
 test('getResizedSrcs: skip retina if src is too small', assert => {
   const props = getResizedSrcs('image.jpg?size=2000x1500', 2000)
   assert.equal(props.src, 'image.jpg?size=2000x1500&resize=2000x')

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -199,11 +199,13 @@ const cover = {
       props: (node, index, parent) => {
         const src = extractImage(node)
         const displayWidth = FIGURE_SIZES[parent.data.size] || 1500
+        const fillMaxWidth = parent.data.size !== undefined
 
         return {
           ...FigureImage.utils.getResizedSrcs(
             src,
-            displayWidth
+            displayWidth,
+            fillMaxWidth
           ),
           alt: node.children[0].alt
         }

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -199,13 +199,13 @@ const cover = {
       props: (node, index, parent) => {
         const src = extractImage(node)
         const displayWidth = FIGURE_SIZES[parent.data.size] || 1500
-        const fillMaxWidth = parent.data.size !== undefined
+        const setMaxWidth = parent.data.size !== undefined
 
         return {
           ...FigureImage.utils.getResizedSrcs(
             src,
             displayWidth,
-            fillMaxWidth
+            setMaxWidth
           ),
           alt: node.children[0].alt
         }


### PR DESCRIPTION
Before:
![screen shot 2017-12-30 at 14 13 53](https://user-images.githubusercontent.com/23520051/34454436-cc1777f8-ed6b-11e7-9770-2f3e917ac820.png)

After:
![screen shot 2017-12-30 at 14 14 14](https://user-images.githubusercontent.com/23520051/34454440-d5096d3a-ed6b-11e7-85f1-61407387ab5d.png)
