### PR TITLE
feat(FrontTile): add image-only use case, e.g. for cartoons

### DIFF
--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -65,7 +65,7 @@ const styles = {
       margin: '0 auto 60px auto'
     }
   }),
-  imageOnlyContainer: css({
+  onlyImageContainer: css({
     margin: '0 auto',
     fontSize: 0
   }),
@@ -78,6 +78,11 @@ const styles = {
     [tUp]: {
       ...sizeLarge
     }
+  }),
+  onlyImage: css({
+    minWidth: '100px',
+    maxHeight: '100% !important',
+    maxWidth: '100% !important'
   }),
   row: css({
     margin: 0,
@@ -167,7 +172,7 @@ const Tile = ({
   bgColor,
   align,
   aboveTheFold,
-  imageOnly
+  onlyImage
 }) => {
   const background = bgColor || ''
   const justifyContent =
@@ -182,13 +187,9 @@ const Tile = ({
     cursor: onClick ? 'pointer' : 'default',
     justifyContent
   }
-  if (imageOnly) {
-    containerStyle = {
-      ...containerStyle,
-      padding: 0
-    }
+  if (onlyImage) {
+    containerStyle.padding = 0
   }
-  const imageStyle = imageOnly ? {maxHeight: '100%', maxWidth: '100%'} : {}
 
   return (
     <div
@@ -199,14 +200,14 @@ const Tile = ({
       className='tile'
     >
       {imageProps && (
-        <div {...(imageOnly ? styles.imageOnlyContainer : styles.imageContainer)}>
+        <div {...(onlyImage ? styles.onlyImageContainer : styles.imageContainer)}>
           <LazyLoad visible={aboveTheFold}>
             <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
-              {...styles.image} style={imageStyle}/>
+              {...(onlyImage ? styles.onlyImage : styles.image)} />
           </LazyLoad>
         </div>
       )}
-      {!imageOnly && <div {...styles.textContainer}>
+      {!onlyImage && <div {...styles.textContainer}>
         <Text color={color} maxWidth={'600px'} margin={'0 auto'}>
           {children}
         </Text>
@@ -228,7 +229,7 @@ Tile.propTypes = {
     'bottom'
   ]),
   aboveTheFold: PropTypes.bool,
-  imageOnly: PropTypes.bool
+  onlyImage: PropTypes.bool
 }
 
 Tile.defaultProps = {

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -65,6 +65,10 @@ const styles = {
       margin: '0 auto 60px auto'
     }
   }),
+  imageOnlyContainer: css({
+    margin: '0 auto',
+    fontSize: 0
+  }),
   image: css({
     minWidth: '100px',
     ...sizeSmall,
@@ -153,7 +157,18 @@ TeaserFrontTileRow.defaultProps = {
   columns: 1
 }
 
-const Tile = ({ children, attributes, image, alt, onClick, color, bgColor, align, aboveTheFold }) => {
+const Tile = ({
+  children,
+  attributes,
+  image,
+  alt,
+  onClick,
+  color,
+  bgColor,
+  align,
+  aboveTheFold,
+  imageOnly
+}) => {
   const background = bgColor || ''
   const justifyContent =
     align === 'top' ? 'flex-start' : align === 'bottom' ? 'flex-end' : ''
@@ -162,32 +177,40 @@ const Tile = ({ children, attributes, image, alt, onClick, color, bgColor, align
     IMAGE_SIZE.large,
     false
   )
+  let containerStyle = {
+    background,
+    cursor: onClick ? 'pointer' : 'default',
+    justifyContent
+  }
+  if (imageOnly) {
+    containerStyle = {
+      ...containerStyle,
+      padding: 0
+    }
+  }
+  const imageStyle = imageOnly ? {maxHeight: '100%', maxWidth: '100%'} : {}
 
   return (
     <div
       {...attributes}
       {...styles.container}
       onClick={onClick}
-      style={{
-        background,
-        cursor: onClick ? 'pointer' : 'default',
-        justifyContent
-      }}
+      style={containerStyle}
       className='tile'
     >
       {imageProps && (
-        <div {...styles.imageContainer}>
+        <div {...(imageOnly ? styles.imageOnlyContainer : styles.imageContainer)}>
           <LazyLoad visible={aboveTheFold}>
             <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
-              {...styles.image} />
+              {...styles.image} style={imageStyle}/>
           </LazyLoad>
         </div>
       )}
-      <div {...styles.textContainer}>
+      {!imageOnly && <div {...styles.textContainer}>
         <Text color={color} maxWidth={'600px'} margin={'0 auto'}>
           {children}
         </Text>
-      </div>
+      </div>}
     </div>
   )
 }
@@ -203,7 +226,9 @@ Tile.propTypes = {
     'top',
     'middle',
     'bottom'
-  ])
+  ]),
+  aboveTheFold: PropTypes.bool,
+  imageOnly: PropTypes.bool
 }
 
 Tile.defaultProps = {

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -5,6 +5,7 @@ Supported props:
 - `color`: The text color.
 - `bgColor`: The background color to use in stacked mode.
 - `align`: `middle` (default), `top` or `bottom`.
+- `imageOnly`: Whether to render only the image (full width or height).
 
 A `<TeaserFrontTileHeadline />` should be used.
 
@@ -143,6 +144,46 @@ Supported props:
     <TeaserFrontCredit>
       An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
+  </TeaserFrontTile>
+</TeaserFrontTileRow>
+```
+
+### Image only
+
+```react
+<TeaserFrontTileRow columns={2}>
+  <TeaserFrontTile imageOnly image='/static/dada.jpg' bgColor='#fff'>
+    <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
+  </TeaserFrontTile>
+  <TeaserFrontTile image='/static/rothaus_landscape.jpg'
+    color='#fff' bgColor='#000'>
+    <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
+    <TeaserFrontCredit>
+      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+    </TeaserFrontCredit>
+  </TeaserFrontTile>
+</TeaserFrontTileRow>
+```
+
+```react
+<TeaserFrontTileRow columns={2}>
+  <TeaserFrontTile imageOnly image='/static/video.jpg' bgColor='#000'>
+    <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
+  </TeaserFrontTile>
+  <TeaserFrontTile image='/static/rothaus_portrait.jpg'
+    color='#000' bgColor='#fff'>
+    <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
+    <TeaserFrontCredit>
+      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+    </TeaserFrontCredit>
+  </TeaserFrontTile>
+</TeaserFrontTileRow>
+```
+
+```react
+<TeaserFrontTileRow>
+  <TeaserFrontTile imageOnly image='/static/video.jpg'>
+    <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -5,7 +5,7 @@ Supported props:
 - `color`: The text color.
 - `bgColor`: The background color to use in stacked mode.
 - `align`: `middle` (default), `top` or `bottom`.
-- `imageOnly`: Whether to render only the image (full width or height).
+- `onlyImage`: Whether to render only the image (full width or height).
 
 A `<TeaserFrontTileHeadline />` should be used.
 
@@ -152,7 +152,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow columns={2}>
-  <TeaserFrontTile imageOnly image='/static/dada.jpg' bgColor='#fff'>
+  <TeaserFrontTile onlyImage image='/static/dada.jpg' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
@@ -167,7 +167,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow columns={2}>
-  <TeaserFrontTile imageOnly image='/static/video.jpg' bgColor='#000'>
+  <TeaserFrontTile onlyImage image='/static/video.jpg' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
@@ -182,7 +182,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile imageOnly image='/static/video.jpg'>
+  <TeaserFrontTile onlyImage image='/static/video.jpg'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
 </TeaserFrontTileRow>

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -264,5 +264,74 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 <hr /></section>
 
+<section><h6>TEASERGROUP</h6>
+
+\`\`\`
+{
+  "columns": 2
+}
+\`\`\`
+
+<section><h6>TEASER</h6>
+
+\`\`\`
+{
+  "bgColor": "#fff",
+  "center": false,
+  "color": "#000",
+  "kind": "editorial",
+  "portrait": true,
+  "reverse": false,
+  "teaserType": "frontTile",
+  "textPosition": "topleft",
+  "titleSize": "standard",
+  "url": "https://www.republik.ch/updates/portraets"
+}
+\`\`\`
+
+![](https://assets.republik.ch/images/pierre_rom.jpeg?size=853x853)
+
+###### Echte Republikaner
+
+# Pierre
+
+#### Republik-Verleger, 93 Jahre
+
+Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
+
+<hr /></section>
+
+<section><h6>TEASER</h6>
+
+\`\`\`
+{
+  "bgColor": "#000",
+  "center": false,
+  "color": "#000",
+  "kind": "editorial",
+  "portrait": true,
+  "reverse": false,
+  "teaserType": "frontTile",
+  "textPosition": "topleft",
+  "titleSize": "standard",
+  "url": "https://www.republik.ch/updates/portraets",
+  "imageOnly": true
+}
+\`\`\`
+
+![](/static/video.jpg?size=4332x2437)
+
+###### Echte Republikaner
+
+# Mavie
+
+#### Republik-Verlegerin, 8 Monate
+
+Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
+
+<hr /></section>
+
+<hr /></section>
+
 `}</Markdown>
 ```

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -349,6 +349,7 @@ const createSchema = ({
         'bgColor',
         'center',
         'showImage',
+        'onlyImage',
         'image',
         'kind'
       ]


### PR DESCRIPTION
Allows to display a full-width or full-height image in a front tile.

Previews:
https://r-styleguide-pr-99.herokuapp.com/teaserfronttile#image-only
https://r-styleguide-pr-99.herokuapp.com/templates/front

In Publikator, all we'd need is an "imageOnly" checkbox for tiles.

Depends on https://github.com/orbiting/publikator-frontend/pull/131