### PR TITLE
fix(Comment): support non-paragraph content in blockquotes and nesting of blockquotes

### DIFF
--- a/src/components/CommentBody/email/Blockquote.js
+++ b/src/components/CommentBody/email/Blockquote.js
@@ -1,22 +1,34 @@
 import React from 'react'
 
+import colors from '../../../theme/colors'
 import { paragraphStyle } from './Paragraph'
 
 export const BlockQuoteParagraph = ({ children }) => (
  <p style={{
     ...paragraphStyle,
     margin: 0,
-    padding: '0 0 20px 0',
+    padding: '10px 0',
   }}>
     {children}
   </p>
+)
+
+export const BlockQuoteNested = ({ children }) => (
+  <div style={{
+    backgroundColor: '#f7f7f7',
+    borderLeft: `2px solid ${colors.divider}`,
+    margin: '20px auto',
+    padding: '20px 25px',
+  }}>
+    {children}
+  </div>
 )
 
 export default ({ children }) => (
   <div style={{
     backgroundColor: '#f7f7f7',
     margin: '20px auto',
-    padding: '20px 25px 0 25px',
+    padding: '20px 25px',
   }}>
     {children}
   </div>

--- a/src/components/CommentBody/email/index.js
+++ b/src/components/CommentBody/email/index.js
@@ -4,6 +4,7 @@ export {
 
 export {
   default as BlockQuote,
+  BlockQuoteNested,
   BlockQuoteParagraph
 } from './Blockquote'
 

--- a/src/components/CommentBody/web/Blockquote.js
+++ b/src/components/CommentBody/web/Blockquote.js
@@ -1,35 +1,46 @@
 import React from 'react'
 import { css } from 'glamor'
 
+import colors from '../../../theme/colors'
 import { mUp } from '../../../theme/mediaQueries'
 import { serifRegular14, serifRegular16 } from '../../Typography/styles'
 
 const styles = {
   blockquote: css({
-    margin: '20px auto'
+    backgroundColor: '#f7f7f7',
+    margin: '20px auto',
+    padding: '15px',
+    [mUp]: {
+      padding: '25px',
+    }
   }),
   paragraph: css({
-    backgroundColor: '#f7f7f7',
-    margin: 0,
-    padding: '0 15px 12px 15px',
+    margin: '6px 0',
     ...serifRegular14,
     [mUp]: {
       ...serifRegular16,
-      padding: '0 25px 20px 25px',
-      '&:first-child': {
-        paddingTop: '20px'
-      }
+      margin: '10px 0'
     },
     '&:first-child': {
-      paddingTop: '12px'
+      marginTop: 0
+    },
+    '&:last-child': {
+      marginBottom: 0
     }
   })
 }
+
 
 export const BlockQuoteParagraph = ({ children }) => (
   <p {...styles.paragraph}>
     {children}
   </p>
+)
+
+export const BlockQuoteNested = ({ children }) => (
+  <div {...styles.blockquote} style={{borderLeft: `2px solid ${colors.divider}`}}>
+    {children}
+  </div>
 )
 
 export default ({ children }) => (

--- a/src/components/CommentBody/web/index.js
+++ b/src/components/CommentBody/web/index.js
@@ -4,6 +4,7 @@ export {
 
 export {
   default as CommentBodyBlockQuote,
+  BlockQuoteNested as CommentBodyBlockQuoteNested,
   BlockQuoteParagraph as CommentBodyBlockQuoteParagraph
 } from './Blockquote'
 

--- a/src/templates/Comment/docs.md
+++ b/src/templates/Comment/docs.md
@@ -39,12 +39,47 @@ All headings are mapped to bold:
 
 ### Heading 3
 
-Someone said:
+A small blockquote:
 
 > **Blockquote** paragraph one
 > on *two lines*
 >
 > Paragraph two on another line
+
+A large blockquote:
+
+> ## Nested Blockquote level 0
+> 
+> **Blockquote** paragraph one
+> on *two lines*
+>
+> Paragraph two on another line
+>
+> ***
+>
+> 1. First **ordered list** item
+> 2. Another item
+> 1. Actual numbers don't matter, just that it's a number
+> 4. And another item.
+>
+> * First **unordered list** item
+> * Another item
+> * And another item
+>
+>> Nested Blockquote level 1
+>>> Nested Blockquote level 2
+>>>> Nested Blockquote level 3
+>>>>> Nested Blockquote level 4
+>
+>
+> Inline \`code\` uses \`back-ticks\`.
+>
+> \`\`\`
+> A code block nested inside a blockquote
+> second line
+>
+> third line
+> \`\`\`
 
 Inline \`code\` uses \`back-ticks\`.
 
@@ -62,7 +97,6 @@ Inline HTML tags like <sub>subscript</sub> and <sup>superscript</sup> are not su
 [Some link reference][1]
 [Some labelled reference][label]
 ![Some image reference alt text][imageIdentifier]
-
 
 [1]: https://republik.ch
 [label]: https://project-r.construction
@@ -83,6 +117,7 @@ const emailSchema = createCommentSchema()
 
 ```react|noSource
 <Markdown schema={emailSchema}>{`
+
 
 A comment with [a link](https://example.com/ "Mit Titel"), an autolinked URL https://www.republik.ch, a long autolinked URL https://www.republik.ch/01234567890123456789012345678901234567890123456789.png, ![an image](/static/landscape.jpg?size=2000x1411 "Mit Bildtitel") and [...] an ellipsis.
 
@@ -113,12 +148,47 @@ All headings are mapped to bold:
 
 ### Heading 3
 
-Someone said:
+A small blockquote:
 
-> Blockquote paragraph **one**
+> **Blockquote** paragraph one
 > on *two lines*
 >
 > Paragraph two on another line
+
+A large blockquote:
+
+> ## Nested Blockquote level 0
+> 
+> **Blockquote** paragraph one
+> on *two lines*
+>
+> Paragraph two on another line
+>
+> ***
+>
+> 1. First **ordered list** item
+> 2. Another item
+> 1. Actual numbers don't matter, just that it's a number
+> 4. And another item.
+>
+> * First **unordered list** item
+> * Another item
+> * And another item
+>
+>> Nested Blockquote level 1
+>>> Nested Blockquote level 2
+>>>> Nested Blockquote level 3
+>>>>> Nested Blockquote level 4
+>
+>
+> Inline \`code\` uses \`back-ticks\`.
+>
+> \`\`\`
+> A code block nested inside a blockquote
+> second line
+>
+> third line
+> \`\`\`
 
 Inline \`code\` uses \`back-ticks\`.
 
@@ -135,9 +205,11 @@ Inline HTML tags like <sub>subscript</sub> and <sup>superscript</sup> are not su
 
 [Some link reference][1]
 [Some labelled reference][label]
+![Some image reference alt text][imageIdentifier]
 
 [1]: https://republik.ch
 [label]: https://project-r.construction
+[imageIdentifier]: /static/landscape.jpg
 
 `}</Markdown>
 ```

--- a/src/templates/Comment/docs.md
+++ b/src/templates/Comment/docs.md
@@ -48,7 +48,7 @@ A small blockquote:
 
 A large blockquote:
 
-> ## Nested Blockquote level 0
+> ## Blockquote level 0
 > 
 > **Blockquote** paragraph one
 > on *two lines*
@@ -157,7 +157,7 @@ A small blockquote:
 
 A large blockquote:
 
-> ## Nested Blockquote level 0
+> ## Blockquote level 0
 > 
 > **Blockquote** paragraph one
 > on *two lines*

--- a/src/templates/Comment/email.js
+++ b/src/templates/Comment/email.js
@@ -3,6 +3,7 @@ import createCommentSchema from './schema'
 import {
   BlockCode,
   BlockQuote,
+  BlockQuoteNested,
   BlockQuoteParagraph,
   Code,
   Container,
@@ -21,6 +22,7 @@ const createSchema = ({ ...args } = {}) => {
   return createCommentSchema({
     BlockCode,
     BlockQuote,
+    BlockQuoteNested,
     BlockQuoteParagraph,
     Code,
     Container,

--- a/src/templates/Comment/schema.js
+++ b/src/templates/Comment/schema.js
@@ -13,6 +13,7 @@ import { HR } from '../../components/Typography'
 const createCommentSchema = ({
   BlockCode,
   BlockQuote,
+  BlockQuoteNested,
   BlockQuoteParagraph,
   Code,
   Container,
@@ -145,22 +146,6 @@ const createCommentSchema = ({
     ]
   }
 
-  const blockquoteParagraph = {
-    matchMdast: matchParagraph,
-    component: BlockQuoteParagraph,
-    rules: [
-      ...globalInlines
-    ]
-  }
-
-  const blockQuote = {
-    matchMdast: matchType('blockquote'),
-    component: BlockQuote,
-    rules: [
-      blockquoteParagraph
-    ]
-  }
-
   const blockCode = {
     matchMdast: matchType('code'),
     props: node => ({
@@ -210,6 +195,51 @@ const createCommentSchema = ({
     component: ({identifier, url}) => (
       <Definition>[{identifier}] <SafeA href={url}>{url}</SafeA></Definition>
     )
+  }
+
+  const blockquoteParagraph = {
+    matchMdast: matchParagraph,
+    component: BlockQuoteParagraph,
+    rules: [
+      ...globalInlines
+    ]
+  }
+
+  const getNestedRule = (levels, rule) => {
+    if (levels === 0) {
+      return rule
+    }
+    rule.rules.push(rule)
+    return getNestedRule(levels - 1, rule)
+  }
+
+  const blockQuoteNested = {
+    matchMdast: matchType('blockquote'),
+    component: BlockQuoteNested,
+    rules: [
+      heading,
+      blockquoteParagraph,
+      blockCode,
+      list,
+      thematicBreak,
+      blockLevelHtml,
+      definition
+    ]
+  }
+
+  const blockQuote = {
+    matchMdast: matchType('blockquote'),
+    component: BlockQuote,
+    rules: [
+      blockquoteParagraph,
+      heading,
+      getNestedRule(3, blockQuoteNested),
+      blockCode,
+      list,
+      thematicBreak,
+      blockLevelHtml,
+      definition
+    ]
   }
 
   return {

--- a/src/templates/Comment/schema.js
+++ b/src/templates/Comment/schema.js
@@ -205,26 +205,9 @@ const createCommentSchema = ({
     ]
   }
 
-  const getNestedRule = (levels, rule) => {
-    if (levels === 0) {
-      return rule
-    }
-    rule.rules.push(rule)
-    return getNestedRule(levels - 1, rule)
-  }
-
   const blockQuoteNested = {
     matchMdast: matchType('blockquote'),
-    component: BlockQuoteNested,
-    rules: [
-      heading,
-      blockquoteParagraph,
-      blockCode,
-      list,
-      thematicBreak,
-      blockLevelHtml,
-      definition
-    ]
+    component: BlockQuoteNested
   }
 
   const blockQuote = {
@@ -233,7 +216,7 @@ const createCommentSchema = ({
     rules: [
       blockquoteParagraph,
       heading,
-      getNestedRule(3, blockQuoteNested),
+      blockQuoteNested,
       blockCode,
       list,
       thematicBreak,

--- a/src/templates/Comment/web.js
+++ b/src/templates/Comment/web.js
@@ -3,6 +3,7 @@ import createCommentSchema from './schema'
 import {
   CommentBodyBlockCode,
   CommentBodyBlockQuote,
+  CommentBodyBlockQuoteNested,
   CommentBodyBlockQuoteParagraph,
   CommentBodyCode,
   CommentBodyDefinition,
@@ -18,6 +19,7 @@ const createSchema = ({ ...args } = {}) => {
   return createCommentSchema({
     BlockCode: CommentBodyBlockCode,
     BlockQuote: CommentBodyBlockQuote,
+    BlockQuoteNested: CommentBodyBlockQuoteNested,
     BlockQuoteParagraph: CommentBodyBlockQuoteParagraph,
     Code: CommentBodyCode,
     Container: CommentBodyContainer,


### PR DESCRIPTION
Fixes https://github.com/orbiting/styleguide/issues/133

# Web:
![screen shot 2018-05-16 at 18 04 08](https://user-images.githubusercontent.com/23520051/40129558-de1bde96-5934-11e8-8ec4-abecf0d4afa7.png)

# Email:
<img width="811" alt="screen shot 2018-05-16 at 18 09 14" src="https://user-images.githubusercontent.com/23520051/40129570-e8905348-5934-11e8-81e7-c81d9fae094d.png">
