### PR TITLE
feat(TileHeadline): support 'medium' size (used for feuilleton)

### DIFF
--- a/src/components/TeaserFront/TileHeadline.js
+++ b/src/components/TeaserFront/TileHeadline.js
@@ -9,13 +9,13 @@ const smallSize = {
   marginBottom: '16px'
 }
 
-const mediumSize = {
+const standardSize = {
   fontSize: '32px',
   lineHeight: '37px',
   marginBottom: '25px'
 }
 
-const defaultSize = {
+const mediumSize = {
   fontSize: '48px',
   lineHeight: '54px',
   marginBottom: '25px'
@@ -33,6 +33,13 @@ const styles = {
     ...serifTitle20,
     ...smallSize,
     [mUp]: {
+      ...standardSize
+    }
+  }),
+  editorialCol2Medium: css({
+    ...serifTitle20,
+    ...smallSize,
+    [mUp]: {
       ...mediumSize
     }
   }),
@@ -40,10 +47,17 @@ const styles = {
     ...serifTitle20,
     ...smallSize,
     [mUp]: {
-      ...mediumSize
+      ...standardSize
     }
   }),
   interactionCol2: css({
+    ...sansSerifMedium20,
+    ...smallSize,
+    [mUp]: {
+      ...standardSize
+    }
+  }),
+  interactionCol2Medium: css({
     ...sansSerifMedium20,
     ...smallSize,
     [mUp]: {
@@ -54,20 +68,24 @@ const styles = {
     ...sansSerifMedium20,
     ...smallSize,
     [mUp]: {
-      ...mediumSize
+      ...standardSize
     }
   }),
   scribble: css({
     ...cursiveTitle20,
     ...smallSize,
     [mUp]: {
-      ...mediumSize
+      ...standardSize
     }
   })
 }
 
-export const Editorial = ({ children, columns }) => {
-  const style = columns === 3 ? styles.editorialCol3 : styles.editorialCol2
+export const Editorial = ({ children, medium, columns }) => {
+  const style = columns === 3
+    ? styles.editorialCol3
+    : medium
+      ? styles.editorialCol2Medium
+      : styles.editorialCol2
   return (
     <h1 {...styles.base} {...style}>
       {children}
@@ -75,8 +93,12 @@ export const Editorial = ({ children, columns }) => {
   )
 }
 
-export const Interaction = ({ children, columns }) => {
-  const style = columns === 3 ? styles.interactionCol3 : styles.interactionCol2
+export const Interaction = ({ children, medium, columns }) => {
+  const style = columns === 3
+    ? styles.interactionCol3
+    : medium
+      ? styles.interactionCol2Medium
+      : styles.interactionCol2
   return (
     <h1 {...styles.base} {...style}>
       {children}

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -393,6 +393,7 @@ const createSchema = ({
         'color',
         'bgColor',
         'center',
+        'titleSize',
         'showImage',
         'onlyImage',
         'image',
@@ -404,14 +405,17 @@ const createSchema = ({
       image,
       title(
         'FRONTTILETITLE',
-        ({ children, attributes, kind, columns }) => {
+        ({ children, attributes, kind, titleSize, columns }) => {
           const Component = kind === 'editorial'
           ? TeaserFrontTileHeadline.Editorial
           : kind === 'scribble'
             ? TeaserFrontTileHeadline.Scribble
             : TeaserFrontTileHeadline.Interaction
+          const sizes = {
+            medium: titleSize === 'medium'
+          }
           return (
-            <Component attributes={attributes} columns={columns}>
+            <Component attributes={attributes} columns={columns} {...sizes}>
               {children}
             </Component>
           )


### PR DESCRIPTION
- Enables titleSize dropdown for FrontTile
- Renames existing `mediumSize` style to `standardSize` to avoid confusion
- Support `mediumSize` (a bit larger than standard) for col2 titles, as required for feuilleton.