### PR TITLE
fix(frontimage): bottomleft/right positioning of text should be relative to bottom (instead of 50%)

### DIFF
--- a/src/components/TeaserFront/Text.js
+++ b/src/components/TeaserFront/Text.js
@@ -7,7 +7,7 @@ import colors from '../../theme/colors'
 const TEXT_PADDING = 50
 
 const positionHalfWidth = {
-  height: `calc(50% - ${TEXT_PADDING}px)`,
+  position: 'absolute',
   width: `calc(50% - ${TEXT_PADDING}px)`
 }
 
@@ -54,15 +54,16 @@ const styles = {
   bottomleft: css({
     [tUp]: {
       ...positionHalfWidth,
-      left: `${TEXT_PADDING}px`,
-      top: '50%'
+      bottom: `${TEXT_PADDING}px`,
+      left: `${TEXT_PADDING}px`
+      
     }
   }),
   bottomright: css({
     [tUp]: {
       ...positionHalfWidth,
-      left: '50%',
-      top: '50%'
+      bottom: `${TEXT_PADDING}px`,
+      left: '50%'
     }
   }),
   top: css({


### PR DESCRIPTION
Typical issue in production with longer leads:
<img width="1238" alt="screen shot 2018-06-04 at 10 58 48" src="https://user-images.githubusercontent.com/23520051/40909919-17853bcc-67eb-11e8-8d88-e5b14b0ca8a7.png">

With the fix, text may grow upwards:
<img width="991" alt="screen shot 2018-06-04 at 11 28 53" src="https://user-images.githubusercontent.com/23520051/40909943-23a3d648-67eb-11e8-8d5e-13de4d02e497.png">
