### PR TITLE
feat: positioned byline for front teaser images

### DIFF
--- a/src/components/Dossier/Teaser.md
+++ b/src/components/Dossier/Teaser.md
@@ -15,7 +15,7 @@ Props:
     </TeaserFrontDossierLead>
   </TeaserFrontDossierIntro>
   <TeaserFrontTileRow columns={3}>
-    <TeaserFrontTile image='/static/rothaus_landscape.jpg'>
+    <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
       <DossierTileLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
@@ -31,7 +31,7 @@ Props:
         <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
       </TeaserFrontCredit>
     </TeaserFrontTile>
-    <TeaserFrontTile image='/static/rothaus_portrait.jpg'>
+    <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The fox</DossierTileHeadline.Editorial>
       <DossierTileLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
@@ -47,7 +47,7 @@ Props:
 
 ```react
 <TeaserFrontDossier>
-  <TeaserFrontDossierIntro image='/static/desert.jpg?size=4323x2962'>
+  <TeaserFrontDossierIntro image='/static/desert.jpg?size=4323x2962' byline='Foto: Thomas Vuillemin'>
     <DossierTag>Dossier</DossierTag>
     <TeaserFrontDossierHeadline>Dossiertitel</TeaserFrontDossierHeadline>
     <TeaserFrontDossierLead>
@@ -55,7 +55,7 @@ Props:
     </TeaserFrontDossierLead>
   </TeaserFrontDossierIntro>
   <TeaserFrontTileRow columns={3}>
-    <TeaserFrontTile image='/static/rothaus_landscape.jpg'>
+    <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
       <DossierTileLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
@@ -71,7 +71,7 @@ Props:
         <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
       </TeaserFrontCredit>
     </TeaserFrontTile>
-    <TeaserFrontTile image='/static/rothaus_portrait.jpg'>
+    <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The fox</DossierTileHeadline.Editorial>
       <DossierTileLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
@@ -88,7 +88,7 @@ Props:
 
 ```react
 <TeaserFrontDossier>
-  <TeaserFrontDossierIntro image='/static/rothaus_portrait.jpg'>
+  <TeaserFrontDossierIntro image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
     <DossierTag>Dossier</DossierTag>
     <TeaserFrontDossierHeadline>Dossiertitel</TeaserFrontDossierHeadline>
     <TeaserFrontDossierLead>
@@ -96,7 +96,7 @@ Props:
     </TeaserFrontDossierLead>
   </TeaserFrontDossierIntro>
   <TeaserFrontTileRow columns={3}>
-    <TeaserFrontTile image='/static/rothaus_landscape.jpg'>
+    <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
       <DossierTileLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
@@ -112,7 +112,7 @@ Props:
         <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
       </TeaserFrontCredit>
     </TeaserFrontTile>
-    <TeaserFrontTile image='/static/rothaus_portrait.jpg'>
+    <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The fox</DossierTileHeadline.Editorial>
       <DossierTileLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.

--- a/src/components/Dossier/TeaserIntro.js
+++ b/src/components/Dossier/TeaserIntro.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css, merge } from 'glamor'
 import { mUp, tUp } from '../TeaserFront/mediaQueries'
