### PR TITLE
fix(AudioPlayer): more useful UX when source failed loading

### DIFF
--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -277,14 +277,14 @@ class AudioPlayer extends Component {
     this.setInstanceState = state => {
       this.setState(state)
     }
-  }
-  toggle() {
-    const { audio } = this
-    if (audio) {
-      if (audio.paused || audio.ended) {
-        this.play()
-      } else {
-        this.pause()
+    this.toggle = () => {
+      const { audio } = this
+      if (audio) {
+        if (audio.paused || audio.ended) {
+          this.play()
+        } else {
+          this.pause()
+        }
       }
     }
   }
@@ -362,9 +362,9 @@ class AudioPlayer extends Component {
           onLoadedMetadata={this.onLoadedMetaData}
           crossOrigin="anonymous"
         >
-          {src.mp3 && <source src={src.mp3} type="audio/mpeg" onError={(e) => this.onSourceError(e)} />}
-          {src.aac && <source src={src.aac} type="audio/mp4" onError={(e) => this.onSourceError(e)} />}
-          {src.ogg && <source src={src.ogg} type="audio/ogg" onError={(e) => this.onSourceError(e)} />}
+          {src.mp3 && <source src={src.mp3} type="audio/mpeg" onError={this.onSourceError} />}
+          {src.aac && <source src={src.aac} type="audio/mp4" onError={this.onSourceError} />}
+          {src.ogg && <source src={src.ogg} type="audio/ogg" onError={this.onSourceError} />}
         </audio>}
         {isVideo && <video
           {...styles.audio}
@@ -374,11 +374,11 @@ class AudioPlayer extends Component {
           crossOrigin="anonymous"
           playsInline
         >
-          {src.hls && <source src={src.hls} type="application/x-mpegURL" onError={(e) => this.onSourceError(e)} />}
-          {src.mp4 && <source src={src.mp4} type="video/mp4" onError={(e) => this.onSourceError(e)} />}
+          {src.hls && <source src={src.hls} type="application/x-mpegURL" onError={this.onSourceError} />}
+          {src.mp4 && <source src={src.mp4} type="video/mp4" onError={this.onSourceError} />}
         </video>}
         <div {...styles.controls}>
-          <div {...styles.play} onClick={playEnabled ? () => this.toggle() : null}>
+          <div {...styles.play} onClick={playEnabled ? this.toggle : null}>
             {!playing && <Play size={30} fill={playEnabled ? '#000' : colors.disabled} />}
             {playing && <Pause size={30} fill="#000" />}
           </div>

--- a/src/components/AudioPlayer/docs.md
+++ b/src/components/AudioPlayer/docs.md
@@ -16,6 +16,7 @@ Props:
   src={{
     mp3: '/static/sample.mp3'
   }}
+  t={t}
 />
 ```
 
@@ -25,9 +26,9 @@ Props:
     mp3: '/static/sample.mp3'
   }}
   size='narrow'
+  t={t}
 />
 ```
-
 
 ```react
 <AudioPlayer
@@ -35,6 +36,7 @@ Props:
     mp3: '/static/sample.mp3'
   }}
   size='tiny'
+  t={t}
 />
 ```
 
@@ -43,6 +45,7 @@ Props:
   src={{
     mp3: '/static/non-existing-sample.mp3'
   }}
+  t={t}
 />
 ```
 
@@ -54,5 +57,6 @@ The `<AudioPlayer />` may also be used to play from video sources when visual co
     hls: 'https://player.vimeo.com/external/213080233.m3u8?s=40bdb9917fa47b39119a9fe34b9d0fb13a10a92e',
     mp4: 'https://player.vimeo.com/external/213080233.hd.mp4?s=ab84df0ac9134c86bb68bd9ea7ac6b9df0c35774&profile_id=175',
   }}
+  t={t}
 />
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,7 @@ ReactDOM.render(
             path: '/audioplayer',
             title: 'AudioPlayer',
             imports: {
+              t,
               css,
               ...require('./components/Typography'),
               ...require('./components/AudioPlayer'),

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-02-15T18:23:17.569Z",
+  "updated": "2018-02-19T15:08:08.334Z",
   "title": "live",
   "data": [
     {
@@ -66,6 +66,14 @@
     {
       "key": "styleguide/comment/adminUnpublished",
       "value": "Leider mussen wir Ihren Beitrag unveröffentlichen. Wenden sie sich an kontakt@republik.ch."
+    },
+    {
+      "key": "styleguide/AudioPlayer/sourceError",
+      "value": "Audio konnte nicht geladen werden."
+    },
+    {
+      "key": "styleguide/AudioPlayer/sourceErrorTryAgain",
+      "value": "Nochmal versuchen"
     },
     {
       "key": "styleguide/video/dnt/note",


### PR DESCRIPTION
Instead of keeping the loading spinner around endlessly, provide a meaningful message and a link to retry.

<img width="760" alt="screen shot 2018-02-19 at 17 56 47" src="https://user-images.githubusercontent.com/23520051/36389095-484ef0da-159e-11e8-8efa-219428582417.png">

