### PR TITLE
fix(LazyLoad): prevent against the bottom line effect showing up on some front image teasers

### DIFF
--- a/src/components/LazyLoad/Image.js
+++ b/src/components/LazyLoad/Image.js
@@ -18,7 +18,9 @@ const styles = {
 
 export default ({src, srcSet, sizes, alt, aspectRatio, attributes, visible, offset}) => (
   <LazyLoad attributes={{...styles.container, ...attributes}} offset={offset} visible={visible} style={{
-    paddingBottom: `${100 / aspectRatio}%`,
+    // We always subtract 1px to prevent against rounding issues that can lead
+    // to the background color shining through at the bottom of the image.
+    paddingBottom: `calc(${100 / aspectRatio}% - 1px)`,
     backgroundColor: src.match(/\.png(\.webp)?(\?|$)/)
       ? 'transparent'
       : undefined


### PR DESCRIPTION
This only occurs for certain widths of the browser window and some specific images, but when it happens, it's ugly. Reason is a mismatch of the placeholder space (which is an exact padding-bottom percentage of the image's aspect ratio resulting in sub-pixel values), while the image size itself may get rounded to full pixels by the browser.

Before (note the red background shining through at the bottom):
<img width="1333" alt="screen shot 2018-03-12 at 15 59 24" src="https://user-images.githubusercontent.com/23520051/37291248-8c8c4948-260e-11e8-84fa-e78da4bc7546.png">
After:
<img width="1333" alt="screen shot 2018-03-12 at 16 00 03" src="https://user-images.githubusercontent.com/23520051/37291263-9261f8ae-260e-11e8-8b72-9239674b6113.png">
