### PR TITLE
fix(Charts): stabilize sort and group by

### DIFF
--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -4,17 +4,21 @@ import { createElement } from 'react'
 import PropTypes from 'prop-types'
 
 export const groupBy = (array, key) => {
+  const keys = []
   const object = array.reduce(
     (o, item, index) => {
       const k = key(item, index) || ''
-      o[k] = o[k] || []
+      if (!o[k]) {
+        o[k] = []
+        keys.push(k)
+      }
       o[k].push(item)
       return o
     },
     {}
   )
 
-  return Object.keys(object).map(k => ({
+  return keys.map(k => ({
     key: k,
     values: object[k]
   }))
@@ -25,12 +29,19 @@ export const sortPropType = PropTypes.oneOf(['none', 'ascending', 'descending'])
 export const runSort = (cmd, array, accessor = d => d) => {
   if (cmd !== 'none') {
     const compare = cmd === 'descending' ? descending : ascending
-    array.sort((a, b) => compare(accessor(a), accessor(b)))
+    array.sort((a, b) =>
+      compare(accessor(a), accessor(b)) ||
+      ascending(array.indexOf(a), array.indexOf(b)) // stable sort
+    )
   }
 }
 
 export const sortBy = (array, accessor) =>
-  [].concat(array).sort((a, b) => ascending(accessor(a), accessor(b)))
+  [].concat(array)
+    .sort((a, b) =>
+      ascending(accessor(a), accessor(b)) ||
+      ascending(array.indexOf(a), array.indexOf(b)) // stable sort
+    )
 
 export const measure = onMeasure => {
   let ref


### PR DESCRIPTION
Because [sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) is not stable and implementation differs between Chrome and Safari we currently end up with incorrectly positioned labels SSR with v8 and then browser rendering with a different engine.

Example Safari
<img width="703" alt="screen shot 2018-02-26 at 14 26 03" src="https://user-images.githubusercontent.com/410211/36672925-680bfc7a-1b01-11e8-8c6d-8d3f89ef147e.png">

After Fix
<img width="684" alt="screen shot 2018-02-26 at 14 26 38" src="https://user-images.githubusercontent.com/410211/36672935-716b507c-1b01-11e8-8ef4-25dfb5f2e832.png">

I thought the react keys would catch it. But I do use index in many keys (not exclusively). Anyhow it's correct to stable sort anyhow since manual order in the dataset is supported by design.