### PR TITLE
fix(EditorialNewsletter): Re-activate button for inserting images

### DIFF
--- a/src/templates/EditorialNewsletter/schema.js
+++ b/src/templates/EditorialNewsletter/schema.js
@@ -128,7 +128,11 @@ const createNewsletterSchema = ({
     editorModule: 'figure',
     editorOptions: {
       pixelNote: 'Auflösung: min. 1200x (proportionaler Schnitt)',
-      insertButtonText: 'Bild'
+      insertButtonText: 'Bild',
+      insertTypes: [
+        'PARAGRAPH'
+      ],
+      type: 'CENTERFIGURE'
     },
     rules: [
       {


### PR DESCRIPTION
Inserting images stopped working on the editorial newsletter template. With this change, things are working as intended again (tested end-to-end in mailchimp).