### PR TITLE
fix(Figure): 5px top-margin for figure caption

### DIFF
--- a/src/components/Figure/Caption.js
+++ b/src/components/Figure/Caption.js
@@ -7,7 +7,7 @@ import { PADDING } from '../Center'
 
 const styles = {
   caption: css({
-    margin: '0 auto',
+    margin: '5px auto 0 auto',
     width: '100%',
     maxWidth: `calc(100vw - ${PADDING * 2}px)`,
     ...sansSerifRegular12,

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -6,6 +6,7 @@ import { getResizedSrcs } from './utils'
 
 const styles = {
   image: css({
+    display: 'block',
     width: '100%'
   }),
   wrappedImage: css({

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -15,7 +15,6 @@ export { default as FigureByline } from './Byline'
 
 const styles = {
   figure: css({
-    lineHeight: 0,
     margin: 0,
     marginBottom: 15,
     padding: 0,

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -15,6 +15,7 @@ export { default as FigureByline } from './Byline'
 
 const styles = {
   figure: css({
+    lineHeight: 0,
     margin: 0,
     marginBottom: 15,
     padding: 0,


### PR DESCRIPTION
This was introduced by image placeholders (display: block), while unwrapped image's (display: inline) captions still have some default top spacing inherited from line-height. To reset spacing for both cases, we're also using `display: block` on normal images now and explicitly set the top margin on the caption.

Before:
<img width="687" alt="screen shot 2018-01-23 at 18 05 34" src="https://user-images.githubusercontent.com/23520051/35290223-d27677aa-0069-11e8-9651-fdef5e50bfbe.png">

After:
<img width="680" alt="screen shot 2018-01-23 at 18 05 53" src="https://user-images.githubusercontent.com/23520051/35290234-dacc686a-0069-11e8-9aa7-21226979ea0e.png">

