### PR TITLE
feat(VideoPlayer): enable fullscreen button on iOS

### DIFF
--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -254,7 +254,8 @@ class VideoPlayer extends Component {
           this.setState(() => ({
             isFullscreen: this.state.fullscreen.element() === this.video
           }))
-        }
+        },
+        video: this.video
       })
     })
 

--- a/src/components/VideoPlayer/fullscreen.js
+++ b/src/components/VideoPlayer/fullscreen.js
@@ -60,12 +60,24 @@ const getFullscreenApi = () => {
   return api.requestFullscreen ? api : null
 }
 
-export const setupFullscreen = ({ onChange }) => {
+export const setupFullscreen = ({ onChange, video }) => {
   if (typeof document === 'undefined') {
     return
   }
   const api = getFullscreenApi()
   if (!api) {
+    if (video && video.webkitEnterFullscreen) {
+      // iOS provides fullscreen on video element directly instead of document.
+      return {
+        request(video) {
+          video.webkitEnterFullscreen()
+        },
+        element() {
+          return video
+        },
+        dispose() {}
+      }
+    }
     return
   }
 


### PR DESCRIPTION
Right now we don't have a fullscreen button on iOS. But there's actually a way to request fullscreen on the video element directly on iOS.

<img width="966" alt="screen shot 2018-06-14 at 11 16 37" src="https://user-images.githubusercontent.com/23520051/41403338-eb7299ee-6fc4-11e8-9980-46ac8ee97f57.png">
<img width="994" alt="screen shot 2018-06-14 at 11 17 29" src="https://user-images.githubusercontent.com/23520051/41403353-f3617c4c-6fc4-11e8-8486-65436e918fd7.png">
