### PR TITLE
fix(AudioPlayer): resolve TimeRanges object without using keys()

### DIFF
--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -419,6 +419,13 @@ class AudioPlayer extends Component {
       right: timePosition === 'right' ? rightIconsWidth + 10 : 'auto'
     }
 
+    let timeRanges = []
+    if (buffered && !!buffered.length) {
+      for (let i = 0; i < buffered.length; i++) {
+        timeRanges.push({start: buffered.start(i), end: buffered.end(i)})
+      }
+    }
+
     return (
       <div {...merge(styles.wrapper, breakoutStyles[size])}
         ref={this.containerRef}
@@ -508,15 +515,13 @@ class AudioPlayer extends Component {
           />
           <div {...styles.buffer}>
             {this.audio &&
-              buffered &&
-              !!buffered.length &&
-              Array.from(Array(buffered.length).keys()).map(index => (
+              timeRanges.map(({start, end}, index) => (
                 <span
                   key={index}
                   {...styles.timeRange}
                   style={{
-                    left: `${buffered.start(index) / this.audio.duration * 100}%`,
-                    width: `${(buffered.end(index) - buffered.start(index)) /
+                    left: `${start / this.audio.duration * 100}%`,
+                    width: `${(end - start) /
                       this.audio.duration *
                       100}%`
                   }}

--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -420,7 +420,7 @@ class AudioPlayer extends Component {
     }
 
     let timeRanges = []
-    if (buffered && !!buffered.length) {
+    if (buffered && buffered.length) {
       for (let i = 0; i < buffered.length; i++) {
         timeRanges.push({start: buffered.start(i), end: buffered.end(i)})
       }


### PR DESCRIPTION
Currently, on IE11 the AudioPlayer explodes when playback starts with this error message:
<img width="769" alt="screen shot 2018-03-22 at 11 41 10" src="https://user-images.githubusercontent.com/23520051/37770148-b37c7420-2dd3-11e8-8638-75870583616b.png">

The error message suggests that IE11 has issues with Array.prototype.keys() at least in republik-frontend context -- which in fact is executed only when playing starts.

Currently I can't test this on IE11 locally, but I would like to check this speculative fix on .love.

TimeRanges interface: https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges