### PR TITLE
feat(VideoPlayer): add fullscreen mode

### DIFF
--- a/src/components/VideoPlayer/Fullscreen.js
+++ b/src/components/VideoPlayer/Fullscreen.js
@@ -44,7 +44,7 @@ const apiSurfaces = [
   ]
 ]
 
-const fullscreenFunction = () => {
+const getFullscreenApi = () => {
   for (let i = 0; i < apiSurfaces.length; i++) {
     let apiSurface = apiSurfaces[i]
     if (!!document[apiSurface[1]]) {
@@ -59,29 +59,29 @@ const fullscreenFunction = () => {
 }
 
 const Fullscreen = () => {
-  const fn = fullscreenFunction()
-  if (!fn) {
+  const api = getFullscreenApi()
+  if (!api) {
     return null
   }
 
   return {
     request: elem => {
       elem = elem || document.documentElement
-      elem[fn.requestFullscreen]()
+      elem[api.requestFullscreen]()
     },
     addChangeListener: callback => {
-      document.addEventListener(fn.fullscreenchange, callback, false)
+      document.addEventListener(api.fullscreenchange, callback, false)
     },
     addErrorListener: callback => {
-      document.addEventListener(fn.fullscreenerror, callback, false)
+      document.addEventListener(api.fullscreenerror, callback, false)
     },
     removeChangeListener: callback => {
-      document.removeEventListener(fn.fullscreenchange, callback, false)
+      document.removeEventListener(api.fullscreenchange, callback, false)
     },
     removeErrorListener: callback => {
-      document.removeEventListener(fn.fullscreenerror, callback, false)
+      document.removeEventListener(api.fullscreenerror, callback, false)
     },
-    isFullscreen: () => !!document[fn.fullscreenElement]
+    isFullscreen: () => !!document[api.fullscreenElement]
   }
 }
 

--- a/src/components/VideoPlayer/Fullscreen.js
+++ b/src/components/VideoPlayer/Fullscreen.js
@@ -1,4 +1,5 @@
 const apiSurfaces = [
+  // Canonical non-prefixed API
   [
     'requestFullscreen',
     'exitFullscreen',
@@ -7,6 +8,7 @@ const apiSurfaces = [
     'fullscreenchange',
     'fullscreenerror'
   ],
+  // contemporary webkit
   [
     'webkitRequestFullscreen',
     'webkitExitFullscreen',
@@ -18,7 +20,7 @@ const apiSurfaces = [
   // legacy webkit (Safari 5.1)
   [
     'webkitRequestFullScreen',
-    'webkitCancelFullScreen',
+    'webkitCancelFullScreen',  // That's why we check apiSurface[1] for feature detection below.
     'webkitCurrentFullScreenElement',
     'webkitCancelFullScreen',
     'webkitfullscreenchange',

--- a/src/components/VideoPlayer/Fullscreen.js
+++ b/src/components/VideoPlayer/Fullscreen.js
@@ -1,0 +1,88 @@
+const functionSets = [
+  [
+    'requestFullscreen',
+    'exitFullscreen',
+    'fullscreenElement',
+    'fullscreenEnabled',
+    'fullscreenchange',
+    'fullscreenerror'
+  ],
+  [
+    'webkitRequestFullscreen',
+    'webkitExitFullscreen',
+    'webkitFullscreenElement',
+    'webkitFullscreenEnabled',
+    'webkitfullscreenchange',
+    'webkitfullscreenerror'
+  ],
+  // legacy webkit (Safari 5.1)
+  [
+    'webkitRequestFullScreen',
+    'webkitCancelFullScreen',
+    'webkitCurrentFullScreenElement',
+    'webkitCancelFullScreen',
+    'webkitfullscreenchange',
+    'webkitfullscreenerror'
+  ],
+  [
+    'mozRequestFullScreen',
+    'mozCancelFullScreen',
+    'mozFullScreenElement',
+    'mozFullScreenEnabled',
+    'mozfullscreenchange',
+    'mozfullscreenerror'
+  ],
+  // IE11
+  // https://msdn.microsoft.com/en-us/library/dn265028(v=vs.85).aspx
+  [
+    'msRequestFullscreen',
+    'msExitFullscreen',
+    'msFullscreenElement',
+    'msFullscreenEnabled',
+    'MSFullscreenChange',
+    'MSFullscreenError'
+  ]
+]
+
+const fullscreenFunction = () => {
+  for (let i = 0; i < functionSets.length; i++) {
+    let functionSet = functionSets[i]
+    if (!!document[functionSet[1]]) {
+      let functionMap = {}
+      for (let j = 0; j < functionSet.length; j++) {
+        functionMap[functionSets[0][j]] = functionSet[j]
+      }
+      return functionMap
+    }
+  }
+  return null
+}
+
+const Fullscreen = () => {
+  const fn = fullscreenFunction()
+  if (!fn) {
+    return null
+  }
+
+  return {
+    request: elem => {
+      elem = elem || document.documentElement
+      elem[fn.requestFullscreen]()
+    },
+    addChangeListener: callback => {
+      document.addEventListener(fn.fullscreenchange, callback, false)
+    },
+    addErrorListener: callback => {
+      document.addEventListener(fn.fullscreenerror, callback, false)
+    },
+    removeChangeListener: callback => {
+      document.removeEventListener(fn.fullscreenchange, callback, false)
+    },
+    removeErrorListener: callback => {
+      document.removeEventListener(fn.fullscreenerror, callback, false)
+    },
+    isFullscreen: () => !!document[fn.fullscreenElement]
+  }
+}
+
+export default Fullscreen

--- a/src/components/VideoPlayer/Fullscreen.js
+++ b/src/components/VideoPlayer/Fullscreen.js
@@ -1,4 +1,4 @@
-const functionSets = [
+const apiSurfaces = [
   [
     'requestFullscreen',
     'exitFullscreen',
@@ -45,14 +45,14 @@ const functionSets = [
 ]
 
 const fullscreenFunction = () => {
-  for (let i = 0; i < functionSets.length; i++) {
-    let functionSet = functionSets[i]
-    if (!!document[functionSet[1]]) {
-      let functionMap = {}
-      for (let j = 0; j < functionSet.length; j++) {
-        functionMap[functionSets[0][j]] = functionSet[j]
+  for (let i = 0; i < apiSurfaces.length; i++) {
+    let apiSurface = apiSurfaces[i]
+    if (!!document[apiSurface[1]]) {
+      let api = {}
+      for (let j = 0; j < apiSurface.length; j++) {
+        api[apiSurfaces[0][j]] = apiSurface[j]
       }
-      return functionMap
+      return api
     }
   }
   return null

--- a/src/components/VideoPlayer/Icons/Fullscreen.js
+++ b/src/components/VideoPlayer/Icons/Fullscreen.js
@@ -1,0 +1,31 @@
+import React, { Fragment } from 'react'
+import Fullscreen from 'react-icons/lib/md/fullscreen'
+import FullscreenExit from 'react-icons/lib/md/fullscreen-exit'
+
+const Icon = ({ size, fill, off }) => (
+  <Fragment>
+    {off ? (
+      <Fullscreen
+        size={size}
+        height={size}
+        fill={fill}
+        style={{ verticalAlign: 'inherit' }}
+      />
+    ) : (
+      <FullscreenExit
+        size={size}
+        height={size}
+        fill={fill}
+        style={{ verticalAlign: 'inherit' }}
+      />
+    )}
+  </Fragment>
+)
+
+Icon.defaultProps = {
+  size: 24,
+  fill: '#fff',
+  off: true
+}
+
+export default Icon

--- a/src/components/VideoPlayer/Icons/Fullscreen.js
+++ b/src/components/VideoPlayer/Icons/Fullscreen.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import Fullscreen from 'react-icons/lib/md/fullscreen'
 import FullscreenExit from 'react-icons/lib/md/fullscreen-exit'
 

--- a/src/components/VideoPlayer/Icons/Fullscreen.js
+++ b/src/components/VideoPlayer/Icons/Fullscreen.js
@@ -2,25 +2,27 @@ import React, { Fragment } from 'react'
 import Fullscreen from 'react-icons/lib/md/fullscreen'
 import FullscreenExit from 'react-icons/lib/md/fullscreen-exit'
 
-const Icon = ({ size, fill, off }) => (
-  <Fragment>
-    {off ? (
+const Icon = ({ size, fill, off }) => {
+  if (off) {
+    return (
       <Fullscreen
         size={size}
         height={size}
         fill={fill}
         style={{ verticalAlign: 'inherit' }}
       />
-    ) : (
+    )
+  } else {
+    return (
       <FullscreenExit
         size={size}
         height={size}
         fill={fill}
         style={{ verticalAlign: 'inherit' }}
       />
-    )}
-  </Fragment>
-)
+    )
+  }
+}
 
 Icon.defaultProps = {
   size: 24,

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -8,6 +8,9 @@ import Play from './Icons/Play'
 import Volume from './Icons/Volume'
 import Subtitles from './Icons/Subtitles'
 
+import Fullscreen from 'react-icons/lib/md/fullscreen'
+import FullscreenExit from 'react-icons/lib/md/fullscreen-exit'
+
 const ZINDEX_VIDEOPLAYER_ICONS = 6
 const ZINDEX_VIDEOPLAYER_SCRUB = 3
 const PROGRESS_HEIGHT = 4
@@ -92,7 +95,8 @@ class VideoPlayer extends Component {
       progress: 0,
       muted: globalState.muted,
       subtitles: props.subtitles || globalState.subtitles,
-      loading: false
+      loading: false,
+      fullscreen: false
     }
 
     this.updateProgress = () => {
@@ -267,7 +271,9 @@ class VideoPlayer extends Component {
   }
   render() {
     const { src, showPlay, size, forceMuted, autoPlay, loop, attributes = {} } = this.props
-    const { playing, progress, muted, subtitles, loading } = this.state
+    const { playing, progress, muted, subtitles, loading, fullscreen } = this.state
+
+    console.log(document)
 
     return (
       <div {...merge(styles.wrapper, breakoutStyles[size])}>
@@ -345,6 +351,20 @@ class VideoPlayer extends Component {
             >
               <Volume off={muted} />
             </span>}
+            <span
+              role="button"
+              title={`Untertitel ${subtitles ? 'an' : 'aus'}`}
+              onClick={e => {
+                e.preventDefault()
+                e.stopPropagation()
+                this.setState(() => ({
+                  fullscreen: !fullscreen
+                }))
+              }}
+            >
+              {!fullscreen && <Fullscreen size={24} height={24} fill='#fff' style={{verticalAlign: 'inherit'}} />}
+              {fullscreen && <FullscreenExit size={24} height={24} fill="#fff" style={{verticalAlign: 'inherit'}} />}
+            </span>
           </div>
         </div>
         <div {...styles.progress} style={{ width: `${progress * 100}%` }} />


### PR DESCRIPTION
Try out: https://r-styleguide-pr-105.herokuapp.com/videoplayer

- New fullscreen icon appears if browser supports fullscreen API
- In fullscreen mode, native controls are enabled

Chrome inline:
<img width="884" alt="screen shot 2018-02-13 at 18 49 27" src="https://user-images.githubusercontent.com/23520051/36165066-a3519cbc-10ee-11e8-9db9-a50e6299f14d.png">

Chrome fullscreen:
![screen shot 2018-02-13 at 18 40 14](https://user-images.githubusercontent.com/23520051/36165093-bd3a60be-10ee-11e8-81b0-7a3e37595252.png)

Firefox fullscreen:
![screen shot 2018-02-13 at 18 47 13](https://user-images.githubusercontent.com/23520051/36165116-ca1b86be-10ee-11e8-91ff-ab65ee8b7d69.png)

Safari fullscreen:
![screen shot 2018-02-13 at 18 51 21](https://user-images.githubusercontent.com/23520051/36165170-ece3da52-10ee-11e8-87d0-8f24eb623de4.png)

MS Edge fullscreen:
<img width="1163" alt="screen shot 2018-02-13 at 18 31 09" src="https://user-images.githubusercontent.com/23520051/36165191-fb7ed4e0-10ee-11e8-9aa0-df492fb847d7.png">

IE11 fullscreen:
<img width="1514" alt="screen shot 2018-02-13 at 16 11 43" src="https://user-images.githubusercontent.com/23520051/36165206-09cbed80-10ef-11e8-89a6-6a87ac7e4875.png">

iOS shows no fullscreen icon since API is not supported and it's playing fullscreen anyway.
<img width="545" alt="screen shot 2018-02-13 at 18 38 44" src="https://user-images.githubusercontent.com/23520051/36165216-145ea0da-10ef-11e8-8993-9d2cbafe6d36.png">





