### PR TITLE
fix(Charts): drop timebar value sort

### DIFF
--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -10,7 +10,6 @@ import colors from '../../theme/colors'
 
 import {
   calculateAxis,
-  sortBy,
   groupBy,
   deduplicate,
   transparentAxisStroke,
@@ -94,7 +93,6 @@ const TimeBarChart = (props) => {
       value: +d.value
     }
   })
-  data = sortBy(data, d => d.value).reverse()
 
   const colorAccessor = d => d.datum[props.color]
   const colorValues = data.map(colorAccessor)


### PR DESCRIPTION
<img width="926" alt="screen shot 2018-04-04 at 16 27 42" src="https://user-images.githubusercontent.com/410211/38313917-65e9cd46-3825-11e8-86a3-16f1021d6d2e.png">

`TimeBar` currently has a default descending value sort. As far as I remember this was mostly implemented for stable and predictable results. But taking the sort from the data is actually a better default for pretty much all cases. And instead of changing the default and making it a configurable option I simply removed it. This can still be done by preprocessing the data.

No `TimeBar`s have been used in production—because of that it being very subtle I'm going to skip marking it as breaking change.