### PR TITLE
fix(Templates): prevent prominent error in newsletters without cover

### DIFF
--- a/src/templates/EditorialNewsletter/email/Cover.js
+++ b/src/templates/EditorialNewsletter/email/Cover.js
@@ -1,19 +1,28 @@
 import React from 'react'
 
-export const CoverImage = ({ src, alt }) => (
-  <img
-    src={src}
-    alt={alt}
-    border="0"
-    style={{
-      margin: 0,
-      padding: 0,
-      width: '100%',
-      height: 'auto !important',
-      maxWidth: '100% !important'
-    }}
-  />
-)
+export const CoverImage = ({ src, alt }) => {
+  // skip rendering empty cover images
+  // - some email clients show a prominent error when rendering an img tag without a src
+  // - this happens for covers all the time because they currently can't be removed in publikator-frontend
+  if (!src && !alt) {
+    return null
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      border="0"
+      style={{
+        margin: 0,
+        padding: 0,
+        width: '100%',
+        height: 'auto !important',
+        maxWidth: '100% !important'
+      }}
+    />
+  )
+}
 
 export default ({ children }) => (
   <tr>


### PR DESCRIPTION
Outlook and some other clients show erros when a img src is missing:
<img width="803" alt="screen shot 2018-07-12 at 12 14 34" src="https://user-images.githubusercontent.com/410211/42627988-f4fe4240-85ce-11e8-9d92-e1e72ab03810.png">

In our current workflow all daily and soon weekly newsletters are sent with an empty cover image. This is because the cover can't be removed in `publikator-frontend`.

This simple workaround should prevent this going forward. Even if we add cover removing to `publikator-frontend` IMO this will still be good to have in place for production errors where it was forgotten to remove.

Make sure to bump styleguide in the backends afterwards:
- https://github.com/orbiting/backends/blob/master/packages/documents/package.json
- https://github.com/orbiting/backends/blob/master/servers/republik/package.json

and deploy `republik-publikator-api` (`republik-api` is not strictly necessary since preview mail, afaik, do have a cover).