### PR TITLE
Feuilleton front

### DIFF
--- a/src/components/Dossier/Lead.js
+++ b/src/components/Dossier/Lead.js
@@ -2,14 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp } from '../TeaserFront/mediaQueries'
-import { serifRegular16, serifRegular22 } from '../Typography/styles'
+import { serifRegular16, serifRegular23 } from '../Typography/styles'
 
 const styles = {
   lead: css({
     ...serifRegular16,
     margin: '0 0 10px 0',
     [mUp]: {
-      ...serifRegular22,
+      ...serifRegular23,
       margin: '0 0 20px 0'
     }
   })

--- a/src/components/Dossier/Lead.js
+++ b/src/components/Dossier/Lead.js
@@ -2,14 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp } from '../TeaserFront/mediaQueries'
-import { serifRegular16, serifRegular23 } from '../Typography/styles'
+import { serifRegular16, serifRegular22 } from '../Typography/styles'
 
 const styles = {
   lead: css({
     ...serifRegular16,
     margin: '0 0 10px 0',
     [mUp]: {
-      ...serifRegular23,
+      ...serifRegular22,
       margin: '0 0 20px 0'
     }
   })

--- a/src/components/Figure/Byline.js
+++ b/src/components/Figure/Byline.js
@@ -36,6 +36,14 @@ const positionStyle = {
       paddingLeft: 0
     }
   }),