-import { FigureImage } from '../Figure'
+import { FigureImage, FigureByline } from '../Figure'
 
 const styles = {
   container: css({
@@ -38,6 +38,7 @@ const styles = {
     }
   }),
   imageContainer: css({
+    position: 'relative',
     [mUp]: {
       flexShrink: 0,
       fontSize: 0, // Removes the small flexbox space.
@@ -51,7 +52,7 @@ const styles = {
   })
 }
 
-const TeaserIntro = ({ children, attributes, image, alt, onClick, t }) => {
+const TeaserIntro = ({ children, attributes, image, alt, onClick, byline, t }) => {
   return (
     <div
       {...attributes}
@@ -67,6 +68,7 @@ const TeaserIntro = ({ children, attributes, image, alt, onClick, t }) => {
             {...FigureImage.utils.getResizedSrcs(image, 750)}
             alt={alt}
           />
+          {byline && <FigureByline position='rightCompact'>{byline}</FigureByline>}
         </div>
       )}
       <div {...merge(styles.content, image ? styles.contentWithImage : {})}>
@@ -79,6 +81,7 @@ TeaserIntro.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string,
+  byline: PropTypes.string,
   alt: PropTypes.string,
   onClick: PropTypes.func
 }

--- a/src/components/Figure/Byline.js
+++ b/src/components/Figure/Byline.js
@@ -1,21 +1,90 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { sansSerifRegular10, sansSerifRegular12 } from '../Typography/styles'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
+import { mUp as mUpFront } from '../TeaserFront/mediaQueries'
 
 const styles = {
   byline: css({
     ...sansSerifRegular10,
+    textRendering: 'optimizeLegibility',
+    WebkitFontSmoothing: 'antialiased',
     [mUp]: {
       ...sansSerifRegular12
     }
   })
 }
 
-export const Byline = ({ children, attributes }) => {
+const positionBaseStyle = {
+  ...sansSerifRegular12,
+  transform: 'rotate(-90deg)',
+  transformOrigin: '0 100%',
+  textAlign: 'left',
+  position: 'absolute',
+  bottom: 0,
+  whiteSpace: 'nowrap'
+}
+
+const positionStyle = {
+  below: css({
+    display: 'block',
+    marginTop: '5px',
+    paddingLeft: '15px',
+    [mUpFront]: {
+      ...sansSerifRegular12,
+      paddingLeft: 0
+    }
+  }),
+  // right of relative container on desktop, below on mobile.
+  right: css({
+    paddingLeft: '15px',
+    [mUpFront]: {
+      ...positionBaseStyle,
+      left: '100%',
+      marginLeft: '18px'
+    }
+  }),
+  // right of relative container on desktop and mobile, always small font size.
+  rightCompact: css({
+    ...positionBaseStyle,
+    ...sansSerifRegular10,
+    left: '100%',
+    marginLeft: '15px',
+    [mUpFront]: {
+      ...sansSerifRegular10
+    }
+  }),
+  // left of relative container on desktop, below on mobile.
+  left: css({
+    paddingLeft: '15px',
+    [mUpFront]: {
+      ...positionBaseStyle,
+      left: 0,
+      marginLeft: '-5px'
+    }
+  }),
+  // left inside relative container on desktop, below on mobile.
+  leftInside: css({
+    display: 'block',
+    marginTop: '5px',
+    paddingLeft: '15px',
+    [mUpFront]: {
+      ...positionBaseStyle,
+      left: 0,
+      marginTop: 0,
+      marginLeft: '18px'
+    }
+  })
+}
+
+export const Byline = ({ children, attributes, style, position }) => {
   return (
-    <span {...attributes} {...styles.byline}>
+    <span
+      {...attributes}
+      style={style}
+      {...merge(styles.byline, positionStyle[position])}
+    >
       {children}
     </span>
   )
@@ -23,7 +92,14 @@ export const Byline = ({ children, attributes }) => {
 
 Byline.propTypes = {
   children: PropTypes.node.isRequired,
-  attributes: PropTypes.object
+  attributes: PropTypes.object,
+  position: PropTypes.oneOf([
+    'below', 'right', 'rightImportant', 'left', 'leftInside'
+  ])
+}
+
+Byline.defaultProps = {
+  style: {}
 }
 
 export default Byline

--- a/src/components/Figure/Byline.js
+++ b/src/components/Figure/Byline.js
@@ -94,7 +94,11 @@ Byline.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   position: PropTypes.oneOf([
-    'below', 'right', 'rightImportant', 'left', 'leftInside'
+    'below',
+    'right',
+    'rightCompact',
+    'left',
+    'leftInside'
   ])
 }
 

--- a/src/components/Figure/Byline.js
+++ b/src/components/Figure/Byline.js
@@ -50,7 +50,7 @@ const positionStyle = {
     ...positionBaseStyle,
     ...sansSerifRegular10,
     left: '100%',
-    marginLeft: '15px',
+    marginLeft: '14px',
     [mUpFront]: {
       ...sansSerifRegular10
     }
@@ -83,7 +83,7 @@ export const Byline = ({ children, attributes, style, position }) => {
     <span
       {...attributes}
       style={style}
-      {...merge(styles.byline, positionStyle[position])}
+      {...merge(styles.byline, position && positionStyle[position])}
     >
       {children}
     </span>

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -12,6 +12,7 @@ const styles = {
   }),
   maxWidth: css({
     display: 'block',
+    position: 'relative'
   })
 }
 

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp, tUp } from './mediaQueries'
-import { FigureImage } from '../Figure'
+import { FigureImage, FigureByline } from '../Figure'
 import Text from './Text'
 
 const styles = {
@@ -29,6 +29,7 @@ const ImageBlock = ({
   children,
   attributes,
   image,
+  byline,
   alt,
   onClick,
   color,
@@ -43,7 +44,10 @@ const ImageBlock = ({
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
-      <FigureImage aboveTheFold={aboveTheFold} {...FigureImage.utils.getResizedSrcs(image, 1500, false)} alt={alt} />
+      <div style={{position: 'relative', fontSize: 0}}>
+        <FigureImage aboveTheFold={aboveTheFold} {...FigureImage.utils.getResizedSrcs(image, 1500, false)} alt={alt} />
+        {byline && <FigureByline position='leftInside' style={{color}}>{byline}</FigureByline>}
+      </div>
       <div {...styles.textContainer}>
         <Text position={textPosition} color={color} center={center}>
           {children}
@@ -57,6 +61,7 @@ ImageBlock.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string.isRequired,
+  byline: PropTypes.string,
   alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -14,7 +14,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 
 ```react
 <TeaserFrontImage
-  image='/static/desert.jpg?size=4323x2962'
+  image='/static/desert.jpg?size=4323x2962' byline='Foto: Bildagentur'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontImageHeadline.Editorial small>The sand is near</TeaserFrontImageHeadline.Editorial>
@@ -28,7 +28,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   textPosition='topright'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -43,7 +43,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   textPosition='bottomleft'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -58,7 +58,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   textPosition='bottomright'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -73,7 +73,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   center
   textPosition='topright' 
   color='#fff' bgColor='#000'>
@@ -89,7 +89,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   textPosition='topright'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -104,7 +104,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   center
   textPosition='top'
   color='#fff' bgColor='#000'>
@@ -120,7 +120,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   center
   textPosition='middle'
   color='#fff' bgColor='#000'>
@@ -136,7 +136,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   center
   textPosition='bottom'
   color='#fff' bgColor='#000'>
@@ -152,7 +152,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   center
   textPosition='middle'
   color='#fff' bgColor='#000'>
@@ -168,7 +168,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
   center
   textPosition='middle'
   color='#fff' bgColor='#000'>

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -14,7 +14,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 
 ```react
 <TeaserFrontImage
-  image='/static/desert.jpg?size=4323x2962' byline='Foto: Bildagentur'
+  image='/static/desert.jpg?size=4323x2962' byline='Foto: Thomas Vuillemin'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontImageHeadline.Editorial small>The sand is near</TeaserFrontImageHeadline.Editorial>
@@ -28,7 +28,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   textPosition='topright'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -43,7 +43,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   textPosition='bottomleft'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -58,7 +58,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   textPosition='bottomright'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -73,7 +73,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   center
   textPosition='topright' 
   color='#fff' bgColor='#000'>
@@ -89,7 +89,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   textPosition='topright'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
@@ -104,7 +104,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   center
   textPosition='top'
   color='#fff' bgColor='#000'>
@@ -120,7 +120,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   center
   textPosition='middle'
   color='#fff' bgColor='#000'>
@@ -136,7 +136,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   center
   textPosition='bottom'
   color='#fff' bgColor='#000'>
@@ -152,7 +152,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   center
   textPosition='middle'
   color='#fff' bgColor='#000'>
@@ -168,7 +168,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 ```
 
 ```react
-<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Bildagentur'
+<TeaserFrontImage image='/static/desert.jpg' byline='Foto: Thomas Vuillemin'
   center
   textPosition='middle'
   color='#fff' bgColor='#000'>

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp, dUp } from './mediaQueries'
-import { FigureImage } from '../Figure'
+import { FigureImage, FigureByline } from '../Figure'
 import Text from './Text'
 
 const styles = {
@@ -44,6 +44,7 @@ const styles = {
     }
   }),
   imageContainer: css({
+    position: 'relative',
     [mUp]: {
       flexShrink: 0,
       fontSize: 0, // Removes the small flexbox space.
@@ -67,6 +68,7 @@ const Split = ({
   children,
   attributes,
   image,
+  byline,
   alt,
   onClick,
   color,
@@ -78,6 +80,7 @@ const Split = ({
 }) => {
   const background = bgColor || ''
   const flexDirection = reverse ? 'row-reverse' : ''
+  const bylinePosition = portrait ? reverse ? 'left' : 'right' : 'below'
   return (
     <div
       {...attributes}
@@ -96,6 +99,7 @@ const Split = ({
         )}
       >
         <FigureImage aboveTheFold={aboveTheFold} {...FigureImage.utils.getResizedSrcs(image, 750)} alt={alt} />
+        {byline && <FigureByline position={bylinePosition} style={{color}}>{byline}</FigureByline>}
       </div>
       <div
         {...css(
@@ -117,6 +121,7 @@ Split.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string.isRequired,
+  byline: PropTypes.string,
   alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -13,7 +13,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 <TeaserFrontSplit
   image='/static/rothaus_portrait.jpg?size=945x1331'
   portrait
-  byline='Foto: Bildagentur'
+  byline='Foto: Laurent Burst'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>
@@ -30,7 +30,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 <TeaserFrontSplit
   image='/static/rothaus_portrait.jpg'
   portrait reverse
-  byline='Foto: Bildagentur'
+  byline='Foto: Laurent Burst'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>
@@ -46,7 +46,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 ```react
 <TeaserFrontSplit
   image='/static/rothaus_landscape.jpg'
-  byline='Foto: Bildagentur'
+  byline='Foto: Laurent Burst'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>
@@ -63,7 +63,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 <TeaserFrontSplit
   image='/static/rothaus_landscape.jpg'
   reverse
-  byline='Foto: Bildagentur'
+  byline='Foto: Laurent Burst'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -10,8 +10,10 @@ Supported props:
 A `<TeaserFrontSplitHeadline />` should be used.
 
 ```react
-<TeaserFrontSplit image='/static/rothaus_portrait.jpg?size=945x1331'
+<TeaserFrontSplit
+  image='/static/rothaus_portrait.jpg?size=945x1331'
   portrait
+  byline='Foto: Bildagentur'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>
@@ -25,8 +27,10 @@ A `<TeaserFrontSplitHeadline />` should be used.
 ```
 
 ```react
-<TeaserFrontSplit image='/static/rothaus_portrait.jpg'
+<TeaserFrontSplit
+  image='/static/rothaus_portrait.jpg'
   portrait reverse
+  byline='Foto: Bildagentur'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>
@@ -40,7 +44,9 @@ A `<TeaserFrontSplitHeadline />` should be used.
 ```
 
 ```react
-<TeaserFrontSplit image='/static/rothaus_landscape.jpg'
+<TeaserFrontSplit
+  image='/static/rothaus_landscape.jpg'
+  byline='Foto: Bildagentur'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>
@@ -54,8 +60,10 @@ A `<TeaserFrontSplitHeadline />` should be used.
 ```
 
 ```react
-<TeaserFrontSplit image='/static/rothaus_landscape.jpg'
+<TeaserFrontSplit
+  image='/static/rothaus_landscape.jpg'
   reverse
+  byline='Foto: Bildagentur'
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial>Headline</TeaserFrontSplitHeadline.Editorial>

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -5,7 +5,7 @@ import { mUp, tUp } from './mediaQueries'
 import Text from './Text'
 import colors from '../../theme/colors'
 
-import { FigureImage } from '../Figure'
+import { FigureImage, FigureByline } from '../Figure'
 import LazyLoad from '../LazyLoad'
 
 const IMAGE_SIZE = {
@@ -166,6 +166,7 @@ const Tile = ({
   children,
   attributes,
   image,
+  byline,
   alt,
   onClick,
   color,
@@ -201,9 +202,10 @@ const Tile = ({
     >
       {imageProps && (
         <div {...(onlyImage ? styles.onlyImageContainer : styles.imageContainer)}>
-          <LazyLoad visible={aboveTheFold}>
+          <LazyLoad visible={aboveTheFold} style={{position: 'relative', fontSize: 0}}>
             <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
               {...(onlyImage ? styles.onlyImage : styles.image)} />
+            {byline && <FigureByline position='rightCompact' style={{color}}>{byline}</FigureByline>}
           </LazyLoad>
         </div>
       )}
@@ -220,6 +222,7 @@ Tile.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   image: PropTypes.string,
+  byline: PropTypes.string,
   alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -18,6 +18,7 @@ Supported props:
 ```react
 <TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
+    byline='Foto: Bildagentur'
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -28,6 +29,7 @@ Supported props:
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
+    byline='Foto: Bildagentur'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -43,6 +45,7 @@ Supported props:
 ```react
 <TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
+    byline='Foto: Bildagentur'
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -64,8 +67,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile image='/static/rothaus_portrait.jpg'
-    color='#fff' bgColor='#000'>
+  <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Bildagentur' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
@@ -79,8 +81,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile image='/static/rothaus_landscape.jpg'
-    color='#fff' bgColor='#000'>
+  <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Bildagentur' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
@@ -94,7 +95,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile color='#000' bgColor='#fff'>
+  <TeaserFrontTile byline='Foto: Bildagentur' color='#000' bgColor='#fff'>
     <Editorial.Format>Umfrage</Editorial.Format>
     <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
     <TeaserFrontCredit>
@@ -108,9 +109,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow columns={2}>
-  <TeaserFrontTile image='/static/rothaus_landscape.jpg'
-    align='top'
-    color='#000' bgColor='#fff'>
+  <TeaserFrontTile align='top' image='/static/rothaus_landscape.jpg' byline='Foto: Bildagentur' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
       An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
@@ -118,6 +117,7 @@ Supported props:
   </TeaserFrontTile>
   <TeaserFrontTile
     align='top'
+    byline='Foto: Bildagentur'
     image='/static/rothaus_landscape.jpg'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>An article which deserves top-alignment</TeaserFrontTileHeadline.Editorial>
@@ -131,6 +131,7 @@ Supported props:
 ```react
 <TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
+    byline='Foto: Bildagentur'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
@@ -139,7 +140,7 @@ Supported props:
   </TeaserFrontTile>
   <TeaserFrontTile
     align='bottom'
-    color='#000' bgColor='#fff'>
+    byline='Foto: Bildagentur' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
       An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
@@ -155,7 +156,7 @@ Supported props:
   <TeaserFrontTile onlyImage image='/static/dada.jpg' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
-  <TeaserFrontTile image='/static/rothaus_landscape.jpg'
+  <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Bildagentur'
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
@@ -170,7 +171,7 @@ Supported props:
   <TeaserFrontTile onlyImage image='/static/video.jpg' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
-  <TeaserFrontTile image='/static/rothaus_portrait.jpg'
+  <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Bildagentur'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -18,7 +18,7 @@ Supported props:
 ```react
 <TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
-    byline='Foto: Bildagentur'
+    byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -29,7 +29,7 @@ Supported props:
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
-    byline='Foto: Bildagentur'
+    byline='Foto: Laurent Burst'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -45,7 +45,7 @@ Supported props:
 ```react
 <TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
-    byline='Foto: Bildagentur'
+    byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -67,7 +67,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Bildagentur' color='#fff' bgColor='#000'>
+  <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
@@ -81,7 +81,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Bildagentur' color='#fff' bgColor='#000'>
+  <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
@@ -95,7 +95,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow>
-  <TeaserFrontTile byline='Foto: Bildagentur' color='#000' bgColor='#fff'>
+  <TeaserFrontTile byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <Editorial.Format>Umfrage</Editorial.Format>
     <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
     <TeaserFrontCredit>
@@ -109,7 +109,7 @@ Supported props:
 
 ```react
 <TeaserFrontTileRow columns={2}>
-  <TeaserFrontTile align='top' image='/static/rothaus_landscape.jpg' byline='Foto: Bildagentur' color='#000' bgColor='#fff'>
+  <TeaserFrontTile align='top' image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
       An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
@@ -117,7 +117,7 @@ Supported props:
   </TeaserFrontTile>
   <TeaserFrontTile
     align='top'
-    byline='Foto: Bildagentur'
+    byline='Foto: Laurent Burst'
     image='/static/rothaus_landscape.jpg'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>An article which deserves top-alignment</TeaserFrontTileHeadline.Editorial>
@@ -131,7 +131,7 @@ Supported props:
 ```react
 <TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
-    byline='Foto: Bildagentur'
+    byline='Foto: Laurent Burst'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
@@ -140,7 +140,7 @@ Supported props:
   </TeaserFrontTile>
   <TeaserFrontTile
     align='bottom'
-    byline='Foto: Bildagentur' color='#000' bgColor='#fff'>
+    byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
       An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
@@ -156,7 +156,7 @@ Supported props:
   <TeaserFrontTile onlyImage image='/static/dada.jpg' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
-  <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Bildagentur'
+  <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
@@ -171,7 +171,7 @@ Supported props:
   <TeaserFrontTile onlyImage image='/static/video.jpg' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
-  <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Bildagentur'
+  <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -26,6 +26,7 @@ This will be wrapped around and links (headlines and credits) and the whole teas
 \`\`\`
 {
   "bgColor": "SandyBrown",
+  "byline": "Foto: Bildagentur",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -63,6 +64,7 @@ Foto: [Thomas Vuillemin on Unsplash](https://unsplash.com/photos/c1_K8Qfd_iQ)
 \`\`\`
 {
   "bgColor": "#000",
+  "byline": "Foto: Bildagentur",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -92,6 +94,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 \`\`\`
 {
   "bgColor": "#ffffff",
+  "byline": "Foto: Bildagentur",
   "center": false,
   "color": "#000000",
   "kind": "editorial",
@@ -123,6 +126,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 \`\`\`
 {
   "bgColor": "#da4343",
+  "byline": "Foto: Bildagentur",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -150,10 +154,11 @@ Von Sonderkorrespondent [Lukas Bünger](<>)
 \`\`\`
 {
   "bgColor": "#000",
+  "byline": "Foto: Bildagentur",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
-  "portrait": true,
+  "portrait": false,
   "reverse": false,
   "teaserType": "frontSplit",
   "textPosition": "topleft",
@@ -201,6 +206,7 @@ Von [Christof Moser](/~6556e282-4ac4-4129-8f8f-d20f28170c39 "Christof Moser")
 
 \`\`\`
 {
+  "byline": "Foto: Bildagentur",
   "kind": "editorial",
   "teaserType": "articleTile",
   "url": "https://www.republik.ch/updates/portraets"
@@ -240,6 +246,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 \`\`\`
 {
+  "byline": "Foto: Bildagentur",
   "kind": "editorial",
   "teaserType": "articleTile",
   "url": "https://www.republik.ch/updates/portraets"
@@ -277,6 +284,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 \`\`\`
 {
   "bgColor": "#fff",
+  "byline": "Foto: Bildagentur",
   "center": false,
   "color": "#000",
   "kind": "editorial",

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -26,7 +26,7 @@ This will be wrapped around and links (headlines and credits) and the whole teas
 \`\`\`
 {
   "bgColor": "SandyBrown",
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Thomas Vuillemin",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -64,7 +64,7 @@ Foto: [Thomas Vuillemin on Unsplash](https://unsplash.com/photos/c1_K8Qfd_iQ)
 \`\`\`
 {
   "bgColor": "#000",
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -85,7 +85,7 @@ Foto: [Thomas Vuillemin on Unsplash](https://unsplash.com/photos/c1_K8Qfd_iQ)
 
 #### Republik-Verleger, 93 Jahre
 
-Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
+Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 <hr /></section>
 
@@ -94,7 +94,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 \`\`\`
 {
   "bgColor": "#ffffff",
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "center": false,
   "color": "#000000",
   "kind": "editorial",
@@ -115,7 +115,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 #### Republik-Verlegerin, 8 Monate
 
-Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
+Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 <hr /></section>
 
@@ -126,7 +126,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 \`\`\`
 {
   "bgColor": "#da4343",
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -154,7 +154,7 @@ Von Sonderkorrespondent [Lukas Bünger](<>)
 \`\`\`
 {
   "bgColor": "#000",
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "center": false,
   "color": "#fff",
   "kind": "editorial",
@@ -183,12 +183,19 @@ Von [Christof Moser](/~6556e282-4ac4-4129-8f8f-d20f28170c39 "Christof Moser")
 
 \`\`\`
 {
+  "byline": "Foto: Laurent Burst",
   "teaserType": "frontArticleCollection",
   "url": "https://www.republik.ch/updates/wer-sind-sie"
 }
 \`\`\`
 
 <section><h6>ARTICLECOLLECTIONINTRO</h6>
+
+\`\`\`
+{
+  "byline": "Foto: Laurent Burst"
+}
+\`\`\`
 
 ![](/static/rothaus_landscape.jpg?size=2000x1331)
 
@@ -206,7 +213,7 @@ Von [Christof Moser](/~6556e282-4ac4-4129-8f8f-d20f28170c39 "Christof Moser")
 
 \`\`\`
 {
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "kind": "editorial",
   "teaserType": "articleTile",
   "url": "https://www.republik.ch/updates/portraets"
@@ -221,7 +228,7 @@ Von [Christof Moser](/~6556e282-4ac4-4129-8f8f-d20f28170c39 "Christof Moser")
 
 #### Republik-Verleger, 93 Jahre
 
-Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
+Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 <hr /></section>
 
@@ -246,7 +253,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 \`\`\`
 {
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "kind": "editorial",
   "teaserType": "articleTile",
   "url": "https://www.republik.ch/updates/portraets"
@@ -261,7 +268,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 #### Republik-Verlegerin, 8 Monate
 
-Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
+Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 <hr /></section>
 
@@ -284,7 +291,7 @@ Foto: [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 \`\`\`
 {
   "bgColor": "#fff",
-  "byline": "Foto: Bildagentur",
+  "byline": "Foto: Laurent Burst",
   "center": false,
   "color": "#000",
   "kind": "editorial",

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -193,7 +193,8 @@ const createSchema = ({
         'bgColor',
         'center',
         'titleSize',
-        'image'
+        'image',
+        'byline'
       ]
     },
     rules: [
@@ -244,6 +245,7 @@ const createSchema = ({
         'bgColor',
         'center',
         'image',
+        'byline',
         'kind',
         'titleSize',
         'reverse',
@@ -352,6 +354,7 @@ const createSchema = ({
         // TODO: Enable once tiles can be selected by clicking the image.
         // 'onlyImage',
         'image',
+        'byline',
         'kind'
       ]
     },
@@ -430,6 +433,7 @@ const createSchema = ({
       dnd: false,
       formOptions: [
         'image',
+        'byline',
         'kind'
       ]
     },


### PR DESCRIPTION
Approach:
- Re-use `<FigureByline>`
- Make sure it's inside a `position:relative` container
- Add a `position` attribute with a distinct set of positioning options
- No config options in Publikator needed other than entering the byline string

Previews:
https://r-styleguide-pr-107.herokuapp.com/teaserfrontimage
https://r-styleguide-pr-107.herokuapp.com/teaserfrontsplit
https://r-styleguide-pr-107.herokuapp.com/teaserfronttile
https://r-styleguide-pr-107.herokuapp.com/teaserfrontdossier
https://r-styleguide-pr-107.herokuapp.com/templates/front

Publikator PR: https://github.com/orbiting/publikator-frontend/pull/136