### PR TITLE
Two Random Fixes

### DIFF
--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -680,6 +680,9 @@ const createSchema = ({
           {
             matchMdast: matchZone('CENTER'),
             component: Center,
+            // prevent empty data object forward to component
+            // - Center spreads all props onto its div
+            props: () => ({}),
             editorModule: 'center',
             rules: [
               {

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -121,7 +121,8 @@ const createTeasers = ({
         props: (node) => {
           return {
             title: node.title,
-            href: node.url
+            href: node.url,
+            color: colors.text
           }
         },
         component: ({ children, data, ...props }) =>


### PR DESCRIPTION
text color links for article collections (requested by Christof)
<img width="1207" alt="screen shot 2018-05-23 at 17 53 51" src="https://user-images.githubusercontent.com/410211/40436038-55c62834-5eb2-11e8-9f71-43729ed22b33.png">

fix empty data object being forwarded into center (reported by @wereHamster, thx!)
![unnamed](https://user-images.githubusercontent.com/410211/40436094-7e0899da-5eb2-11e8-8534-e8227f293de7.png)