+  belowFramed: css({
+    display: 'block',
+    marginTop: '5px',
+    paddingLeft: 0,
+    [mUpFront]: {
+      ...sansSerifRegular12
+    }
+  }),
   // right of relative container on desktop, below on mobile.
   right: css({
     paddingLeft: '15px',
@@ -108,6 +116,7 @@ Byline.propTypes = {
   attributes: PropTypes.object,
   position: PropTypes.oneOf([
     'below',
+    'belowFramed',
     'right',
     'rightCompact',
     'left',

--- a/src/components/Figure/Byline.js
+++ b/src/components/Figure/Byline.js
@@ -36,7 +36,7 @@ const positionStyle = {
       paddingLeft: 0
     }
   }),
-  belowFramed: css({
+  belowFrame: css({
     display: 'block',
     marginTop: '5px',
     paddingLeft: 0,
@@ -116,7 +116,7 @@ Byline.propTypes = {
   attributes: PropTypes.object,
   position: PropTypes.oneOf([
     'below',
-    'belowFramed',
+    'belowFrame',
     'right',
     'rightCompact',
     'left',

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -68,11 +68,11 @@ const ImageBlock = ({
   center,
   aboveTheFold,
   onlyImage,
-  framed
+  frame
 }) => {
   const background = bgColor || ''
   return (
-    <div {...attributes} {...(framed ? styles.containerFramed : styles.container)} onClick={onClick} style={{
+    <div {...attributes} {...(frame ? styles.containerFramed : styles.container)} onClick={onClick} style={{
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
@@ -82,8 +82,8 @@ const ImageBlock = ({
           {byline}
         </FigureByline>}
       </div>
-      {!onlyImage && <div {...(framed ? styles.textContainerFramed : styles.textContainer)}>
-        <Text position={textPosition} color={color} compactColor={framed && colors.text} center={center}>
+      {!onlyImage && <div {...(frame ? styles.textContainerFramed : styles.textContainer)}>
+        <Text position={textPosition} color={color} collapsedColor={frame && colors.text} center={center}>
           {children}
         </Text>
       </div>}
@@ -110,7 +110,7 @@ ImageBlock.propTypes = {
     'bottom'
   ]),
   onlyImage: PropTypes.bool,
-  framed: PropTypes.bool
+  frame: PropTypes.bool
 }
 
 ImageBlock.defaultProps = {

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -2,25 +2,52 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp, tUp } from './mediaQueries'
+import colors from '../../theme/colors'
 import zIndex from '../../theme/zIndex'
 import { FigureImage, FigureByline } from '../Figure'
 import Text from './Text'
 
+const containerStyle = {
+  position: 'relative',
+  lineHeight: 0,
+  margin: 0,
+  zIndex: zIndex.frontImage,
+  [tUp]: {
+    background: 'none'
+  }
+}
+
+const textContainerStyle = {
+  overflow: 'hidden',  // Hides unpositioned content on mobile.
+  padding: '15px 15px 40px 15px',
+  [mUp]: {
+    padding: '40px 15% 70px 15%'
+  },
+  [tUp]: {
+    padding: 0
+  }
+}
+
 const styles = {
   container: css({
-    position: 'relative',
-    lineHeight: 0,
-    margin: 0,
-    zIndex: zIndex.frontImage,
-    [tUp]: {
-      background: 'none'
+    ...containerStyle
+  }),
+  containerFramed: css({
+    ...containerStyle,
+    margin: '15px',
+    [mUp]: {
+      background: 'none',
+      margin: '50px 5%'
     }
   }),
   textContainer: css({
-    overflow: 'hidden',  // Hides unpositioned content on mobile.
-    padding: '15px 15px 40px 15px',
+    ...textContainerStyle
+  }),
+  textContainerFramed: css({
+    ...textContainerStyle,
+    padding: '15px 0 40px 0',
     [mUp]: {
-      padding: '40px 15% 70px 15%'
+      padding: '40px 0 70px 0'
     },
     [tUp]: {
       padding: 0
@@ -36,15 +63,17 @@ const ImageBlock = ({
   alt,
   onClick,
   color,
+  compactColor,
   bgColor,
   textPosition,
   center,
   aboveTheFold,
-  onlyImage
+  onlyImage,
+  framed
 }) => {
   const background = bgColor || ''
   return (
-    <div {...attributes} {...styles.container} onClick={onClick} style={{
+    <div {...attributes} {...(framed ? styles.containerFramed : styles.container)} onClick={onClick} style={{
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
@@ -54,8 +83,8 @@ const ImageBlock = ({
           {byline}
         </FigureByline>}
       </div>
-      {!onlyImage && <div {...styles.textContainer}>
-        <Text position={textPosition} color={color} center={center}>
+      {!onlyImage && <div {...(framed ? styles.textContainerFramed : styles.textContainer)}>
+        <Text position={textPosition} color={color} compactColor={framed && colors.text} center={center}>
           {children}
         </Text>
       </div>}
@@ -70,6 +99,7 @@ ImageBlock.propTypes = {
   byline: PropTypes.string,
   alt: PropTypes.string,
   color: PropTypes.string,
+  compactColor: PropTypes.string,
   bgColor: PropTypes.string,
   center: PropTypes.bool,
   textPosition: PropTypes.oneOf([
@@ -81,7 +111,8 @@ ImageBlock.propTypes = {
     'middle',
     'bottom'
   ]),
-  onlyImage: PropTypes.bool
+  onlyImage: PropTypes.bool,
+  framed: PropTypes.bool
 }
 
 ImageBlock.defaultProps = {

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -32,7 +32,7 @@ const styles = {
   container: css({
     ...containerStyle
   }),
-  containerFramed: css({
+  containerFrame: css({
     ...containerStyle,
     margin: '15px',
     [mUp]: {
@@ -43,7 +43,7 @@ const styles = {
   textContainer: css({
     ...textContainerStyle
   }),
-  textContainerFramed: css({
+  textContainerFrame: css({
     ...textContainerStyle,
     padding: '15px 0 40px 0',
     [mUp]: {
@@ -72,7 +72,7 @@ const ImageBlock = ({
 }) => {
   const background = bgColor || ''
   return (
-    <div {...attributes} {...(frame ? styles.containerFramed : styles.container)} onClick={onClick} style={{
+    <div {...attributes} {...(frame ? styles.containerFrame : styles.container)} onClick={onClick} style={{
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
@@ -82,7 +82,7 @@ const ImageBlock = ({
           {byline}
         </FigureByline>}
       </div>
-      {!onlyImage && <div {...(frame ? styles.textContainerFramed : styles.textContainer)}>
+      {!onlyImage && <div {...(frame ? styles.textContainerFrame : styles.textContainer)}>
         <Text position={textPosition} color={color} collapsedColor={frame && colors.text} center={center}>
           {children}
         </Text>

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -63,7 +63,6 @@ const ImageBlock = ({
   alt,
   onClick,
   color,
-  compactColor,
   bgColor,
   textPosition,
   center,
@@ -99,7 +98,6 @@ ImageBlock.propTypes = {
   byline: PropTypes.string,
   alt: PropTypes.string,
   color: PropTypes.string,
-  compactColor: PropTypes.string,
   bgColor: PropTypes.string,
   center: PropTypes.bool,
   textPosition: PropTypes.oneOf([

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -216,13 +216,13 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 </TeaserFrontImage>
 ```
 
-### `framed`: Horizontal `framed` margins and regular text color in stacked mode
+### `frame`: Horizontal `frame` margins and regular text color in stacked mode
 
 ```react
 <TeaserFrontImage
-  framed
+  frame
   image='/static/desert.jpg?size=4323x2962' byline='Foto: Thomas Vuillemin'
-  color='#fff' compactColor='#000' bgColor='#fff'>
+  color='#fff' collapsedColor='#000' bgColor='#fff'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontImageHeadline.Editorial small>The sand is near</TeaserFrontImageHeadline.Editorial>
   <TeaserFrontLead>

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -216,4 +216,22 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 </TeaserFrontImage>
 ```
 
+### Alternate text color in stacked mode
+
+```react
+<TeaserFrontImage
+  framed
+  image='/static/desert.jpg?size=4323x2962' byline='Foto: Thomas Vuillemin'
+  color='#fff' compactColor='#000' bgColor='#fff'>
+  <Editorial.Format>Neutrum</Editorial.Format>
+  <TeaserFrontImageHeadline.Editorial small>The sand is near</TeaserFrontImageHeadline.Editorial>
+  <TeaserFrontLead>
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
+  </TeaserFrontLead>
+  <TeaserFrontCredit>
+    An article by <TeaserFrontCreditLink href='#' color='#adf'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+  </TeaserFrontCredit>
+</TeaserFrontImage>
+```
+
 Photo by Thomas Vuillemin on [Unsplash](https://unsplash.com/photos/c1_K8Qfd_iQ)

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -216,7 +216,7 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 </TeaserFrontImage>
 ```
 
-### Alternate text color in stacked mode
+### `framed`: Horizontal `framed` margins and regular text color in stacked mode
 
 ```react
 <TeaserFrontImage

--- a/src/components/TeaserFront/Lead.js
+++ b/src/components/TeaserFront/Lead.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Editorial } from '../Typography'
 
 const Lead = ({ children }) => {
-  return <Editorial.Lead style={{color: 'inherit'}}>{children}</Editorial.Lead>
+  return <Editorial.Lead style={{color: 'inherit', display: 'inline'}}>{children}</Editorial.Lead>
 }
 
 Lead.propTypes = {

--- a/src/components/TeaserFront/Lead.js
+++ b/src/components/TeaserFront/Lead.js
@@ -2,12 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Editorial } from '../Typography'
 
-const Lead = ({ children }) => {
-  return <Editorial.Lead style={{color: 'inherit', display: 'inline'}}>{children}</Editorial.Lead>
-}
+const Lead = ({ children, columns }) => (
+  <Editorial.Lead small={columns === 3} style={{color: 'inherit', display: 'inline'}}>
+    {children}
+  </Editorial.Lead>
+)
 
 Lead.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  columns: PropTypes.number
 }
 
 export default Lead

--- a/src/components/TeaserFront/Lead.js
+++ b/src/components/TeaserFront/Lead.js
@@ -1,11 +1,41 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Editorial } from '../Typography'
+import colors from '../../theme/colors'
+import { css } from 'glamor'
+import { mUp } from './mediaQueries'
+import {
+  serifRegular18,
+  serifRegular19,
+  serifRegular23
+} from '../Typography/styles'
 
-const Lead = ({ children, columns }) => (
-  <Editorial.Lead small={columns === 3} style={{color: 'inherit', display: 'inline'}}>
+const leadStyle = {
+  ...serifRegular19,
+  lineHeight: '27px',
+  margin: '0 0 10px 0',
+  color: colors.text
+}
+
+const lead = css({
+  ...leadStyle,
+  [mUp]: {
+    ...serifRegular23,
+    margin: '0 0 20px 0'
+  }
+})
+
+const leadSmall = css({
+  ...leadStyle,
+  [mUp]: {
+    ...serifRegular18,
+    margin: '0 0 20px 0'
+  }
+})
+
+const Lead = ({ children, columns, attributes, ...props }) => (
+  <span {...attributes} {...props} {...(columns === 3 ? leadSmall : lead)} style={{color: 'inherit'}}>
     {children}
-  </Editorial.Lead>
+  </span>
 )
 
 Lead.propTypes = {

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -16,6 +16,16 @@ const styles = {
       padding: '70px 5%'
     }
   }),
+  containerFramed: css({
+    margin: 0,
+    overflow: 'hidden',
+    [mUp]: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '50px 5%'
+    }
+  }),
   containerPortrait: css({
     [mUp]: {
       padding: 0,
@@ -53,6 +63,17 @@ const styles = {
       width: '50%'
     }
   }),
+  imageContainerFramed: css({
+    padding: '15px 15px 0 15px',
+    position: 'relative',
+    [mUp]: {
+      padding: 0,
+      flexShrink: 0,
+      fontSize: 0, // Removes the small flexbox space.
+      height: 'auto',
+      width: '50%'
+    }
+  }),
   imageContainerPortrait: css({
     [mUp]: {
       width: '40%',
@@ -77,15 +98,16 @@ const Split = ({
   center,
   reverse,
   portrait,
-  aboveTheFold
+  aboveTheFold,
+  framed
 }) => {
   const background = bgColor || ''
   const flexDirection = reverse ? 'row-reverse' : ''
-  const bylinePosition = portrait ? reverse ? 'left' : 'right' : 'below'
+  const bylinePosition = framed ? 'belowFramed' : portrait ? reverse ? 'left' : 'right' : 'below'
   return (
     <div
       {...attributes}
-      {...css(styles.container, portrait ? styles.containerPortrait : {})}
+      {...css(framed ? styles.containerFramed : styles.container, portrait ? styles.containerPortrait : {})}
       onClick={onClick}
       style={{
         background,
@@ -95,7 +117,7 @@ const Split = ({
     >
       <div
         {...css(
-          styles.imageContainer,
+          framed ? styles.imageContainerFramed : styles.imageContainer,
           portrait ? styles.imageContainerPortrait : {}
         )}
       >

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -16,7 +16,7 @@ const styles = {
       padding: '70px 5%'
     }
   }),
-  containerFramed: css({
+  containerFrame: css({
     margin: 0,
     overflow: 'hidden',
     [mUp]: {
@@ -63,7 +63,7 @@ const styles = {
       width: '50%'
     }
   }),
-  imageContainerFramed: css({
+  imageContainerFrame: css({
     padding: '15px 15px 0 15px',
     position: 'relative',
     [mUp]: {
@@ -103,11 +103,11 @@ const Split = ({
 }) => {
   const background = bgColor || ''
   const flexDirection = reverse ? 'row-reverse' : ''
-  const bylinePosition = frame ? 'belowFramed' : portrait ? reverse ? 'left' : 'right' : 'below'
+  const bylinePosition = frame ? 'belowFrame' : portrait ? reverse ? 'left' : 'right' : 'below'
   return (
     <div
       {...attributes}
-      {...css(frame ? styles.containerFramed : styles.container, portrait ? styles.containerPortrait : {})}
+      {...css(frame ? styles.containerFrame : styles.container, portrait ? styles.containerPortrait : {})}
       onClick={onClick}
       style={{
         background,
@@ -117,7 +117,7 @@ const Split = ({
     >
       <div
         {...css(
-          frame ? styles.imageContainerFramed : styles.imageContainer,
+          frame ? styles.imageContainerFrame : styles.imageContainer,
           portrait ? styles.imageContainerPortrait : {}
         )}
       >

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -99,15 +99,15 @@ const Split = ({
   reverse,
   portrait,
   aboveTheFold,
-  framed
+  frame
 }) => {
   const background = bgColor || ''
   const flexDirection = reverse ? 'row-reverse' : ''
-  const bylinePosition = framed ? 'belowFramed' : portrait ? reverse ? 'left' : 'right' : 'below'
+  const bylinePosition = frame ? 'belowFramed' : portrait ? reverse ? 'left' : 'right' : 'below'
   return (
     <div
       {...attributes}
-      {...css(framed ? styles.containerFramed : styles.container, portrait ? styles.containerPortrait : {})}
+      {...css(frame ? styles.containerFramed : styles.container, portrait ? styles.containerPortrait : {})}
       onClick={onClick}
       style={{
         background,
@@ -117,7 +117,7 @@ const Split = ({
     >
       <div
         {...css(
-          framed ? styles.imageContainerFramed : styles.imageContainer,
+          frame ? styles.imageContainerFramed : styles.imageContainer,
           portrait ? styles.imageContainerPortrait : {}
         )}
       >

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -6,6 +6,7 @@ Supported props:
 - `bgColor`: The background color to use in stacked mode.
 - `portrait`: Whether to use the portrait layout.
 - `reverse`: Whether the layout should be reversed (i.e. the image appears to the right).
+- `frame`: Whether to use the canonical frame margins.
 
 A `<TeaserFrontSplitHeadline />` should be used.
 
@@ -153,7 +154,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 
 ```react
 <TeaserFrontSplit
-  framed
+  frame
   image='/static/rothaus_portrait.jpg'
   byline='Foto: Laurent Burst'
   color='#fff' bgColor='#000'>
@@ -170,7 +171,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 
 ```react
 <TeaserFrontSplit
-  framed
+  frame
   image='/static/rothaus_landscape.jpg'
   reverse
   byline='Foto: Laurent Burst'

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -150,7 +150,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 </TeaserFrontSplit>
 ```
 
-### Framed
+### Frame
 
 ```react
 <TeaserFrontSplit

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -11,6 +11,41 @@ A `<TeaserFrontSplitHeadline />` should be used.
 
 ```react
 <TeaserFrontSplit
+  even
+  image='/static/rothaus_portrait.jpg'
+  byline='Foto: Laurent Burst'
+  color='#fff' bgColor='#000'>
+  <Editorial.Format>Neutrum</Editorial.Format>
+  <TeaserFrontSplitHeadline.Editorial>Es ist kalt in Österreich</TeaserFrontSplitHeadline.Editorial>
+  <TeaserFrontLead>
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
+  </TeaserFrontLead>
+  <TeaserFrontCredit>
+    An article by <TeaserFrontCreditLink href='#' color='#fba'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+  </TeaserFrontCredit>
+</TeaserFrontSplit>
+```
+
+```react
+<TeaserFrontSplit
+  even
+  image='/static/rothaus_portrait.jpg'
+  reverse
+  byline='Foto: Laurent Burst'
+  color='#fff' bgColor='#000'>
+  <Editorial.Format>Neutrum</Editorial.Format>
+  <TeaserFrontSplitHeadline.Editorial>Es ist kalt in Österreich</TeaserFrontSplitHeadline.Editorial>
+  <TeaserFrontLead>
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
+  </TeaserFrontLead>
+  <TeaserFrontCredit>
+    An article by <TeaserFrontCreditLink href='#' color='#fba'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+  </TeaserFrontCredit>
+</TeaserFrontSplit>
+```
+
+```react
+<TeaserFrontSplit
   image='/static/rothaus_portrait.jpg?size=945x1331'
   portrait
   byline='Foto: Laurent Burst'
@@ -105,6 +140,43 @@ A `<TeaserFrontSplitHeadline />` should be used.
   color='#fff' bgColor='#000'>
   <Editorial.Format>Neutrum</Editorial.Format>
   <TeaserFrontSplitHeadline.Editorial large>Es ist kalt</TeaserFrontSplitHeadline.Editorial>
+  <TeaserFrontLead>
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
+  </TeaserFrontLead>
+  <TeaserFrontCredit>
+    An article by <TeaserFrontCreditLink href='#' color='#fba'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+  </TeaserFrontCredit>
+</TeaserFrontSplit>
+```
+
+### Framed
+
+```react
+<TeaserFrontSplit
+  framed
+  image='/static/rothaus_portrait.jpg'
+  byline='Foto: Laurent Burst'
+  color='#fff' bgColor='#000'>
+  <Editorial.Format>Neutrum</Editorial.Format>
+  <TeaserFrontSplitHeadline.Editorial>Es ist kalt in Österreich</TeaserFrontSplitHeadline.Editorial>
+  <TeaserFrontLead>
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
+  </TeaserFrontLead>
+  <TeaserFrontCredit>
+    An article by <TeaserFrontCreditLink href='#' color='#fba'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+  </TeaserFrontCredit>
+</TeaserFrontSplit>
+```
+
+```react
+<TeaserFrontSplit
+  framed
+  image='/static/rothaus_landscape.jpg'
+  reverse
+  byline='Foto: Laurent Burst'
+  color='#fff' bgColor='#000'>
+  <Editorial.Format>Neutrum</Editorial.Format>
+  <TeaserFrontSplitHeadline.Editorial>Es ist kalt in Österreich</TeaserFrontSplitHeadline.Editorial>
   <TeaserFrontLead>
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
   </TeaserFrontLead>

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -6,7 +6,7 @@ import { css } from 'glamor'
 const Subject = ({ children, color }) => {
   const style = css({
     color,
-    display: 'inline-block',
+    display: 'inline',
     minWidth: '100px'
   })
   return <Editorial.Subject {...style}>{children}</Editorial.Subject>

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -3,18 +3,23 @@ import PropTypes from 'prop-types'
 import { Editorial } from '../Typography'
 import { css } from 'glamor'
 
-const Subject = ({ children, color }) => {
+const Subject = ({ children, color, columns }) => {
   const style = css({
     color,
     display: 'inline',
     minWidth: '100px'
   })
-  return <Editorial.Subject {...style}>{children}</Editorial.Subject>
+  return (
+    <Editorial.Subject {...style} small={columns === 3}>
+      {children}
+    </Editorial.Subject>
+  )
 }
 
 Subject.propTypes = {
   children: PropTypes.node.isRequired,
-  color: PropTypes.string
+  color: PropTypes.string,
+  columns: PropTypes.number
 }
 
 Subject.defaultProps = {

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -1,17 +1,40 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Editorial } from '../Typography'
 import { css } from 'glamor'
 import { lab } from 'd3-color'
-import { tUp } from './mediaQueries'
+import { mUp, tUp } from './mediaQueries'
+import {
+  sansSerifRegular18,
+  sansSerifRegular19,
+  sansSerifRegular23
+} from '../Typography/styles'
 
-const Subject = ({ children, color, compactColor, columns }) => {
+const subjectStyle = {
+  ...sansSerifRegular19,
+  lineHeight: '27px',
+  [mUp]: {
+    ...sansSerifRegular23,
+  }
+}
+
+const subject = css({
+  ...subjectStyle
+})
+
+const subjectSmall = css({
+  ...subjectStyle,
+  [mUp]: {
+    ...sansSerifRegular18,
+    lineHeight: '24px'
+  }
+})
+
+const Subject = ({ children, color, collapsedColor, columns }) => {
   const labColor = lab(color)
-  const labCompactColor = lab(compactColor || color)
+  const labCompactColor = lab(collapsedColor || color)
 
   const style = css({
     color: labCompactColor.l > 50 ? labCompactColor.darker(0.6) : labCompactColor.brighter(3.0),
-    display: 'inline',
     marginRight: !!children.length ? '.5em' : 0,
     minWidth: '100px',
     [tUp]: {
@@ -19,16 +42,16 @@ const Subject = ({ children, color, compactColor, columns }) => {
     }
   })
   return (
-    <Editorial.Subject {...style} small={columns === 3}>
+    <span {...style} {...(columns === 3 ? subjectSmall : subject)}>
       {children}
-    </Editorial.Subject>
+    </span>
   )
 }
 
 Subject.propTypes = {
   children: PropTypes.node.isRequired,
   color: PropTypes.string,
-  compactColor: PropTypes.string,
+  collapsedColor: PropTypes.string,
   columns: PropTypes.number
 }
 

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Editorial } from '../Typography'
+import { css } from 'glamor'
+
+const Subject = ({ children, color }) => {
+  const style = css({
+    color,
+    display: 'inline-block',
+    minWidth: '100px'
+  })
+  return <Editorial.Subject {...style}>{children}</Editorial.Subject>
+}
+
+Subject.propTypes = {
+  children: PropTypes.node.isRequired,
+  color: PropTypes.string
+}
+
+Subject.defaultProps = {
+  color: '#8c8c8c'
+}
+
+export default Subject

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types'
 import { Editorial } from '../Typography'
 import { css } from 'glamor'
 import { lab } from 'd3-color'
-import { mUp, tUp } from './mediaQueries'
+import { tUp } from './mediaQueries'
 
 const Subject = ({ children, color, compactColor, columns }) => {
   const labColor = lab(color)
   const labCompactColor = lab(compactColor || color)
-  console.log(color, lab(color))
 
   const style = css({
     color: labCompactColor.l > 50 ? labCompactColor.darker(1.0) : labCompactColor.brighter(3.0),
     display: 'inline',
+    marginRight: !!children.length ? '.5em' : 0,
     minWidth: '100px',
     [tUp]: {
       color: labColor.l > 50 ? labColor.darker(2.0) : labColor.brighter(3.0),

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -10,7 +10,7 @@ const Subject = ({ children, color, compactColor, columns }) => {
   const labCompactColor = lab(compactColor || color)
 
   const style = css({
-    color: labCompactColor.l > 50 ? labCompactColor.darker(1.0) : labCompactColor.brighter(3.0),
+    color: labCompactColor.l > 50 ? labCompactColor.darker(0.6) : labCompactColor.brighter(3.0),
     display: 'inline',
     marginRight: !!children.length ? '.5em' : 0,
     minWidth: '100px',

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -2,12 +2,21 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Editorial } from '../Typography'
 import { css } from 'glamor'
+import { lab } from 'd3-color'
+import { mUp, tUp } from './mediaQueries'
 
-const Subject = ({ children, color, columns }) => {
+const Subject = ({ children, color, compactColor, columns }) => {
+  const labColor = lab(color)
+  const labCompactColor = lab(compactColor || color)
+  console.log(color, lab(color))
+
   const style = css({
-    color,
+    color: labCompactColor.l > 50 ? labCompactColor.darker(1.0) : labCompactColor.brighter(3.0),
     display: 'inline',
-    minWidth: '100px'
+    minWidth: '100px',
+    [tUp]: {
+      color: labColor.l > 50 ? labColor.darker(2.0) : labColor.brighter(3.0),
+    }
   })
   return (
     <Editorial.Subject {...style} small={columns === 3}>
@@ -19,11 +28,12 @@ const Subject = ({ children, color, columns }) => {
 Subject.propTypes = {
   children: PropTypes.node.isRequired,
   color: PropTypes.string,
+  compactColor: PropTypes.string,
   columns: PropTypes.number
 }
 
 Subject.defaultProps = {
-  color: '#8c8c8c'
+  //color: '#8c8c8c'
 }
 
 export default Subject

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -32,8 +32,4 @@ Subject.propTypes = {
   columns: PropTypes.number
 }
 
-Subject.defaultProps = {
-  //color: '#8c8c8c'
-}
-
 export default Subject

--- a/src/components/TeaserFront/Text.js
+++ b/src/components/TeaserFront/Text.js
@@ -134,6 +134,7 @@ Text.propTypes = {
     'bottom'
   ]),
   color: PropTypes.string,
+  compactColor: PropTypes.string,
   maxWidth: PropTypes.string,
   margin: PropTypes.string
 }

--- a/src/components/TeaserFront/Text.js
+++ b/src/components/TeaserFront/Text.js
@@ -92,7 +92,7 @@ const Text = ({
   position,
   center,
   color,
-  compactColor,
+  collapsedColor,
   maxWidth,
   margin
 }) => {
@@ -100,8 +100,8 @@ const Text = ({
   const rootStyles = position ? styles.rootPosition : {}
   const middleStyles = position === 'middle' ? styles.rootMiddle : {}
 
-  const colorStyle = compactColor && css({
-    color: compactColor,
+  const colorStyle = collapsedColor && css({
+    color: collapsedColor,
     [tUp]: {
       color
     }
@@ -113,7 +113,7 @@ const Text = ({
         {...attributes}
         {...colorStyle}
         {...css(styles.positioned, position ? styles[position] : {})}
-        style={{ color: !compactColor && color, textAlign, maxWidth, margin }}
+        style={{ color: !collapsedColor && color, textAlign, maxWidth, margin }}
       >
         {children}
       </div>
@@ -134,7 +134,7 @@ Text.propTypes = {
     'bottom'
   ]),
   color: PropTypes.string,
-  compactColor: PropTypes.string,
+  collapsedColor: PropTypes.string,
   maxWidth: PropTypes.string,
   margin: PropTypes.string
 }

--- a/src/components/TeaserFront/Text.js
+++ b/src/components/TeaserFront/Text.js
@@ -96,7 +96,7 @@ const Text = ({
   maxWidth,
   margin
 }) => {
-  const textAlign = center ? 'center' : ''
+  const textAlign = center ? 'center' : undefined
   const rootStyles = position ? styles.rootPosition : {}
   const middleStyles = position === 'middle' ? styles.rootMiddle : {}
 
@@ -113,7 +113,7 @@ const Text = ({
         {...attributes}
         {...colorStyle}
         {...css(styles.positioned, position ? styles[position] : {})}
-        style={{ color: !collapsedColor && color, textAlign, maxWidth, margin }}
+        style={{ color: !collapsedColor ? color : undefined, textAlign, maxWidth, margin }}
       >
         {children}
       </div>

--- a/src/components/TeaserFront/Text.js
+++ b/src/components/TeaserFront/Text.js
@@ -92,18 +92,28 @@ const Text = ({
   position,
   center,
   color,
+  compactColor,
   maxWidth,
   margin
 }) => {
   const textAlign = center ? 'center' : ''
   const rootStyles = position ? styles.rootPosition : {}
   const middleStyles = position === 'middle' ? styles.rootMiddle : {}
+
+  const colorStyle = compactColor && css({
+    color: compactColor,
+    [tUp]: {
+      color
+    }
+  })
+
   return (
     <div {...rootStyles} {...middleStyles}>
       <div
         {...attributes}
+        {...colorStyle}
         {...css(styles.positioned, position ? styles[position] : {})}
-        style={{ color, textAlign, maxWidth, margin }}
+        style={{ color: !compactColor && color, textAlign, maxWidth, margin }}
       >
         {children}
       </div>
@@ -123,7 +133,7 @@ Text.propTypes = {
     'middle',
     'bottom'
   ]),
-  textColor: PropTypes.string,
+  color: PropTypes.string,
   maxWidth: PropTypes.string,
   margin: PropTypes.string
 }

--- a/src/components/TeaserFront/TileHeadline.js
+++ b/src/components/TeaserFront/TileHeadline.js
@@ -1,17 +1,23 @@
 import React from 'react'
 import { css } from 'glamor'
-import { mUp } from './mediaQueries'
+import { mUp, tUp } from './mediaQueries'
 import { serifTitle20, sansSerifMedium20 } from '../Typography/styles'
 
 const smallSize = {
   fontSize: '26px',
-  lineHeight: '28px',
+  lineHeight: '32px',
   marginBottom: '16px'
 }
 
 const mediumSize = {
   fontSize: '32px',
-  lineHeight: '34px',
+  lineHeight: '37px',
+  marginBottom: '25px'
+}
+
+const defaultSize = {
+  fontSize: '48px',
+  lineHeight: '54px',
   marginBottom: '25px'
 }
 
@@ -23,14 +29,34 @@ const styles = {
       marginBottom: 8
     }
   }),
-  editorial: css({
+  editorialCol2: css({
+    ...serifTitle20,
+    ...smallSize,
+    [mUp]: {
+      ...mediumSize
+    },
+    [tUp]: {
+      ...defaultSize
+    }
+  }),
+  editorialCol3: css({
     ...serifTitle20,
     ...smallSize,
     [mUp]: {
       ...mediumSize
     }
   }),
-  interaction: css({
+  interactionCol2: css({
+    ...sansSerifMedium20,
+    ...smallSize,
+    [mUp]: {
+      ...mediumSize
+    },
+    [tUp]: {
+      ...defaultSize
+    }
+  }),
+  interactionCol3: css({
     ...sansSerifMedium20,
     ...smallSize,
     [mUp]: {
@@ -39,17 +65,19 @@ const styles = {
   })
 }
 
-export const Editorial = ({ children }) => {
+export const Editorial = ({ children, columns }) => {
+  const style = columns === 3 ? styles.editorialCol3 : styles.editorialCol2
   return (
-    <h1 {...styles.base} {...styles.editorial}>
+    <h1 {...styles.base} {...style}>
       {children}
     </h1>
   )
 }
 
-export const Interaction = ({ children }) => {
+export const Interaction = ({ children, columns }) => {
+  const style = columns === 3 ? styles.interactionCol3 : styles.interactionCol2
   return (
-    <h1 {...styles.base} {...styles.interaction}>
+    <h1 {...styles.base} {...style}>
       {children}
     </h1>
   )

--- a/src/components/TeaserFront/index.js
+++ b/src/components/TeaserFront/index.js
@@ -14,5 +14,6 @@ export { default as TeaserFrontSplit } from './Split'
 export { default as TeaserFrontTile, TeaserFrontTileRow } from './Tile'
 
 export { default as TeaserFrontLead } from './Lead'
+export { default as TeaserFrontSubject } from './Subject'
 export { default as TeaserFrontCredit } from './Credit'
 export { default as TeaserFrontCreditLink } from './CreditLink'

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -53,7 +53,7 @@ const lead = css({
   ...styles.serifRegular19,
   margin: '0 0 10px 0',
   [mUp]: {
-    ...styles.serifRegular23,
+    ...styles.serifRegular22,
     margin: '0 0 20px 0'
   },
   color: colors.text
@@ -65,11 +65,26 @@ export const Lead = ({ children, attributes, ...props }) => (
   </p>
 )
 
+const subject = css({
+  margin: '0 .5em 0 0',
+  ...styles.sansSerifRegular19,
+  [mUp]: {
+    ...styles.sansSerifRegular22,
+  }
+})
+
+export const Subject = ({ children, attributes, ...props }) => (
+  <p {...attributes} {...props} {...subject}>
+    {children}
+  </p>
+)
+
 const credit = css({
-  margin: 0,
+  margin: '10px 0 0 0',
   ...styles.sansSerifRegular14,
   [mUp]: {
-    ...styles.sansSerifRegular15
+    ...styles.sansSerifRegular15,
+    margin: '20px 0 0 0'
   },
   color: colors.text
 })

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -78,7 +78,6 @@ export const Lead = ({ children, attributes, small, ...props }) => (
 )
 
 const subjectStyle = {
-  margin: '0 .5em 0 0',
   ...styles.sansSerifRegular19,
   lineHeight: '27px',
   [mUp]: {

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -50,7 +50,7 @@ export const Subhead = ({ children, attributes, ...props }) => (
 )
 
 const lead = css({
- ...styles.serifRegular19,
+  ...styles.serifRegular19,
   margin: '0 0 10px 0',
   [mUp]: {
     ...styles.serifRegular23,

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -49,58 +49,20 @@ export const Subhead = ({ children, attributes, ...props }) => (
   </h2>
 )
 
-const leadStyle = {
-  ...styles.serifRegular19,
-  lineHeight: '27px',
+const lead = css({
+ ...styles.serifRegular19,
   margin: '0 0 10px 0',
   [mUp]: {
-    ...styles.serifRegular22,
+    ...styles.serifRegular23,
     margin: '0 0 20px 0'
   },
   color: colors.text
-}
-
-const lead = css({
-  ...leadStyle
 })
 
-const leadSmall = css({
-  ...leadStyle,
-  [mUp]: {
-    ...styles.serifRegular18
-  }
-})
-
-export const Lead = ({ children, attributes, small, ...props }) => (
-  <span {...attributes} {...props} {...(small ? leadSmall : lead)}>
+export const Lead = ({ children, attributes, ...props }) => (
+  <p {...attributes} {...props} {...lead}>
     {children}
-  </span>
-)
-
-const subjectStyle = {
-  ...styles.sansSerifRegular19,
-  lineHeight: '27px',
-  [mUp]: {
-    ...styles.sansSerifRegular22,
-  }
-}
-
-const subject = css({
-  ...subjectStyle
-})
-
-const subjectSmall = css({
-  ...subjectStyle,
-  [mUp]: {
-    ...styles.sansSerifRegular18,
-    lineHeight: '24px'
-  }
-})
-
-export const Subject = ({ children, attributes, small, ...props }) => (
-  <span {...attributes} {...props} {...(small ? subjectSmall : subject)}>
-    {children}
-  </span>
+  </p>
 )
 
 const credit = css({

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -49,7 +49,7 @@ export const Subhead = ({ children, attributes, ...props }) => (
   </h2>
 )
 
-const lead = css({
+const leadStyle = {
   ...styles.serifRegular19,
   lineHeight: '27px',
   margin: '0 0 10px 0',
@@ -58,25 +58,48 @@ const lead = css({
     margin: '0 0 20px 0'
   },
   color: colors.text
+}
+
+const lead = css({
+  ...leadStyle
 })
 
-export const Lead = ({ children, attributes, ...props }) => (
-  <span {...attributes} {...props} {...lead}>
+const leadSmall = css({
+  ...leadStyle,
+  [mUp]: {
+    ...styles.serifRegular18
+  }
+})
+
+export const Lead = ({ children, attributes, small, ...props }) => (
+  <span {...attributes} {...props} {...(small ? leadSmall : lead)}>
     {children}
   </span>
 )
 
-const subject = css({
+const subjectStyle = {
   margin: '0 .5em 0 0',
   ...styles.sansSerifRegular19,
   lineHeight: '27px',
   [mUp]: {
     ...styles.sansSerifRegular22,
   }
+}
+
+const subject = css({
+  ...subjectStyle
 })
 
-export const Subject = ({ children, attributes, ...props }) => (
-  <span {...attributes} {...props} {...subject}>
+const subjectSmall = css({
+  ...subjectStyle,
+  [mUp]: {
+    ...styles.sansSerifRegular18,
+    lineHeight: '24px'
+  }
+})
+
+export const Subject = ({ children, attributes, small, ...props }) => (
+  <span {...attributes} {...props} {...(small ? subjectSmall : subject)}>
     {children}
   </span>
 )

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -60,9 +60,9 @@ const lead = css({
 })
 
 export const Lead = ({ children, attributes, ...props }) => (
-  <p {...attributes} {...props} {...lead}>
+  <span {...attributes} {...props} {...lead}>
     {children}
-  </p>
+  </span>
 )
 
 const subject = css({
@@ -74,9 +74,9 @@ const subject = css({
 })
 
 export const Subject = ({ children, attributes, ...props }) => (
-  <p {...attributes} {...props} {...subject}>
+  <span {...attributes} {...props} {...subject}>
     {children}
-  </p>
+  </span>
 )
 
 const credit = css({

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -51,6 +51,7 @@ export const Subhead = ({ children, attributes, ...props }) => (
 
 const lead = css({
   ...styles.serifRegular19,
+  lineHeight: '27px',
   margin: '0 0 10px 0',
   [mUp]: {
     ...styles.serifRegular22,
@@ -68,6 +69,7 @@ export const Lead = ({ children, attributes, ...props }) => (
 const subject = css({
   margin: '0 .5em 0 0',
   ...styles.sansSerifRegular19,
+  lineHeight: '27px',
   [mUp]: {
     ...styles.sansSerifRegular22,
   }

--- a/src/components/Typography/docs.md
+++ b/src/components/Typography/docs.md
@@ -92,12 +92,12 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 <div {...css(styles.serifBold16)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
-#### `serifRegular{25,22,21,19,18,16,14}`
+#### `serifRegular{25,23,21,19,18,16,14}`
 ```react|noSource,plain
 <div {...css(styles.serifRegular25)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
-<div {...css(styles.serifRegular22)}>The quick brown fox jumps over the lazy dog</div>
+<div {...css(styles.serifRegular23)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
 <div {...css(styles.serifRegular21)}>The quick brown fox jumps over the lazy dog</div>
@@ -141,12 +141,12 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 <div {...css(styles.sansSerifMedium16)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
-#### `sansSerifRegular{30,22,18,16,15,14,12,11,10}`
+#### `sansSerifRegular{30,23,21,18,16,15,14,12,11,10}`
 ```react|noSource,plain
 <div {...css(styles.sansSerifRegular30)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
-<div {...css(styles.sansSerifRegular22)}>The quick brown fox jumps over the lazy dog</div>
+<div {...css(styles.sansSerifRegular23)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
 <div {...css(styles.sansSerifRegular21)}>The quick brown fox jumps over the lazy dog</div>

--- a/src/components/Typography/docs.md
+++ b/src/components/Typography/docs.md
@@ -92,12 +92,12 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 <div {...css(styles.serifBold16)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
-#### `serifRegular{25,23,21,19,18,16,14}`
+#### `serifRegular{25,22,21,19,18,16,14}`
 ```react|noSource,plain
 <div {...css(styles.serifRegular25)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
-<div {...css(styles.serifRegular23)}>The quick brown fox jumps over the lazy dog</div>
+<div {...css(styles.serifRegular22)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
 <div {...css(styles.serifRegular21)}>The quick brown fox jumps over the lazy dog</div>
@@ -141,9 +141,12 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 <div {...css(styles.sansSerifMedium16)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
-#### `sansSerifRegular{30,21,18,16,15,14,12,11,10}`
+#### `sansSerifRegular{30,22,18,16,15,14,12,11,10}`
 ```react|noSource,plain
 <div {...css(styles.sansSerifRegular30)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.sansSerifRegular22)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
 <div {...css(styles.sansSerifRegular21)}>The quick brown fox jumps over the lazy dog</div>

--- a/src/components/Typography/styles.js
+++ b/src/components/Typography/styles.js
@@ -63,10 +63,10 @@ export const serifRegular25 = {
   fontSize: 25,
   lineHeight: '33px'
 }
-export const serifRegular22 = {
+export const serifRegular23 = {
   fontFamily: fontFamilies.serifRegular,
-  fontSize: 22,
-  lineHeight: '28px'
+  fontSize: 23,
+  lineHeight: '30px'
 }
 export const serifRegular21 = {
   fontFamily: fontFamilies.serifRegular,
@@ -148,10 +148,10 @@ export const sansSerifRegular30 = {
   lineHeight: '35px',
   letterSpacing: -0.26,
 }
-export const sansSerifRegular22 = {
+export const sansSerifRegular23 = {
   fontFamily: fontFamilies.sansSerifRegular,
-  fontSize: 22,
-  lineHeight: '28px'
+  fontSize: 23,
+  lineHeight: '30px'
 }
 export const sansSerifRegular21 = {
   fontFamily: fontFamilies.sansSerifRegular,

--- a/src/components/Typography/styles.js
+++ b/src/components/Typography/styles.js
@@ -63,10 +63,10 @@ export const serifRegular25 = {
   fontSize: 25,
   lineHeight: '33px'
 }
-export const serifRegular23 = {
+export const serifRegular22 = {
   fontFamily: fontFamilies.serifRegular,
-  fontSize: 23,
-  lineHeight: '30px'
+  fontSize: 22,
+  lineHeight: '28px'
 }
 export const serifRegular21 = {
   fontFamily: fontFamilies.serifRegular,
@@ -147,6 +147,11 @@ export const sansSerifRegular30 = {
   fontSize: 30,
   lineHeight: '35px',
   letterSpacing: -0.26,
+}
+export const sansSerifRegular22 = {
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontSize: 22,
+  lineHeight: '28px'
 }
 export const sansSerifRegular21 = {
   fontFamily: fontFamilies.sansSerifRegular,

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -32,6 +32,8 @@ import {
   DossierTileLead
 } from '../../components/Dossier'
 
+import { subject } from '../Front'
+
 import { Breakout } from '../../components/Center'
 
 import * as Editorial from '../../components/Typography/Editorial'
@@ -178,6 +180,7 @@ const createTeasers = ({
           )
         }
       ),
+      subject,
       articleTileLead,
       teaserFormat,
       teaserCredit

--- a/src/templates/Article/utils.js
+++ b/src/templates/Article/utils.js
@@ -27,6 +27,7 @@ export const matchFigure = matchZone('FIGURE')
 
 export const matchLast = (node, index, parent) => index === parent.children.length - 1
 export const matchTeaser = matchZone('TEASER')
+export const matchTeaserGroup = matchZone('TEASERGROUP')
 export const matchTeaserType = teaserType =>
   node => matchTeaser(node) && node.data.teaserType === teaserType
 export const extractImage = node => matchImageParagraph(node)

--- a/src/templates/Format/index.js
+++ b/src/templates/Format/index.js
@@ -33,7 +33,8 @@ const createSchema = ({
         items: [
           {value: 'editorial', text: 'Editorial'},
           {value: 'meta', text: 'Meta'},
-          {value: 'scribble', text: 'Ameise'}
+          {value: 'scribble', text: 'Ameise'},
+          {value: 'feuilleton', text: 'Feuilleton'}
         ]
       },
       {

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -98,7 +98,7 @@ Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
   "bgColor": "#ffffff",
   "byline": "Foto: Laurent Burst",
   "center": false,
-  "color": "#000",
+  "color": "#000000",
   "kind": "editorial",
   "portrait": true,
   "reverse": false,

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -45,6 +45,8 @@ This will be wrapped around and links (headlines and credits) and the whole teas
 
 # Welt-Bilder
 
+## Premiere im Rothaus
+
 #### Und es war ihnen wie eine Bestätigung ihrer neuen Träume und guten Absichten.
 
 Foto: [Thomas Vuillemin on Unsplash](https://unsplash.com/photos/c1_K8Qfd_iQ)
@@ -96,7 +98,7 @@ Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
   "bgColor": "#ffffff",
   "byline": "Foto: Laurent Burst",
   "center": false,
-  "color": "#000000",
+  "color": "#000",
   "kind": "editorial",
   "portrait": true,
   "reverse": false,
@@ -112,6 +114,8 @@ Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 ###### Echte Republikaner
 
 # Mavie
+
+## Premiere im Rothaus
 
 #### Republik-Verlegerin, 8 Monate
 

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -45,7 +45,7 @@ This will be wrapped around and links (headlines and credits) and the whole teas
 
 # Welt-Bilder
 
-## Premiere im Rothaus
+### Premiere im Rothaus
 
 #### Und es war ihnen wie eine Bestätigung ihrer neuen Träume und guten Absichten.
 
@@ -115,7 +115,7 @@ Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 # Mavie
 
-## Premiere im Rothaus
+### Premiere im Rothaus
 
 #### Republik-Verlegerin, 8 Monate
 

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -139,7 +139,7 @@ const createSchema = ({
       const teaser = ancestors.find(matchTeaser)
       return {
         color: teaser && teaser.data.color,
-        compactColor: teaser && teaser.data.framed && '#000',
+        collapsedColor: teaser && teaser.data.frame && '#000',
         columns:  teaserGroup ? teaserGroup.data.columns : undefined
       }
     },
@@ -231,7 +231,7 @@ const createSchema = ({
         'image',
         'byline',
         'onlyImage',
-        'framed'
+        'frame'
       ]
     },
     rules: [
@@ -288,7 +288,7 @@ const createSchema = ({
         'titleSize',
         'reverse',
         'portrait',
-        'framed'
+        'frame'
       ]
     },
     rules: [

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -23,7 +23,8 @@ import {
   TeaserFrontTileRow,
   TeaserFrontLead,
   TeaserFrontCredit,
-  TeaserFrontCreditLink
+  TeaserFrontCreditLink,
+  TeaserFrontSubject
 } from '../../components/TeaserFront'
 
 import {
@@ -122,6 +123,30 @@ const createSchema = ({
     rules: globalInlines
   })
 
+  const subject = {
+    matchMdast: matchHeading(2),
+    component: ({ children, attributes, ...props }) =>
+      <TeaserFrontSubject attributes={attributes} {...props}>
+        {children}
+      </TeaserFrontSubject>,
+    props: (node, index, parent, { ancestors }) => {
+      const teaser = ancestors.find(matchTeaser)
+      return {
+        color: teaser && teaser.data.color !== colors.primary && teaser.data.color !== '#000'
+          ? teaser.data.color
+          : undefined
+      }
+    },
+    editorModule: 'headline',
+    editorOptions: {
+      type: 'FRONTSUBJECT',
+      placeholder: 'Subject',
+      depth: 2,
+      isStatic: true
+    },
+    rules: globalInlines
+  }
+
   const lead = {
     matchMdast: matchHeading(4),
     component: ({ children, attributes }) =>
@@ -214,6 +239,7 @@ const createSchema = ({
           </Component>
         }
       ),
+      subject,
       lead,
       format,
       credit
@@ -268,6 +294,7 @@ const createSchema = ({
           </Component>
         }
       ),
+      subject,
       lead,
       format,
       credit
@@ -316,6 +343,7 @@ const createSchema = ({
           </Component>
         }
       ),
+      subject,
       lead,
       format,
       credit
@@ -370,6 +398,7 @@ const createSchema = ({
           )
         }
       ),
+      subject,
       lead,
       format,
       credit
@@ -453,6 +482,7 @@ const createSchema = ({
           )
         }
       ),
+      subject,
       articleTileLead,
       format,
       credit

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -124,7 +124,7 @@ const createSchema = ({
   })
 
   const subject = {
-    matchMdast: matchHeading(2),
+    matchMdast: matchHeading(3),
     component: ({ children, attributes, ...props }) =>
       <TeaserFrontSubject attributes={attributes} {...props}>
         {children}
@@ -144,7 +144,7 @@ const createSchema = ({
     editorOptions: {
       type: 'FRONTSUBJECT',
       placeholder: 'Subject',
-      depth: 2,
+      depth: 3,
       isStatic: true
     },
     rules: globalInlines

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -53,6 +53,31 @@ const image = {
   isVoid: true
 }
 
+export const subject = {
+  matchMdast: matchHeading(3),
+  component: ({ children, attributes, ...props }) =>
+    <TeaserFrontSubject attributes={attributes} {...props}>
+      {children}
+    </TeaserFrontSubject>,
+  props: (node, index, parent, { ancestors }) => {
+    const teaserGroup = ancestors.find(matchTeaserGroup)
+    const teaser = ancestors.find(matchTeaser)
+    return {
+      color: teaser && teaser.data.color,
+      collapsedColor: teaser && teaser.data.frame && '#000',
+      columns:  teaserGroup ? teaserGroup.data.columns : undefined
+    }
+  },
+  editorModule: 'headline',
+  editorOptions: {
+    type: 'FRONTSUBJECT',
+    placeholder: 'Subject',
+    depth: 3,
+    isStatic: true
+  },
+  rules: globalInlines
+}
+
 const DefaultLink = ({ children }) => children
 
 const createSchema = ({
@@ -127,31 +152,6 @@ const createSchema = ({
     },
     rules: globalInlines
   })
-
-  const subject = {
-    matchMdast: matchHeading(3),
-    component: ({ children, attributes, ...props }) =>
-      <TeaserFrontSubject attributes={attributes} {...props}>
-        {children}
-      </TeaserFrontSubject>,
-    props: (node, index, parent, { ancestors }) => {
-      const teaserGroup = ancestors.find(matchTeaserGroup)
-      const teaser = ancestors.find(matchTeaser)
-      return {
-        color: teaser && teaser.data.color,
-        collapsedColor: teaser && teaser.data.frame && '#000',
-        columns:  teaserGroup ? teaserGroup.data.columns : undefined
-      }
-    },
-    editorModule: 'headline',
-    editorOptions: {
-      type: 'FRONTSUBJECT',
-      placeholder: 'Subject',
-      depth: 3,
-      isStatic: true
-    },
-    rules: globalInlines
-  }
 
   const lead = {
     matchMdast: matchHeading(4),

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -132,7 +132,10 @@ const createSchema = ({
     props: (node, index, parent, { ancestors }) => {
       const teaser = ancestors.find(matchTeaser)
       return {
-        color: teaser && teaser.data.color !== colors.primary && teaser.data.color !== '#000'
+        color: teaser
+          && teaser.data.color !== colors.primary
+          && teaser.data.color !== '#000'
+          && teaser.data.color !== '#000000'
           ? teaser.data.color
           : undefined
       }

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -40,6 +40,7 @@ import {
 
 import {
   matchTeaser,
+  matchTeaserGroup,
   matchTeaserType,
   extractImage,
   globalInlines,
@@ -130,12 +131,14 @@ const createSchema = ({
         {children}
       </TeaserFrontSubject>,
     props: (node, index, parent, { ancestors }) => {
+      const teaserGroup = ancestors.find(matchTeaserGroup)
       const teaser = ancestors.find(matchTeaser)
       return {
         color: teaser
           && [colors.primary, '#000', '#000000'].indexOf(teaser.data.color) === -1
           ? teaser.data.color
-          : undefined  // fall back to component's default color
+          : undefined,  // fall back to component's default color
+        columns:  teaserGroup ? teaserGroup.data.columns : undefined
       }
     },
     editorModule: 'headline',
@@ -150,10 +153,16 @@ const createSchema = ({
 
   const lead = {
     matchMdast: matchHeading(4),
-    component: ({ children, attributes }) =>
-      <TeaserFrontLead attributes={attributes}>
+    component: ({ children, attributes, ...props }) =>
+      <TeaserFrontLead attributes={attributes} {...props}>
         {children}
       </TeaserFrontLead>,
+    props: (node, index, parent, { ancestors }) => {
+      const teaserGroup = ancestors.find(matchTeaserGroup)
+      return {
+        columns:  teaserGroup ? teaserGroup.data.columns : undefined
+      }
+    },
     editorModule: 'headline',
     editorOptions: {
       type: 'FRONTLEAD',

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -106,11 +106,15 @@ const createSchema = ({
       </Link>,
     props (node, index, parent, { ancestors }) {
       const teaser = ancestors.find(matchTeaser)
+      const teaserGroup = ancestors.find(matchTeaserGroup)
       return {
         kind: parent.data.kind,
         titleSize: parent.data.titleSize,
         href: teaser
           ? teaser.data.url
+          : undefined,
+        columns: teaserGroup
+          ? teaserGroup.data.columns
           : undefined
       }
     },
@@ -397,12 +401,12 @@ const createSchema = ({
       image,
       title(
         'FRONTTILETITLE',
-        ({ children, attributes, kind }) => {
+        ({ children, attributes, kind, columns }) => {
           const Component = kind === 'editorial'
           ? TeaserFrontTileHeadline.Editorial
           : TeaserFrontTileHeadline.Interaction
           return (
-            <Component attributes={attributes}>
+            <Component attributes={attributes} columns={columns}>
               {children}
             </Component>
           )

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -133,11 +133,9 @@ const createSchema = ({
       const teaser = ancestors.find(matchTeaser)
       return {
         color: teaser
-          && teaser.data.color !== colors.primary
-          && teaser.data.color !== '#000'
-          && teaser.data.color !== '#000000'
+          && [colors.primary, '#000', '#000000'].indexOf(teaser.data.color) === -1
           ? teaser.data.color
-          : undefined
+          : undefined  // fall back to component's default color
       }
     },
     editorModule: 'headline',

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -138,10 +138,8 @@ const createSchema = ({
       const teaserGroup = ancestors.find(matchTeaserGroup)
       const teaser = ancestors.find(matchTeaser)
       return {
-        color: teaser
-          && [colors.primary, '#000', '#000000'].indexOf(teaser.data.color) === -1
-          ? teaser.data.color
-          : undefined,  // fall back to component's default color
+        color: teaser && teaser.data.color,
+        compactColor: teaser && teaser.data.framed && '#000',
         columns:  teaserGroup ? teaserGroup.data.columns : undefined
       }
     },
@@ -232,7 +230,8 @@ const createSchema = ({
         'titleSize',
         'image',
         'byline',
-        'onlyImage'
+        'onlyImage',
+        'framed'
       ]
     },
     rules: [
@@ -288,7 +287,8 @@ const createSchema = ({
         'kind',
         'titleSize',
         'reverse',
-        'portrait'
+        'portrait',
+        'framed'
       ]
     },
     rules: [


### PR DESCRIPTION
Main changes:
- optional `subject` element in front of lead
- a `framed` variant of FrontImage (container margin and switch to black headline in stacked mode)
- a `framed` variant of FrontSplit (basically the existing non-portrait teaser with adjusted margins)
- FrontTile updates for three tiles in a row: smaller headline and subject/lead font sizes

FYI, Luki's request for this was having the `subject` (better names welcome) as a block-level element on the markdown level in Publikator. That's why subject + lead have turned into inline elements. Open for better suggestions.

### The `subject` element in a nutshell:
- Will use H3 on the markdown level (placed between title and lead)
- It's optional and shall be used in Feuilleton teasers only
- All front teaser leads will use 22px on desktop now
- Subject and lead are inline elements now
- Design's gray by default
- Will adapt to teaser color if set and !== black (uncommon use case since feuilleton will typically be black on white) 

### Usage examples (note the light gray text in front of the leads):

#### Desktop
![screen shot 2018-08-08 at 14 40 53](https://user-images.githubusercontent.com/23520051/43837529-19cd37d4-9b19-11e8-910f-5c1431a0f42e.png)

![screen shot 2018-08-13 at 10 51 30](https://user-images.githubusercontent.com/23520051/44022068-e14fd354-9ee6-11e8-9a69-75e01f910285.png)

![screen shot 2018-08-13 at 10 59 46](https://user-images.githubusercontent.com/23520051/44022506-0dab61b0-9ee8-11e8-98b8-51c2055ef906.png)

#### Mobile
![screen shot 2018-08-07 at 17 15 40](https://user-images.githubusercontent.com/23520051/43784931-91e48a56-9a65-11e8-8f5b-c902cd6e77bd.png)

![screen shot 2018-08-13 at 10 52 30](https://user-images.githubusercontent.com/23520051/44022127-0619e300-9ee7-11e8-8ee3-2d71cc2966d2.png)

![screen shot 2018-08-13 at 11 00 37](https://user-images.githubusercontent.com/23520051/44022527-20de70ec-9ee8-11e8-9c7e-8342f1af2290.png)

#### Styleguide
<img width="937" alt="screen shot 2018-08-13 at 11 09 41" src="https://user-images.githubusercontent.com/23520051/44022968-7832513c-9ee9-11e8-9b34-af22811c8d7d.png">

