### PR TITLE
fix(FrontImage): Shouldn't set maxWidth

### DIFF
--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -42,7 +42,7 @@ const ImageBlock = ({
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
-      <FigureImage {...FigureImage.utils.getResizedSrcs(image, 1500)} alt={alt} />
+      <FigureImage {...FigureImage.utils.getResizedSrcs(image, 1500, false)} alt={alt} />
       <div {...styles.textContainer}>
         <Text position={textPosition} color={color} center={center}>
           {children}


### PR DESCRIPTION
All front teasers are currently edge-to-edge, just the FrontImage may set maxWidth and screw up text positioning.