### PR TITLE
feat(TeaserFeed): basic support for <em>highlighting</em> in title and description

### DIFF
--- a/src/components/TeaserFeed/Headline.js
+++ b/src/components/TeaserFeed/Headline.js
@@ -16,6 +16,9 @@ const styles = {
     marginBottom: 6,
     [mUp]: {
       marginBottom: 8,
+    },
+    '& em': {
+      fontStyle: 'normal'
     }
   }),
   editorial: css({

--- a/src/components/TeaserFeed/Lead.js
+++ b/src/components/TeaserFeed/Lead.js
@@ -3,14 +3,26 @@ import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
-import { serifRegular16, serifRegular19 } from '../Typography/styles'
+import {
+  serifRegular16,
+  serifRegular19,
+  serifBold16,
+  serifBold19
+} from '../Typography/styles'
 
 const styles = {
   main: css({
     ...serifRegular16,
     margin: '0 0 5px 0',
+    '& em': {
+      ...serifBold16,
+      fontStyle: 'normal'
+    },
     [mUp]: {
-      ...serifRegular19
+      ...serifRegular19,
+      '& em': {
+        ...serifBold19
+      }
     },
     color: colors.text
   })

--- a/src/components/TeaserFeed/index.js
+++ b/src/components/TeaserFeed/index.js
@@ -63,12 +63,16 @@ export const TeaserFeed = ({
     <Container format={format} color={formatMeta.color || metaColor} Link={Link}>
       <Headline style={{color: metaColor}}>
         <Link href={path} passHref>
-          <a {...styles.link} href={path}>{title}</a>
+          <a {...styles.link} href={path} dangerouslySetInnerHTML={{
+            __html: title
+          }} />
         </Link>
       </Headline>
       <Lead>
         <Link href={path} passHref>
-          <a {...styles.link} href={path}>{description}</a>
+          <a {...styles.link} href={path} dangerouslySetInnerHTML={{
+            __html: description
+          }} />
         </Link>
       </Lead>
 


### PR DESCRIPTION
Adds support for strings containing `<em>` highlighting.

Pending actual design decisions, so just implementing a non-controversial style for now:
- bold highlight in description
- invisible highlight in title

<img width="728" alt="screen shot 2018-05-23 at 19 12 20" src="https://user-images.githubusercontent.com/23520051/40440080-4529f3ec-5ebd-11e8-89db-cc3e77c7352c.png">
