### PR TITLE
feat(Templates): getPath on schema

### DIFF
--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -15,6 +15,7 @@ const schema = createArticleSchema({
 - `titleBlockPrepend`, prepend React elements—e.g. a dossier tag—to the title block
 - `titleBlockAppend`, append React elements—e.g. share icons—to the title block
 - `titleBlockRule`, overwrite the whole title block, prepend and append are no longer applied
+- `getPath`, the function to transform meta data to a path, default `/YYYY/MM/DD/:slug`
 - `t`, optional translation function, used for e.g. DNT notes
 - `Link`, a Next.js like `<Link />` component
   This will be wrapped around links. You should attach an `onClick` handler within, if you wish to do client side routing and or prefetching. The component recieves following props:

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -51,7 +51,8 @@ import {
   getDisplayWidth,
   extractImage,
   globalInlines,
-  styles
+  styles,
+  getDatePath
 } from './utils'
 
 import createTeasers from './teasers'
@@ -458,6 +459,7 @@ const createSchema = ({
   repoPrefix = 'article-',
   series = true,
   Link = DefaultLink,
+  getPath = getDatePath,
   t = () => ''
 } = {}) => {
   const teasers = createTeasers({
@@ -466,6 +468,7 @@ const createSchema = ({
 
   return {
     repoPrefix,
+    getPath,
     rules: [
       {
         matchMdast: matchType('root'),

--- a/src/templates/Article/utils.js
+++ b/src/templates/Article/utils.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import { css } from 'glamor'
+import { timeFormat } from 'd3-time-format'
+
 import { Sub, Sup } from '../../components/Typography'
 
 import {
@@ -91,3 +93,9 @@ export const styles = {
     textDecoration: 'none'
   })
 }
+
+const slugDateFormat = timeFormat('%Y/%m/%d')
+
+export const getDatePath = ({ publishDate, slug }) => (
+  `/${slugDateFormat(publishDate)}/${(slug || '').split('/').pop()}`
+)

--- a/src/templates/Discussion/docs.md
+++ b/src/templates/Discussion/docs.md
@@ -10,4 +10,5 @@ const schema = createDiscussionSchema()
 
 Defaults:
 - `repoPrefix`, `discussion-`
+- `getPath`, `/YYYY/MM/DD/:slug/diskussion`
 - `customMetaFields`, repo refs for `format`, `dossier` and `discussion` settings with a `commentsMaxLength`, `commentsMinInterval` and `discussionAnonymity` field.

--- a/src/templates/Discussion/index.js
+++ b/src/templates/Discussion/index.js
@@ -1,11 +1,14 @@
 import createArticleSchema from '../Article'
+import { getDatePath } from '../Article/utils'
 
 const createSchema = ({
   customMetaFields = [],
+  getPath = args => `${getDatePath(args)}/diskussion`,
   ...args
 } = {}) => {
   return createArticleSchema({
     repoPrefix: 'discussion-',
+    getPath,
     customMetaFields: [
       {
         label: 'Beitrag-Maximallänge',

--- a/src/templates/Dossier/docs.md
+++ b/src/templates/Dossier/docs.md
@@ -14,6 +14,7 @@ const schema = createDossierSchema()
 
 Defaults:
 - `repoPrefix`, `dossier-`
+- `getPath`, `/dossier/:slug`
 - `customMetaFields`, always adds repo ref for `discussion`
 - `series`, false
 

--- a/src/templates/Dossier/index.js
+++ b/src/templates/Dossier/index.js
@@ -16,10 +16,12 @@ const createSchema = ({
   series = false,
   Link = DefaultLink,
   titleBlockPrepend = null,
+  getPath = ({ slug }) => `/dossier/${(slug || '').split('/').pop()}`,
   ...args
 } = {}) => {
   return createArticleSchema({
     repoPrefix: 'dossier-',
+    getPath,
     titleBlockPrepend: [
       titleBlockPrepend,
       <Link key='dossierLink' href={dossierHref} passHref>

--- a/src/templates/EditorialNewsletter/docs.md
+++ b/src/templates/EditorialNewsletter/docs.md
@@ -6,6 +6,8 @@ import schema from '@project-r/styleguide/lib/templates/EditorialNewsletter/emai
 
 The email schema uses table layout in container components.
 
+`getPath`: `/YYYY/MM/DD/:slug`
+
 ### With cover image
 
 ```react|noSource

--- a/src/templates/EditorialNewsletter/schema.js
+++ b/src/templates/EditorialNewsletter/schema.js
@@ -20,6 +20,8 @@ import {
   extractImage
 } from '../Article/utils'
 
+import { getDatePath } from '../Article/utils'
+
 const matchLast = (node, index, parent) => index === parent.children.length - 1
 
 const createNewsletterSchema = ({
@@ -198,6 +200,7 @@ const createNewsletterSchema = ({
   return {
     emailTemplate: 'newsletter-editorial',
     repoPrefix: 'newsletter-editorial-',
+    getPath: getDatePath,
     rules: [
       {
         matchMdast: matchType('root'),

--- a/src/templates/Format/docs.md
+++ b/src/templates/Format/docs.md
@@ -10,6 +10,7 @@ const schema = createFormatSchema()
 
 Defaults:
 - `repoPrefix`, `format-`
+- `getPath`, `/format/:slug`
 - `customMetaFields`, always adds repo refs for `discussion`, `dossier` and `format` settings with a `kind` (font) and `color` field.
 - `series`, false
 

--- a/src/templates/Format/index.js
+++ b/src/templates/Format/index.js
@@ -20,10 +20,12 @@ const createSchema = ({
   titleBlockPrepend = null,
   titleBlockAppend = null,
   titleBlockRule,
+  getPath = ({ slug }) => `/format/${(slug || '').split('/').pop()}`,
   ...args
 } = {}) => {
   return createArticleSchema({
     repoPrefix: 'format-',
+    getPath,
     customMetaFields: [
       {
         label: 'Ebene',

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -14,6 +14,8 @@ This will be wrapped around and links (headlines and credits) and the whole teas
 - `href` String, target url or path
 - `passHref` Boolean, indicates this will eventually end in an a tag and you may overwrite href
 
+`getPath`: `/:slug`
+
 # Example
 
 ```react|noSource

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -562,6 +562,7 @@ const createSchema = ({
   }
 
   const schema = {
+    getPath: ({ slug }) => `/${(slug || '').split('/').pop()}`,
     rules: [
       {
         matchMdast: matchType('root'),


### PR DESCRIPTION
This logic is currently in [publikator-backend/blob/master/lib/Document.js ](https://github.com/orbiting/publikator-backend/blob/master/lib/Document.js) but to display in publikator it makes more sense to colocate with the template, like repo prefix.