### PR TITLE
fix(CreditLink): support collapsedColor (similar to Subject)

### DIFF
--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -4,15 +4,32 @@ import { Editorial } from '../Typography'
 import { lab } from 'd3-color'
 import { css } from 'glamor'
 import colors from '../../theme/colors'
+import { tUp } from './mediaQueries'
 
-const CreditLink = ({ children, color, ...props }) => {
+const CreditLink = ({ children, color, collapsedColor, ...props }) => {
   const labColor = lab(color)
-  const style = css({
+  const labCompactColor = lab(collapsedColor || color)
+
+  const baseColorStyle = {
     color,
-    cursor: 'pointer',
     ':hover': {
       color: labColor.b > 0.5 ? labColor.darker(0.6) : labColor.brighter(0.6)
     }
+  }
+
+  const colorStyle = collapsedColor ? {
+    color: collapsedColor,
+    ':hover': {
+      color: labCompactColor.b > 0.5 ? labCompactColor.darker(0.6) : labCompactColor.brighter(0.6)
+    },
+    [tUp]: {
+      ...baseColorStyle
+    }
+  } : baseColorStyle
+
+  const style = css({
+    ...colorStyle,
+    cursor: 'pointer'
   })
   return (
     <Editorial.A {...props} {...style}>

--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -8,7 +8,7 @@ import { tUp } from './mediaQueries'
 
 const CreditLink = ({ children, color, collapsedColor, ...props }) => {
   const labColor = lab(color)
-  const labCompactColor = collapsedColor && lab(collapsedColor)
+  const labCollapsedColor = collapsedColor && lab(collapsedColor)
 
   const baseColorStyle = {
     color,
@@ -17,10 +17,10 @@ const CreditLink = ({ children, color, collapsedColor, ...props }) => {
     }
   }
 
-  const colorStyle = labCompactColor ? {
+  const colorStyle = labCollapsedColor ? {
     color: collapsedColor,
     ':hover': {
-      color: labCompactColor.b > 0.5 ? labCompactColor.darker(0.6) : labCompactColor.brighter(0.6)
+      color: labCollapsedColor.b > 0.5 ? labCollapsedColor.darker(0.6) : labCollapsedColor.brighter(0.6)
     },
     [tUp]: {
       ...baseColorStyle

--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -8,7 +8,7 @@ import { tUp } from './mediaQueries'
 
 const CreditLink = ({ children, color, collapsedColor, ...props }) => {
   const labColor = lab(color)
-  const labCompactColor = lab(collapsedColor || color)
+  const labCompactColor = collapsedColor && lab(collapsedColor)
 
   const baseColorStyle = {
     color,
@@ -17,7 +17,7 @@ const CreditLink = ({ children, color, collapsedColor, ...props }) => {
     }
   }
 
-  const colorStyle = collapsedColor ? {
+  const colorStyle = labCompactColor ? {
     color: collapsedColor,
     ':hover': {
       color: labCompactColor.b > 0.5 ? labCompactColor.darker(0.6) : labCompactColor.brighter(0.6)
@@ -40,7 +40,8 @@ const CreditLink = ({ children, color, collapsedColor, ...props }) => {
 
 CreditLink.propTypes = {
   children: PropTypes.node.isRequired,
-  color: PropTypes.string
+  color: PropTypes.string,
+  collapsedColor: PropTypes.string
 }
 
 CreditLink.defaultProps = {

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -104,7 +104,10 @@ const createSchema = ({
             href: node.url,
             color: teaser
               ? teaser.data.color
-              : colors.primary
+              : colors.primary,
+            collapsedColor: teaser && teaser.data.frame
+              ? '#000'
+              : undefined
           }
         },
         component: ({ children, data, ...props }) =>


### PR DESCRIPTION
### Before (white link on white background if teaser color is white):
<img width="616" alt="screen shot 2018-08-20 at 16 13 36" src="https://user-images.githubusercontent.com/23520051/44348716-88fd7c00-a49b-11e8-8094-722d8bcc7f66.png">

### After (link using collapsedColor):
<img width="647" alt="screen shot 2018-08-20 at 17 02 45" src="https://user-images.githubusercontent.com/23520051/44348734-961a6b00-a49b-11e8-9d1c-179b16d9e593.png">

