### PR TITLE
fix(EditorialNewsletter): sub/sup should have inline style for lineHeight:0

### DIFF
--- a/src/components/TeaserFeed/index.js
+++ b/src/components/TeaserFeed/index.js
@@ -5,11 +5,12 @@ import Lead from './Lead'
 import Credit from './Credit'
 import { css } from 'glamor'
 import { renderMdast } from 'mdast-react-render'
+import { timeFormat } from '../../lib/timeFormat'
 import { Editorial } from '../Typography'
 
-import {
-  matchType
-} from 'mdast-react-render/lib/utils'
+import { matchType } from 'mdast-react-render/lib/utils'
+
+const dateFormat = timeFormat('%d. %B %Y')
 
 const styles = {
   link: css({
@@ -37,10 +38,21 @@ const creditSchema = {
 
 const DefaultLink = ({ children, path, slug }) => children
 
-export const TeaserFeed = ({ kind, format, path, slug, title, description, credits, Link = DefaultLink }) => {
-  const Headline = kind && kind.indexOf('meta') !== -1
-    ? Headlines.Interaction
-    : Headlines.Editorial
+export const TeaserFeed = ({
+  kind,
+  format,
+  path,
+  slug,
+  title,
+  description,
+  credits,
+  publishDate,
+  Link = DefaultLink
+}) => {
+  const Headline =
+    kind && kind.indexOf('meta') !== -1
+      ? Headlines.Interaction
+      : Headlines.Editorial
 
   return (
     <Container kind={kind} format={format}>
@@ -54,8 +66,14 @@ export const TeaserFeed = ({ kind, format, path, slug, title, description, credi
           <a {...styles.link}>{description}</a>
         </Link>
       </Lead>
-      {!!credits && <Credit>{renderMdast(credits, creditSchema)}</Credit>}
+
+      <Credit>
+        {!!credits.length > 0 ? (
+          renderMdast(credits, creditSchema)
+        ) : (
+          dateFormat(Date.parse(publishDate))
+        )}
+      </Credit>
     </Container>
   )
 }
-

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -56,16 +56,12 @@ const subSupStyles = {
   })
 }
 
-export const Sub = ({ children, attributes, ...props }) => (
-  <sub {...props} {...attributes} {...subSupStyles.base} {...subSupStyles.sub}>
-    {children}
-  </sub>
+export const Sub = ({ children, attributes }) => (
+  <sub {...attributes} {...subSupStyles.base} {...subSupStyles.sub}>{children}</sub>
 )
 
-export const Sup = ({ children, attributes, ...props }) => (
-  <sup {...props} {...attributes} {...subSupStyles.base} {...subSupStyles.sup}>
-    {children}
-  </sup>
+export const Sup = ({ children, attributes }) => (
+  <sup {...attributes} {...subSupStyles.base} {...subSupStyles.sup}>{children}</sup>
 )
 
 const quoteRule = css(styles.quote)

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -56,13 +56,11 @@ const subSupStyles = {
   })
 }
 
-export const Sub = ({ children, attributes }) => (
+export const Sub = ({children, attributes}) =>
   <sub {...attributes} {...subSupStyles.base} {...subSupStyles.sub}>{children}</sub>
-)
 
-export const Sup = ({ children, attributes }) => (
+export const Sup = ({children, attributes}) =>
   <sup {...attributes} {...subSupStyles.base} {...subSupStyles.sup}>{children}</sup>
-)
 
 const quoteRule = css(styles.quote)
 const quoteTextRule = css(styles.quoteText)

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -56,11 +56,17 @@ const subSupStyles = {
   })
 }
 
-export const Sub = ({children, attributes}) =>
-  <sub {...attributes} {...subSupStyles.base} {...subSupStyles.sub}>{children}</sub>
+export const Sub = ({ children, attributes, ...props }) => (
+  <sub {...props} {...attributes} {...subSupStyles.base} {...subSupStyles.sub}>
+    {children}
+  </sub>
+)
 
-export const Sup = ({children, attributes}) =>
-  <sup {...attributes} {...subSupStyles.base} {...subSupStyles.sup}>{children}</sup>
+export const Sup = ({ children, attributes, ...props }) => (
+  <sup {...props} {...attributes} {...subSupStyles.base} {...subSupStyles.sup}>
+    {children}
+  </sup>
+)
 
 const quoteRule = css(styles.quote)
 const quoteTextRule = css(styles.quoteText)

--- a/src/templates/EditorialNewsletter/email/SubSup.js
+++ b/src/templates/EditorialNewsletter/email/SubSup.js
@@ -1,12 +1,8 @@
 import React from 'react'
-import {
-  Sub as ImportedSub,
-  Sup as ImportedSup
-} from '../../../components/Typography'
 
 export const Sub = ({ children }) => (
-  <ImportedSub style={{ lineHeight: 0 }}>{children}</ImportedSub>
+  <sub style={{ lineHeight: 0 }}>{children}</sub>
 )
 export const Sup = ({ children }) => (
-  <ImportedSup style={{ lineHeight: 0 }}>{children}</ImportedSup>
+  <sup style={{ lineHeight: 0 }}>{children}</sup>
 )

--- a/src/templates/EditorialNewsletter/email/SubSup.js
+++ b/src/templates/EditorialNewsletter/email/SubSup.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import {
+  Sub as ImportedSub,
+  Sup as ImportedSup
+} from '../../../components/Typography'
+
+export const Sub = ({ children }) => (
+  <ImportedSub style={{ lineHeight: 0 }}>{children}</ImportedSub>
+)
+export const Sup = ({ children }) => (
+  <ImportedSup style={{ lineHeight: 0 }}>{children}</ImportedSup>
+)

--- a/src/templates/EditorialNewsletter/email/index.js
+++ b/src/templates/EditorialNewsletter/email/index.js
@@ -4,6 +4,7 @@ import Container from './Container'
 import Cover, { CoverImage } from './Cover'
 import Center from './Center'
 import Figure, { Image, Caption, Byline } from './Figure'
+import { Sub, Sup } from './SubSup'
 
 const createSchema = ({ ...args } = {}) => {
   return createNewsletterSchema({
@@ -15,6 +16,8 @@ const createSchema = ({ ...args } = {}) => {
     Image,
     Caption,
     Byline,
+    Sub,
+    Sup,
     ...args
   })
 }

--- a/src/templates/EditorialNewsletter/schema.js
+++ b/src/templates/EditorialNewsletter/schema.js
@@ -2,7 +2,6 @@ import Paragraph, { Strong, Em, Link, Br } from './email/Paragraph'
 import { H2 } from './email/Headlines'
 import Blockquote, { BlockquoteText, BlockquoteSource } from './email/Blockquote'
 import List, { ListItem } from './email/List'
-import { Sub, Sup } from './email/SubSup'
 
 import {
   matchType,
@@ -31,7 +30,9 @@ const createNewsletterSchema = ({
   Figure,
   Image,
   Caption,
-  Byline
+  Byline,
+  Sub,
+  Sup
 } = {}) => {
 
   const globalInlines = [

--- a/src/templates/EditorialNewsletter/schema.js
+++ b/src/templates/EditorialNewsletter/schema.js
@@ -2,7 +2,6 @@ import Paragraph, { Strong, Em, Link, Br } from './email/Paragraph'
 import { H2 } from './email/Headlines'
 import Blockquote, { BlockquoteText, BlockquoteSource } from './email/Blockquote'
 import List, { ListItem } from './email/List'
-//import { Sub, Sup } from '../../components/Typography'
 import { Sub, Sup } from './email/SubSup'
 
 import {

--- a/src/templates/EditorialNewsletter/schema.js
+++ b/src/templates/EditorialNewsletter/schema.js
@@ -2,7 +2,8 @@ import Paragraph, { Strong, Em, Link, Br } from './email/Paragraph'
 import { H2 } from './email/Headlines'
 import Blockquote, { BlockquoteText, BlockquoteSource } from './email/Blockquote'
 import List, { ListItem } from './email/List'
-import { Sub, Sup } from '../../components/Typography'
+//import { Sub, Sup } from '../../components/Typography'
+import { Sub, Sup } from './email/SubSup'
 
 import {
   matchType,

--- a/src/templates/EditorialNewsletter/web/index.js
+++ b/src/templates/EditorialNewsletter/web/index.js
@@ -9,6 +9,7 @@ import {
   FigureCaption,
   FigureByline
 } from '../../../components/Figure'
+import { Sub, Sup } from '../../../components/Typography'
 
 const createSchema = ({ ...args } = {}) => {
   return createNewsletterSchema({
@@ -20,6 +21,8 @@ const createSchema = ({ ...args } = {}) => {
     Image: FigureImage,
     Caption: FigureCaption,
     Byline: FigureByline,
+    Sub,
+    Sup,
     ...args
   })
 }


### PR DESCRIPTION
Gmail Before:
![screen shot 2018-01-03 at 17 17 38](https://user-images.githubusercontent.com/23520051/34529050-06dee924-f0ab-11e7-950a-44604070208c.png)

Gmail After:
![screen shot 2018-01-03 at 17 17 56](https://user-images.githubusercontent.com/23520051/34529059-0b2bfca6-f0ab-11e7-939e-94cfe96f0821.png)

Don't get how https://github.com/orbiting/styleguide/pull/77/commits/4b3c6bae3a490087f50393df6b5077936e13c659 sneaked in here, I had already pushed that from a different branch in https://github.com/orbiting/styleguide/pull/76  
  