### PR TITLE
Lazy

### DIFF
--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -3,20 +3,12 @@ import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { imageSizeInfo } from 'mdast-react-render/lib/utils'
 import { getResizedSrcs } from './utils'
+import LazyImage from '../LazyLoad/Image'
 
 const styles = {
   image: css({
     display: 'block',
     width: '100%'
-  }),
-  wrappedImage: css({
-    position: 'absolute',
-    width: '100%'
-  }),
-  aspectRatio: css({
-    backgroundColor: 'rgba(0,0,0,0.1)',
-    display: 'block',
-    position: 'relative'
   }),
   maxWidth: css({
     display: 'block',
@@ -38,19 +30,11 @@ class Image extends Component {
     const aspectRatio = size ? size.width / size.height : undefined
 
     const image = isFinite(aspectRatio)
-      ? (
-        <span
-          {...attributes}
-          {...styles.aspectRatio}
-          style={{paddingBottom: `${100 / aspectRatio}%`}}>
-          <img
-            {...styles.wrappedImage}
-            src={src}
-            srcSet={srcSet}
-            alt={alt} />
-        </span>
-      )
-      : <img {...attributes} {...styles.image} src={src} srcSet={srcSet} alt={alt} />
+      ? <LazyImage attributes={attributes}
+          aspectRatio={aspectRatio}
+          src={src} srcSet={srcSet} alt={alt} />
+      : <img {...attributes} {...styles.image}
+          src={src} srcSet={srcSet} alt={alt} />
 
     if (maxWidth) {
       return (

--- a/src/components/Figure/utils.js
+++ b/src/components/Figure/utils.js
@@ -41,11 +41,12 @@ export const getResizedSrcs = (src, displayWidth, setMaxWidth = true) => {
 
   let srcSet
   if (defaultWidth < maxWidth) {
+    const isHighRes = defaultWidth * 2 <= maxWidth
     // add high res image
-    srcSet = [defaultWidth * 2 <= maxWidth
-      ? defaultWidth * 2
-      : maxWidth
-    ]
+    srcSet = [
+      isHighRes ? defaultWidth * 2 : maxWidth,
+      isHighRes && defaultWidth * 1.5
+    ].filter(Boolean)
       .map(size => [
         imageResizeUrl(src, `${size}x`),
         `${size}w`

--- a/src/components/Figure/utils.test.js
+++ b/src/components/Figure/utils.test.js
@@ -37,7 +37,7 @@ test('getResizedSrcs: size info', assert => {
     width: 4500,
     height: 2500
   })
-  assert.equal(props.srcSet, 'image.jpg?size=4500x2500&resize=4000x 4000w')
+  assert.equal(props.srcSet, 'image.jpg?size=4500x2500&resize=4000x 4000w,image.jpg?size=4500x2500&resize=3000x 3000w')
   assert.equal(props.maxWidth, 4500)
 
   assert.end()
@@ -50,7 +50,7 @@ test('getResizedSrcs: undefined maxWidth if setMaxWidth is false', assert => {
     width: 4500,
     height: 2500
   })
-  assert.equal(props.srcSet, 'image.jpg?size=4500x2500&resize=4000x 4000w')
+  assert.equal(props.srcSet, 'image.jpg?size=4500x2500&resize=4000x 4000w,image.jpg?size=4500x2500&resize=3000x 3000w')
   assert.equal(props.maxWidth, undefined)
 
   assert.end()

--- a/src/components/LazyLoad/Image.js
+++ b/src/components/LazyLoad/Image.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { css } from 'glamor'
+
+import LazyLoad from './'
+
+const styles = {
+  container: css({
+    display: 'block',
+    position: 'relative',
+    backgroundColor: 'rgba(0,0,0,0.1)'
+  }),
+  img: css({
+    display: 'block',
+    position: 'absolute',
+    width: '100%'
+  })
+}
+
+export default ({src, srcSet, sizes, alt, aspectRatio, attributes, visible, offset}) => (
+  <LazyLoad attributes={{...styles.container, ...attributes}} offset={offset} visible={visible} style={{
+    paddingBottom: `${100 / aspectRatio}%`,
+    backgroundColor: src.match(/\.png(\.webp)?(\?|$)/)
+      ? 'transparent'
+      : undefined
+  }}>
+    <img src={src} srcSet={srcSet} sizes={sizes} alt={alt} {...styles.img} />
+  </LazyLoad>
+)

--- a/src/components/LazyLoad/docs.md
+++ b/src/components/LazyLoad/docs.md
@@ -1,0 +1,58 @@
+### `<LazyLoad />`
+
+Awaits the viewport approaching to render its children. It works by rendering a span wrapper which should act as an placeholder—reserving the right amount of space. When `!process.browser` the children will be rendered in a `<noscript>` tag before beeing visible.
+
+#### Properties
+
+- `visible` bool, overwrite laziness—e.g. server rendered first items
+- `offset` number, default 0.5, distance in viewport height to start rendering
+- `style` object, applied to wrapper
+- `attributes` object, spread onto the wrapper
+- `children` node, the lazy loaded content
+
+### `<LazyImage />`
+
+A convenience wrapper for width filling images with an known aspect ratio. It takes care of the placeholder.
+
+#### Properties
+
+- `aspectRatio`, number, `width/height`
+- forwards `offset`, `visible`, `attributes` to `<LazyLoad />`
+- forwards `src`, `srcSet`, `alt`, `sizes` to an `<img />`
+
+#### Example
+
+```react
+<div>
+  <P style={{paddingBottom: '150vh'}}>
+    By default a LazyLoad wrapped component will only load once it's half the screen height away. The is an image below, in 1.5 screen heights:
+  </P>
+  <LazyLoad style={{
+    display: 'block',
+    position: 'relative',
+    paddingBottom: `${100 / (2000 / 1411)}%`,
+    backgroundColor: 'rgba(0,0,0,0.1)'
+  }}>
+    <img src='/static/landscape.jpg?size=2000x1411' style={{
+      display: 'block',
+      position: 'absolute',
+      width: '100%'
+    }} />
+  </LazyLoad>
+  <P style={{paddingTop: 50, paddingBottom: '100vh'}}>
+    The is another image below, in 1 screen heights:
+  </P>
+  <LazyImage src='/static/rothaus_landscape.jpg?size=2000x1331' aspectRatio={2000/1331} />
+  <P style={{paddingTop: 50, paddingBottom: '100vh'}}>
+    And another image with custom constraints, in 1 screen heights:
+  </P>
+  <div style={{height: 200}}>
+    <LazyLoad>
+      <img src='/static/rothaus_portrait.jpg?size=945x1331' style={{
+        maxWidth: 200,
+        maxHeight: 200
+      }} />
+    </LazyLoad>
+  </div>
+</div>
+```

--- a/src/components/LazyLoad/docs.md
+++ b/src/components/LazyLoad/docs.md
@@ -1,6 +1,6 @@
 ### `<LazyLoad />`
 
-Awaits the viewport approaching to render its children. It works by rendering a span wrapper which should act as an placeholder—reserving the right amount of space. When `!process.browser` the children will be rendered in a `<noscript>` tag before beeing visible.
+Awaits the viewport approaching to render its children. It works by rendering a span wrapper which should act as an placeholder—reserving the right amount of space. When `!process.browser` the children will be rendered in a `<noscript>` tag before being visible.
 
 #### Properties
 
@@ -25,7 +25,7 @@ A convenience wrapper for width filling images with an known aspect ratio. It ta
 ```react
 <div>
   <P style={{paddingBottom: '150vh'}}>
-    By default a LazyLoad wrapped component will only load once it's half the screen height away. The is an image below, in 1.5 screen heights:
+    By default a LazyLoad wrapped component will only load once it's half the screen height away. There is an image below, in 1.5 screen heights:
   </P>
   <LazyLoad style={{
     display: 'block',
@@ -40,7 +40,7 @@ A convenience wrapper for width filling images with an known aspect ratio. It ta
     }} />
   </LazyLoad>
   <P style={{paddingTop: 50, paddingBottom: '100vh'}}>
-    The is another image below, in 1 screen heights:
+    There is another image below, in 1 screen heights:
   </P>
   <LazyImage src='/static/rothaus_landscape.jpg?size=2000x1331' aspectRatio={2000/1331} />
   <P style={{paddingTop: 50, paddingBottom: '100vh'}}>

--- a/src/components/LazyLoad/index.js
+++ b/src/components/LazyLoad/index.js
@@ -1,0 +1,111 @@
+import React, { Component } from 'react'
+
+var supportsPassive = false
+try {
+  var opts = Object.defineProperty({}, 'passive', {
+    get: function() {
+      supportsPassive = true
+    }
+  })
+  window.addEventListener('testPassive', null, opts)
+  window.removeEventListener('testPassive', null, opts)
+} catch (e) {}
+
+const onFrame = fn => {
+  let next
+
+  return (...args) => {
+    if (!next) {
+      next = window.requestAnimationFrame(() => {
+        next = undefined
+        fn(...args)
+      })
+    }
+  }
+}
+
+const checkVisible = () => {
+  const height = window.innerHeight
+  const scrollY = window.pageYOffset
+  const scrollYEdge = scrollY + height
+
+  instances.all.forEach(instance => {
+    if (!instance.state.visible) {
+      if (instance.y - instance.props.offset * height < scrollYEdge) {
+        instance.setState({
+          visible: true
+        })
+      }
+    }
+  })
+}
+const onScroll = onFrame(checkVisible)
+
+const onResize = onFrame(() => {
+  const scrollY = window.pageYOffset
+  
+  instances.all.forEach(instance => {
+    if (instance.ref) {
+      const rect = instance.ref.getBoundingClientRect()
+      instance.y = rect.top + scrollY
+    } else {
+      instance.y = undefined
+    }
+  })
+  
+  checkVisible()
+})
+
+const instances = {
+  add(instance) {
+    if (!instances.all.length) {
+      const opts = supportsPassive ? { passive: true } : false
+      window.addEventListener('scroll', onScroll, opts)
+      window.addEventListener('resize', onResize)
+    }
+    instances.all.push(instance)
+    onResize()
+  },
+  rm(instance) {
+    instances.all.splice(instances.all.indexOf(instance), 1)
+    if (!instances.all.length) {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onResize)
+    }
+  },
+  all: []
+}
+
+class LazyLoad extends Component {
+  constructor(...args) {
+    super(...args)
+    this.state = {}
+    this.setRef = ref => {
+      this.ref = ref
+    }
+  }
+  componentDidMount() {
+    instances.add(this)
+  }
+  componentWillUnmount() {
+    instances.rm(this)
+  }
+  render () {
+    const { children, attributes, style } = this.props
+    const visible = this.props.visible || this.state.visible
+    return (
+      <span ref={this.setRef} {...attributes} style={style}>
+        {visible ? children : null}
+        {!visible && !process.browser && <noscript>
+          {children}
+        </noscript>}
+      </span>
+    )
+  }
+}
+
+LazyLoad.defaultProps = {
+  offset: 0.5
+}
+
+export default LazyLoad

--- a/src/components/LazyLoad/index.js
+++ b/src/components/LazyLoad/index.js
@@ -1,28 +1,5 @@
 import React, { Component } from 'react'
-
-var supportsPassive = false
-try {
-  var opts = Object.defineProperty({}, 'passive', {
-    get: function() {
-      supportsPassive = true
-    }
-  })
-  window.addEventListener('testPassive', null, opts)
-  window.removeEventListener('testPassive', null, opts)
-} catch (e) {}
-
-const onFrame = fn => {
-  let next
-
-  return (...args) => {
-    if (!next) {
-      next = window.requestAnimationFrame(() => {
-        next = undefined
-        fn(...args)
-      })
-    }
-  }
-}
+import { rafDebounce } from '../../lib/helpers'
 
 const checkVisible = () => {
   const height = window.innerHeight
@@ -39,9 +16,9 @@ const checkVisible = () => {
     }
   })
 }
-const onScroll = onFrame(checkVisible)
+const onScroll = rafDebounce(checkVisible)
 
-const onResize = onFrame(() => {
+const onResize = rafDebounce(() => {
   const scrollY = window.pageYOffset
   
   instances.all.forEach(instance => {
@@ -59,8 +36,7 @@ const onResize = onFrame(() => {
 const instances = {
   add(instance) {
     if (!instances.all.length) {
-      const opts = supportsPassive ? { passive: true } : false
-      window.addEventListener('scroll', onScroll, opts)
+      window.addEventListener('scroll', onScroll)
       window.addEventListener('resize', onResize)
     }
     instances.all.push(instance)

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -6,6 +6,7 @@ import Text from './Text'
 import colors from '../../theme/colors'
 
 import { FigureImage } from '../Figure'
+import LazyLoad from '../LazyLoad'
 
 const IMAGE_SIZE = {
   tiny: 180,
@@ -176,7 +177,10 @@ const Tile = ({ children, attributes, image, alt, onClick, color, bgColor, align
     >
       {imageProps && (
         <div {...styles.imageContainer}>
-          <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt} {...styles.image} />
+          <LazyLoad>
+            <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
+              {...styles.image} />
+          </LazyLoad>
         </div>
       )}
       <div {...styles.textContainer}>

--- a/src/index.js
+++ b/src/index.js
@@ -169,6 +169,16 @@ ReactDOM.render(
             },
             src: require('./components/VideoPlayer/docs.md')
           },
+          {
+            path: '/lazyload',
+            title: 'LazyLoad',
+            imports: {
+              ...require('./components/Typography').Interaction,
+              LazyLoad: require('./components/LazyLoad'),
+              LazyImage: require('./components/LazyLoad/Image')
+            },
+            src: require('./components/LazyLoad/docs.md')
+          }
         ]
       },
       {

--- a/src/lib.js
+++ b/src/lib.js
@@ -23,6 +23,8 @@ export {default as Autocomplete} from './components/Form/Autocomplete'
 export {default as TitleBlock} from './components/TitleBlock'
 export {default as Center, Breakout} from './components/Center'
 export { VideoPlayer} from './components/VideoPlayer'
+export { LazyLoad } from './components/LazyLoad'
+export { LazyImage } from './components/LazyLoad/Image'
 export {
   InfoBox,
   InfoBoxText,

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -7,3 +7,17 @@ export const intersperse = (list, separator) => {
     return items.concat([separator(item, i), item])
   }, [list[0]])
 }
+
+export const rafDebounce = fn => {
+  let next
+
+  return (...args) => {
+    if (!next) {
+      next = window.requestAnimationFrame(() => {
+        next = undefined
+        fn(...args)
+      })
+    }
+    return next
+  }
+}

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -160,7 +160,7 @@ Von Sonderkorrespondent [Lukas Bünger](<>)
 }
 \`\`\`
 
-![](https://assets.republik.ch/cf_gui/static/team/christof_moser.jpg)
+![](https://assets.republik.ch/cf_gui/static/team/christof_moser.jpg?size=1000x563)
 
 ###### Kluge Gedanken von alten Männern
 
@@ -183,7 +183,7 @@ Von [Christof Moser](/~6556e282-4ac4-4129-8f8f-d20f28170c39 "Christof Moser")
 
 <section><h6>ARTICLECOLLECTIONINTRO</h6>
 
-![](/static/rothaus_landscape.jpg)
+![](/static/rothaus_landscape.jpg?size=2000x1331)
 
 ###### Dossier
 


### PR DESCRIPTION
![jan-25-2018 02-58-53](https://user-images.githubusercontent.com/410211/35366842-bcd4126e-017b-11e8-89d8-ee6258536347.gif)

### `<LazyLoad />`

Awaits the viewport approaching to render its children. It works by rendering a span wrapper which should act as an placeholder—reserving the right amount of space. When `!process.browser` the children will be rendered in a `<noscript>` tag before beeing visible.

#### Properties

- `visible` bool, overwrite laziness—e.g. server rendered first items
- `offset` number, default 0.5, distance in viewport height to start rendering
- `style` object, applied to wrapper
- `attributes` object, spread onto the wrapper
- `children` node, the lazy loaded content

### `<LazyImage />`

A convenience wrapper for width filling images with an known aspect ratio. It takes care of the placeholder.

#### Properties

- `aspectRatio`, number, `width/height`
- forwards `offset`, `visible`, `attributes` to `<LazyLoad />`
- forwards `src`, `srcSet`, `alt`, `sizes` to an `<img />`

#### Example

```js
<div>
  <P style={{paddingBottom: '150vh'}}>
    By default a LazyLoad wrapped component will only load once it is half the screen height away. The is an image below, in 1.5 screen heights:
  </P>
  <LazyLoad style={{
    display: 'block',
    position: 'relative',
    paddingBottom: `${100 / (2000 / 1411)}%`,
    backgroundColor: 'rgba(0,0,0,0.1)'
  }}>
    <img src='/static/landscape.jpg?size=2000x1411' style={{
      display: 'block',
      position: 'absolute',
      width: '100%'
    }} />
  </LazyLoad>
  <P style={{paddingTop: 50, paddingBottom: '100vh'}}>
    The is another image below, in 1 screen heights:
  </P>
  <LazyImage src='/static/rothaus_landscape.jpg?size=2000x1331' aspectRatio={2000/1331} />
  <P style={{paddingTop: 50, paddingBottom: '100vh'}}>
    And another image with custom constraints, in 1 screen heights:
  </P>
  <div style={{height: 200}}>
    <LazyLoad>
      <img src='/static/rothaus_portrait.jpg?size=945x1331' style={{
        maxWidth: 200,
        maxHeight: 200
      }} />
    </LazyLoad>
  </div>
</div>
```

