### PR TITLE
fix: Make interaction headlines responsive

### DIFF
--- a/src/components/Typography/Interaction.js
+++ b/src/components/Typography/Interaction.js
@@ -22,19 +22,28 @@ const interactionHeadline = css({
 })
 
 const interactionH1 = css({
-  ...styles.sansSerifMedium40,
+  ...styles.sansSerifMedium30,
+  [mUp]: {
+    ...styles.sansSerifMedium40
+  },
   color: colors.text,
   margin: 0
 })
 
 const interactionH2 = css({
-  ...styles.sansSerifRegular30,
+  ...styles.sansSerifMedium22,
+  [mUp]: {
+    ...styles.sansSerifMedium30
+  },
   color: colors.text,
   margin: 0
 })
 
 const interactionH3 = css({
-  ...styles.sansSerifMedium22,
+  ...styles.sansSerifMedium19,
+  [mUp]: {
+    ...styles.sansSerifMedium22
+  },
   color: colors.text,
   margin: 0
 })


### PR DESCRIPTION
To allow using e.g. <Interaction.H1> on the feed page greeting in republik-frontend. 

Sounds like overkill to create yet another headline style just for that page, plus they seem to large on crowdfunding mobile anyway:
![screen shot 2017-12-30 at 15 24 32](https://user-images.githubusercontent.com/23520051/34454943-ac712a52-ed75-11e7-995f-26c7e3eceac2.png)
