### PR TITLE
fix(Center): decrease mobile content padding from 20 to 15px

### DIFF
--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -3,7 +3,7 @@ import { css } from 'glamor'
 import PropTypes from 'prop-types'
 
 
-export const PADDING = 20
+export const PADDING = 15
 
 export const MAX_WIDTH = 665
 // iPhone Plus, for max image sizes


### PR DESCRIPTION
- Aligns page content with footer and series top nav.
- Makes the mobile view slightly more compact.
- On article pages we might gain an extra word per line once in a while.

Before:
![screen shot 2018-01-31 at 12 17 46](https://user-images.githubusercontent.com/23520051/35621700-9d341bca-0685-11e8-950a-c03b612865b6.png)

After:
![screen shot 2018-01-31 at 12 16 22](https://user-images.githubusercontent.com/23520051/35621711-a805c800-0685-11e8-94b6-97559a935bb6.png)
