### PR TITLE
fix: use the centerFigure definiton in document rules

### DIFF
--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -837,8 +837,7 @@ const createSchema = ({
               }
             ]
           },
-          cover,
-          figure,
+          centerFigure,
           {
             matchMdast: () => false,
             editorModule: 'specialchars'


### PR DESCRIPTION
Fixes the UI for Edge-To-Edge images in orbiting/publikator-frontend