### PR TITLE
fix(Typography): faux italic

### DIFF
--- a/src/components/CommentBody/email/Paragraph.js
+++ b/src/components/CommentBody/email/Paragraph.js
@@ -24,6 +24,7 @@ const emphasisStyle = {
 
 const cursiveStyle = {
   fontFamily: fontFamilies.serifItalic,
+  fontStyle: 'normal',
   fontWeight: 'normal'
 }
 

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -149,6 +149,7 @@ export const Emphasis = ({ children, attributes, ...props }) => (
 
 const cursive = css({
   fontWeight: 'normal',
+  fontStyle: 'normal',
   fontFamily: fontFamilies.serifItalic
 })
 export const Cursive = ({ children, attributes, ...props }) => (

--- a/src/components/Typography/Interaction.js
+++ b/src/components/Typography/Interaction.js
@@ -88,7 +88,8 @@ export const Emphasis = ({children, attributes, ...props}) => (
 
 const cursive = css({
   fontWeight: 'normal',
-  fontFamily: fontFamilies.sansSerifItalic
+  fontFamily: fontFamilies.sansSerifItalic,
+  fontStyle: 'normal'
 })
 export const Cursive = ({children, attributes, ...props}) => (
   <em {...props} {...attributes} {...cursive}>{children}</em>

--- a/src/templates/EditorialNewsletter/email/Paragraph.js
+++ b/src/templates/EditorialNewsletter/email/Paragraph.js
@@ -22,6 +22,7 @@ const emphasisStyle = {
 }
 const cursiveStyle = {
   fontFamily: fontFamilies.serifItalic,
+  fontStyle: 'normal',
   fontWeight: 'normal'
 }
 


### PR DESCRIPTION
Seems like most browser were doing it, except for Chrome 🙃 

**before**
<img width="1291" alt="cbefore" src="https://user-images.githubusercontent.com/410211/39524667-f10ac33a-4e19-11e8-9432-e90806d9a8fc.png">

**after**
<img width="1291" alt="cafter" src="https://user-images.githubusercontent.com/410211/39524674-fa1e2264-4e19-11e8-8b9d-7b860274db76.png">
