### PR TITLE
feat(Logo): expose ratio

### DIFF
--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -57,5 +57,6 @@ const Logo = (props) => {
 Logo.defaultProps = {
   fill: '#000'
 }
+Logo.ratio = ratio
 
 export default Logo


### PR DESCRIPTION
Useful to support different logos on `.love`:

<img width="1166" alt="screen shot 2018-08-16 at 18 00 01" src="https://user-images.githubusercontent.com/410211/44220213-41ff4600-a17e-11e8-9b5c-fed21a28354f.png">