### PR TITLE
feat(VideoPlayer): isCinemagraph flag

### DIFF
--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -171,7 +171,11 @@ class VideoPlayer extends Component {
       }))
     }
     this.onVolumeChange = () => {
-      if (!this.props.forceMuted && globalState.muted !== this.video.muted) {
+      if (
+        !this.props.forceMuted &&
+        !this.props.cinemagraph &&
+        globalState.muted !== this.video.muted
+      ) {
         this.setMuted(this.video.muted)
       }
     }
@@ -330,10 +334,10 @@ class VideoPlayer extends Component {
     this.state.fullscreen && this.state.fullscreen.dispose()
   }
   render() {
-    const { src, showPlay, size, forceMuted, autoPlay, loop, isCinemagraph, attributes = {} } = this.props
+    const { src, showPlay, size, forceMuted, autoPlay, loop, cinemagraph, attributes = {} } = this.props
     const { playing, progress, muted, subtitles, loading, fullscreen, isFullscreen } = this.state
 
-    const cinemagraphAttributes = isCinemagraph ? {
+    const cinemagraphAttributes = cinemagraph ? {
       loop: true,
       muted: true,
       autoPlay: true,
@@ -408,7 +412,7 @@ class VideoPlayer extends Component {
                 <Subtitles off={!subtitles} />
               </span>
             )}{' '}
-            {forceMuted === undefined && !isCinemagraph && <span
+            {forceMuted === undefined && !cinemagraph && <span
               role="button"
               title={`Audio ${muted ? 'aus' : 'an'}`}
               onClick={e => {
@@ -435,7 +439,7 @@ class VideoPlayer extends Component {
             )}
           </div>
         </div>
-        {!isCinemagraph && <Fragment>
+        {!cinemagraph && <Fragment>
           <div {...styles.progress} style={{ width: `${progress * 100}%` }} />
           <div
             {...styles.scrub}
@@ -472,6 +476,7 @@ CrossOrigin subtitles do not work in older browsers.'`
   loop: PropTypes.bool,
   // ignores global muted state and sets muted
   forceMuted: PropTypes.bool,
+  cinemagraph: PropTypes.bool,
   // arbitrary attributes like playsinline, specific ones win
   attributes: PropTypes.object
 }

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -333,13 +333,20 @@ class VideoPlayer extends Component {
     const { src, showPlay, size, forceMuted, autoPlay, loop, attributes = {} } = this.props
     const { playing, progress, muted, subtitles, loading, fullscreen, isFullscreen } = this.state
 
+    // iOS autoplay fix.
+    const patchedAttributes = autoPlay ? {
+      ...attributes,
+      playsInline: true,
+      'webkit-playsinline': ''
+    } : attributes
+
     return (
       <div {...merge(styles.wrapper, breakoutStyles[size])}
         onClick={this.captureFocus}
       >
         <video
           {...(isFullscreen ? styles.videoFullscreen : styles.video)}
-          {...attributes}
+          {...patchedAttributes}
           style={this.props.style}
           autoPlay={autoPlay}
           muted={forceMuted !== undefined ? forceMuted : muted}

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import colors from '../../theme/colors'
 import { css, merge } from 'glamor'
@@ -330,15 +330,16 @@ class VideoPlayer extends Component {
     this.state.fullscreen && this.state.fullscreen.dispose()
   }
   render() {
-    const { src, showPlay, size, forceMuted, autoPlay, loop, attributes = {} } = this.props
+    const { src, showPlay, size, forceMuted, autoPlay, loop, isCinemagraph, attributes = {} } = this.props
     const { playing, progress, muted, subtitles, loading, fullscreen, isFullscreen } = this.state
 
-    // iOS autoplay fix.
-    const patchedAttributes = autoPlay ? {
-      ...attributes,
+    const cinemagraphAttributes = isCinemagraph ? {
+      loop: true,
+      muted: true,
+      autoPlay: true,
       playsInline: true,
       'webkit-playsinline': ''
-    } : attributes
+    } : {}
 
     return (
       <div {...merge(styles.wrapper, breakoutStyles[size])}
@@ -346,11 +347,12 @@ class VideoPlayer extends Component {
       >
         <video
           {...(isFullscreen ? styles.videoFullscreen : styles.video)}
-          {...patchedAttributes}
+          {...attributes}
           style={this.props.style}
           autoPlay={autoPlay}
           muted={forceMuted !== undefined ? forceMuted : muted}
           loop={loop}
+          {...cinemagraphAttributes}
           ref={this.ref}
           controls={isFullscreen}
           controlsList={isFullscreen ? 'nodownload' : undefined}
@@ -406,7 +408,7 @@ class VideoPlayer extends Component {
                 <Subtitles off={!subtitles} />
               </span>
             )}{' '}
-            {forceMuted === undefined && <span
+            {forceMuted === undefined && !isCinemagraph && <span
               role="button"
               title={`Audio ${muted ? 'aus' : 'an'}`}
               onClick={e => {
@@ -433,15 +435,17 @@ class VideoPlayer extends Component {
             )}
           </div>
         </div>
-        <div {...styles.progress} style={{ width: `${progress * 100}%` }} />
-        <div
-          {...styles.scrub}
-          ref={this.scrubRef}
-          onTouchStart={this.scrubStart}
-          onTouchMove={this.scrub}
-          onTouchEnd={this.scrubEnd}
-          onMouseDown={this.scrubStart}
-        />
+        {!isCinemagraph && <Fragment>
+          <div {...styles.progress} style={{ width: `${progress * 100}%` }} />
+          <div
+            {...styles.scrub}
+            ref={this.scrubRef}
+            onTouchStart={this.scrubStart}
+            onTouchMove={this.scrub}
+            onTouchEnd={this.scrubEnd}
+            onMouseDown={this.scrubStart}
+          />
+        </Fragment>}
       </div>
     )
   }

--- a/src/components/VideoPlayer/docs.md
+++ b/src/components/VideoPlayer/docs.md
@@ -10,6 +10,8 @@ Props:
 - `showPlay`: Whether to show the play button, defaults to `true`
 - `autoPlay`: Boolean, mapped to the video tag
 - `loop`: Boolean, mapped to the video tag
+- `forceMuted`: Boolean, mutes the player and hides the mute interfaces.
+- `isCinemagraph`: Boolean, whether the video is a cinemagraph. Forces `loop`, `muted`, `autoPlay` and `playsInline`.
 - `attributes`: Object, arbitrary attributes mapped to the video tag like playsinline, specific ones win
 
 
@@ -38,21 +40,18 @@ Props:
 />
 ```
 
-#### forceMuted
+#### isCinemagraph
 
-Generally the player manages its own global muted state but you can overwrite it with `forceMuted`. This also hides the mute interfaces.
+Cinemagraphs are still video clips in which minor movement occurs. `isCinemagraph` activates `autoPlay`, `loop`, `playsInline` and `mute` properties and hides the progress bar.
 
 ```react
 <VideoPlayer
   src={{
-    hls: 'https://player.vimeo.com/external/250999239.m3u8?s=54d7c0e48ea4fcf914cfb34c580081f544618da2',
-    mp4: 'https://player.vimeo.com/external/250999239.hd.mp4?s=7d6d2504261c5341158efe3d882a71eb23381302&profile_id=174',
-    thumbnail: `/static/video.jpg`,
-    subtitles: '/static/main.vtt'
+    hls: 'https://player.vimeo.com/external/284964492.m3u8?s=870db361c7129f30909d2406713736bf8a167bd9',
+    mp4: 'https://player.vimeo.com/external/284964492.hd.mp4?s=3fe867442c31bbcce20a5b7f68f2e3e2f4f69f11&profile_id=175',
+    thumbnail: `/static/video.jpg`
   }}
-  loop
-  autoPlay
-  forceMuted
+  isCinemagraph
 />
 ```
 

--- a/src/components/VideoPlayer/docs.md
+++ b/src/components/VideoPlayer/docs.md
@@ -11,7 +11,7 @@ Props:
 - `autoPlay`: Boolean, mapped to the video tag
 - `loop`: Boolean, mapped to the video tag
 - `forceMuted`: Boolean, mutes the player and hides the mute interfaces.
-- `isCinemagraph`: Boolean, whether the video is a cinemagraph. Forces `loop`, `muted`, `autoPlay` and `playsInline`.
+- `cinemagraph`: Boolean, whether the video is a cinemagraph. Forces `loop`, `muted`, `autoPlay` and `playsInline`.
 - `attributes`: Object, arbitrary attributes mapped to the video tag like playsinline, specific ones win
 
 
@@ -40,7 +40,7 @@ Props:
 />
 ```
 
-#### isCinemagraph
+#### cinemagraph
 
 Cinemagraphs are still video clips in which minor movement occurs. `isCinemagraph` activates `autoPlay`, `loop`, `playsInline` and `mute` properties and hides the progress bar.
 
@@ -51,7 +51,7 @@ Cinemagraphs are still video clips in which minor movement occurs. `isCinemagrap
     mp4: 'https://player.vimeo.com/external/284964492.hd.mp4?s=3fe867442c31bbcce20a5b7f68f2e3e2f4f69f11&profile_id=175',
     thumbnail: `/static/video.jpg`
   }}
-  isCinemagraph
+  cinemagraph
 />
 ```
 


### PR DESCRIPTION
This hit us again when introducing the autoPlay flag on Publikator, which doesn't autoplay the video on iOS only. I'd vote for adding the cross-platform magic here.