### PR TITLE
feat(DynamicComponent): edge-to-edge and raw (without figure wrapper)

### DIFF
--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -769,18 +769,26 @@ Zweitens: ich habe erklärt mit diese zwei Spieler: nach Dortmund brauchen viell
 
 ## Dynamic Components
 
+By default dynamic components are wrapped in figures to support all center sizes. Set `raw` to `true` to disable figure wrapping, `size` will have no effect in raw mode.
+
+### `size`
+
+Values: `undefined` (default), `breakout`, `narrow`, `floatTiny`
+
 ```react|noSource
 <Markdown schema={schema}>{`
 <section><h6>CENTER</h6>
+
+Genau zu diesem Zwecke erschaffen, immer im Schatten meines großen Bruders «Lorem Ipsum», freue ich mich jedes Mal, wenn Sie ein paar Zeilen lesen.
 
 <section><h6>DYNAMIC_COMPONENT</h6>
 
 \`\`\`
 {
-  "size": "breakout",
+  "size": "narrow",
   "src": "/static/dynamic_hello.js",
   "props": {
-    "text": "This is it."
+    "text": "This is narrow."
   }
 }
 \`\`\`
@@ -791,6 +799,47 @@ Zweitens: ich habe erklärt mit diese zwei Spieler: nach Dortmund brauchen viell
 
 <hr /></section>
 
+Denn esse est percipi - Sein ist wahrgenommen werden.
+
 <hr /></section>
+`}</Markdown>
+```
+
+### Edge-to-Edge
+
+Simpy unwrap from center
+
+```react|noSource
+<Markdown schema={schema}>{`
+
+<section><h6>CENTER</h6>
+
+Überall dieselbe alte Leier. Das Layout ist fertig, der Text lässt auf sich warten.
+
+<hr /></section>
+
+<section><h6>DYNAMIC_COMPONENT</h6>
+
+\`\`\`
+{
+  "src": "/static/dynamic_hello.js",
+  "props": {
+    "text": "Edge-To-Edge"
+  }
+}
+\`\`\`
+
+\`\`\`html
+<div>Optional static SSR version and placeholder while loading. Default is a loader.</div>
+\`\`\`
+
+<hr /></section>
+
+<section><h6>CENTER</h6>
+
+Damit das Layout nun nicht nackt im Raume steht und sich klein und leer vorkommt, springe ich ein: der Blindtext.
+
+<hr /></section>
+
 `}</Markdown>
 ```

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -146,7 +146,7 @@ Etwas Böses _Foto: Laurent Burst_
 
 ### Edge-to-Edge
 
-Simpy unwrap from center
+Simply unwrap from center
 
 ```react|noSource
 <Markdown schema={schema}>{`
@@ -807,7 +807,7 @@ Denn esse est percipi - Sein ist wahrgenommen werden.
 
 ### Edge-to-Edge
 
-Simpy unwrap from center
+Simply unwrap from center
 
 ```react|noSource
 <Markdown schema={schema}>{`

--- a/src/templates/Article/dynamicComponent.js
+++ b/src/templates/Article/dynamicComponent.js
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import DynamicComponent from '../../components/DynamicComponent'
+import ErrorBoundary from '../../components/ErrorBoundary'
+import {
+  Figure
+} from '../../components/Figure'
+
+import {
+  matchZone
+} from 'mdast-react-render/lib/utils'
+
+const createDynamicComponent = ({t, dynamicComponentRequire, insertButtonText}) => ({
+  matchMdast: matchZone('DYNAMIC_COMPONENT'),
+  component: ({showException, raw = false, size, ...props}) => {
+    const content = (
+      <ErrorBoundary
+        showException={showException}
+        failureMessage={t('styleguide/DynamicComponent/error')}>
+        <DynamicComponent size={size} {...props} />
+      </ErrorBoundary>
+    )
+
+    if (raw) {
+      return content
+    }
+
+    return <Figure size={size}>
+      {content}
+    </Figure>
+  },
+  props: node => {
+    const html = node.children.find(c => c.type === 'code' && c.lang === 'html')
+    return {
+      raw: node.data.raw,
+      size: node.data.size,
+      src: node.data.src,
+      html: html && html.value,
+      props: node.data.props,
+      loader: node.data.loader,
+      require: dynamicComponentRequire
+    }
+  },
+  editorModule: 'dynamiccomponent',
+  editorOptions: {
+    insertTypes: [
+      'PARAGRAPH'
+    ],
+    insertButtonText
+  },
+  isVoid: true
+})
+
+export default createDynamicComponent

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -12,7 +12,6 @@ import * as Editorial from '../../components/Typography/Editorial'
 import * as Interaction from '../../components/Typography/Interaction'
 import { TeaserFeed } from '../../components/TeaserFeed'
 import IllustrationHtml from '../../components/IllustrationHtml'
-import DynamicComponent from '../../components/DynamicComponent'
 import CsvChart from '../../components/Chart/Csv'
 import { ChartTitle, ChartLead } from '../../components/Chart'
 import ErrorBoundary from '../../components/ErrorBoundary'
@@ -65,6 +64,7 @@ import {
 } from './utils'
 
 import createTeasers from './teasers'
+import createDynamicComponent from './dynamicComponent'
 
 const link = {
   matchMdast: matchType('link'),
@@ -965,40 +965,18 @@ const createSchema = ({
                 },
                 isVoid: true
               },
-              {
-                matchMdast: matchZone('DYNAMIC_COMPONENT'),
-                component: ({showException, size, ...props}) => (
-                  <Figure size={size}>
-                    <ErrorBoundary
-                      showException={showException}
-                      failureMessage={t('styleguide/DynamicComponent/error')}>
-                      <DynamicComponent {...props} />
-                    </ErrorBoundary>
-                  </Figure>
-                ),
-                props: node => {
-                  const html = node.children.find(c => c.type === 'code' && c.lang === 'html')
-                  return {
-                    size: node.data.size,
-                    src: node.data.src,
-                    html: html && html.value,
-                    props: node.data.props,
-                    loader: node.data.loader,
-                    require: dynamicComponentRequire
-                  }
-                },
-                editorModule: 'dynamiccomponent',
-                editorOptions: {
-                  insertTypes: [
-                    'PARAGRAPH'
-                  ],
-                  insertButtonText: 'Dynamic Component'
-                },
-                isVoid: true
-              }
+              createDynamicComponent({
+                t,
+                dynamicComponentRequire,
+                insertButtonText: 'Dynamic Component'
+              })
             ]
           },
           centerFigure,
+          createDynamicComponent({
+            t,
+            dynamicComponentRequire
+          }),
           {
             matchMdast: () => false,
             editorModule: 'specialchars'


### PR DESCRIPTION
Support Edge-to-Edge dynamic components:
<img width="1045" alt="screen shot 2018-06-18 at 17 49 36" src="https://user-images.githubusercontent.com/410211/41547277-0afc8e7e-7320-11e8-9539-67a0763020fb.png">

and raw mode without figure wrapping.