### PR TITLE
fix: dossier template docs

### DIFF
--- a/src/templates/Dossier/docs.md
+++ b/src/templates/Dossier/docs.md
@@ -35,14 +35,7 @@ Jemand musste Josef K. verleumdet haben, denn ohne dass er etwas Böses getan h�
 
 Und es war ihnen wie eine Bestätigung ihrer neuen Träume und guten Absichten, als am Ziele ihrer Fahrt die Tochter als erste sich erhob und ihren jungen Körper dehnte. «Es ist ein eigentümlicher Apparat», sagte der Offizier zu dem Forschungsreisenden und überblickte mit einem gewissermaßen bewundernden Blick den ihm doch wohlbekannten Apparat. «Es ist ein eigentümlicher Apparat», sagte der Offizier zu dem Forschungsreisenden und überblickte mit einem gewissermaßen bewundernden Blick den ihm doch wohlbekannten Apparat.
 
-<section><h6>TEASER</h6>
-
-\`\`\`
-{
-  "kind": "meta",
-  "teaserType": "articleDossier"
-}
-\`\`\`
+<section><h6>ARTICLECOLLECTION</h6>
 
 ## Diese Artikel sind im Dossier enthalten:
 


### PR DESCRIPTION
mdast rendering is currently broken on
https://styleguide.republik.ch/templates/dossier
due to outdated markdown.