### PR TITLE
fix(TeaserFeed): Fall back to publish date if a feed item has no credits

### DIFF
--- a/src/components/TeaserFeed/index.js
+++ b/src/components/TeaserFeed/index.js
@@ -5,11 +5,12 @@ import Lead from './Lead'
 import Credit from './Credit'
 import { css } from 'glamor'
 import { renderMdast } from 'mdast-react-render'
+import { timeFormat } from '../../lib/timeFormat'
 import { Editorial } from '../Typography'
 
-import {
-  matchType
-} from 'mdast-react-render/lib/utils'
+import { matchType } from 'mdast-react-render/lib/utils'
+
+const dateFormat = timeFormat('%d. %B %Y')
 
 const styles = {
   link: css({
@@ -37,10 +38,21 @@ const creditSchema = {
 
 const DefaultLink = ({ children, path, slug }) => children
 
-export const TeaserFeed = ({ kind, format, path, slug, title, description, credits, Link = DefaultLink }) => {
-  const Headline = kind && kind.indexOf('meta') !== -1
-    ? Headlines.Interaction
-    : Headlines.Editorial
+export const TeaserFeed = ({
+  kind,
+  format,
+  path,
+  slug,
+  title,
+  description,
+  credits,
+  publishDate,
+  Link = DefaultLink
+}) => {
+  const Headline =
+    kind && kind.indexOf('meta') !== -1
+      ? Headlines.Interaction
+      : Headlines.Editorial
 
   return (
     <Container kind={kind} format={format}>
@@ -54,8 +66,14 @@ export const TeaserFeed = ({ kind, format, path, slug, title, description, credi
           <a {...styles.link}>{description}</a>
         </Link>
       </Lead>
-      {!!credits && <Credit>{renderMdast(credits, creditSchema)}</Credit>}
+
+      <Credit>
+        {!!credits.length > 0 ? (
+          renderMdast(credits, creditSchema)
+        ) : (
+          dateFormat(Date.parse(publishDate))
+        )}
+      </Credit>
     </Container>
   )
 }
-


### PR DESCRIPTION
Makes sure published newsletters appear with a date in the feed.

Preview:
<img width="740" alt="screen shot 2018-01-03 at 16 42 15" src="https://user-images.githubusercontent.com/23520051/34527199-18408e26-f0a5-11e7-9f06-2f4d47005a79.png">

  