### PR TITLE
fix(CommentsTeaser): graciously fall back on span when mdast node has…

### DIFF
--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -61,7 +61,11 @@ export const CommentTeaser = ({
         lineClamp ? merge(styles.clamp, { WebkitLineClamp: lineClamp }) : {}
       )}
     >
-      {renderMdast(content, schema)}
+      {renderMdast(
+        content,
+        schema,
+        { MissingNode: ({ children }) => <span>{children}</span> }
+      )}
     </div>
     <CommentTeaserFooter commentUrl={commentUrl} timeago={timeago} t={t} />
   </div>


### PR DESCRIPTION
… no renderer

Test markdown snippet
```md
ich denke

- also bin ich
   - eingerückt
```

Before:
![image](https://user-images.githubusercontent.com/546185/42459102-74c9e5e6-839b-11e8-9964-02402865f4c8.png)


Now:
![image](https://user-images.githubusercontent.com/546185/42459067-622bc6de-839b-11e8-9e22-f33f37c9545d.png)
