### PR TITLE
feat(TeaserFront): mix format color for `feuilleton` teasers

### DIFF
--- a/src/components/Figure/Byline.js
+++ b/src/components/Figure/Byline.js
@@ -36,7 +36,7 @@ const positionStyle = {
       paddingLeft: 0
     }
   }),
-  belowFrame: css({
+  belowFeuilleton: css({
     display: 'block',
     marginTop: '5px',
     paddingLeft: 0,
@@ -116,7 +116,7 @@ Byline.propTypes = {
   attributes: PropTypes.object,
   position: PropTypes.oneOf([
     'below',
-    'belowFrame',
+    'belowFeuilleton',
     'right',
     'rightCompact',
     'left',

--- a/src/components/TeaserFront/Format.js
+++ b/src/components/TeaserFront/Format.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+import { lab } from 'd3-color'
+import { mUp, tUp } from './mediaQueries'
+import {
+  sansSerifMedium16,
+  sansSerifMedium20
+} from '../Typography/styles'
+
+const format = css({
+  ...sansSerifMedium16,
+  margin: '0 0 18px 0',
+  [mUp]: {
+    ...sansSerifMedium20,
+    margin: '0 0 28px 0'
+  }
+})
+
+const Format = ({ children, color, collapsedColor }) => {
+  const labColor = lab(color)
+  const labCollapsedColor = lab(collapsedColor || color)
+  const colorStyle = color && css({
+    color: labCollapsedColor.l > 50
+      ? labCollapsedColor.darker(0.6)
+      : labCollapsedColor.brighter(3.0),
+    [tUp]: {
+      color: labColor.l > 50 ? labColor.darker(2.0) : labColor.brighter(3.0),
+    }
+  })
+
+  return (
+    <p {...format} {...(colorStyle ? colorStyle : undefined)}>
+      {children}
+    </p>
+  )
+}
+
+Format.propTypes = {
+  children: PropTypes.node.isRequired,
+  color: PropTypes.string,
+  collapsedColor: PropTypes.string
+}
+
+export default Format

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -32,7 +32,7 @@ const styles = {
   container: css({
     ...containerStyle
   }),
-  containerFrame: css({
+  containerFeuilleton: css({
     ...containerStyle,
     margin: '15px',
     [mUp]: {
@@ -43,7 +43,7 @@ const styles = {
   textContainer: css({
     ...textContainerStyle
   }),
-  textContainerFrame: css({
+  textContainerFeuilleton: css({
     ...textContainerStyle,
     padding: '15px 0 40px 0',
     [mUp]: {
@@ -68,11 +68,11 @@ const ImageBlock = ({
   center,
   aboveTheFold,
   onlyImage,
-  frame
+  feuilleton
 }) => {
   const background = bgColor || ''
   return (
-    <div {...attributes} {...(frame ? styles.containerFrame : styles.container)} onClick={onClick} style={{
+    <div {...attributes} {...(feuilleton ? styles.containerFeuilleton : styles.container)} onClick={onClick} style={{
       background,
       cursor: onClick ? 'pointer' : 'default'
     }}>
@@ -82,8 +82,8 @@ const ImageBlock = ({
           {byline}
         </FigureByline>}
       </div>
-      {!onlyImage && <div {...(frame ? styles.textContainerFrame : styles.textContainer)}>
-        <Text position={textPosition} color={color} collapsedColor={frame && colors.text} center={center}>
+      {!onlyImage && <div {...(feuilleton ? styles.textContainerFeuilleton : styles.textContainer)}>
+        <Text position={textPosition} color={color} collapsedColor={feuilleton && colors.text} center={center}>
           {children}
         </Text>
       </div>}
@@ -110,7 +110,7 @@ ImageBlock.propTypes = {
     'bottom'
   ]),
   onlyImage: PropTypes.bool,
-  frame: PropTypes.bool
+  feuilleton: PropTypes.bool
 }
 
 ImageBlock.defaultProps = {

--- a/src/components/TeaserFront/Image.md
+++ b/src/components/TeaserFront/Image.md
@@ -216,11 +216,11 @@ A `<TeaserFrontImageHeadline />` should be used. The default font size can be ch
 </TeaserFrontImage>
 ```
 
-### `frame`: Horizontal `frame` margins and regular text color in stacked mode
+### `feuilleton`: Horizontal `feuilleton` margins and regular text color in stacked mode
 
 ```react
 <TeaserFrontImage
-  frame
+  feuilleton
   image='/static/desert.jpg?size=4323x2962' byline='Foto: Thomas Vuillemin'
   color='#fff' collapsedColor='#000' bgColor='#fff'>
   <Editorial.Format>Neutrum</Editorial.Format>

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -16,7 +16,7 @@ const styles = {
       padding: '70px 5%'
     }
   }),
-  containerFrame: css({
+  containerFeuilleton: css({
     margin: 0,
     overflow: 'hidden',
     [mUp]: {
@@ -63,7 +63,7 @@ const styles = {
       width: '50%'
     }
   }),
-  imageContainerFrame: css({
+  imageContainerFeuilleton: css({
     padding: '15px 15px 0 15px',
     position: 'relative',
     [mUp]: {
@@ -99,15 +99,15 @@ const Split = ({
   reverse,
   portrait,
   aboveTheFold,
-  frame
+  feuilleton
 }) => {
   const background = bgColor || ''
   const flexDirection = reverse ? 'row-reverse' : ''
-  const bylinePosition = frame ? 'belowFrame' : portrait ? reverse ? 'left' : 'right' : 'below'
+  const bylinePosition = feuilleton ? 'belowFeuilleton' : portrait ? reverse ? 'left' : 'right' : 'below'
   return (
     <div
       {...attributes}
-      {...css(frame ? styles.containerFrame : styles.container, portrait ? styles.containerPortrait : {})}
+      {...css(feuilleton ? styles.containerFeuilleton : styles.container, portrait ? styles.containerPortrait : {})}
       onClick={onClick}
       style={{
         background,
@@ -117,7 +117,7 @@ const Split = ({
     >
       <div
         {...css(
-          frame ? styles.imageContainerFrame : styles.imageContainer,
+          feuilleton ? styles.imageContainerFeuilleton : styles.imageContainer,
           portrait ? styles.imageContainerPortrait : {}
         )}
       >

--- a/src/components/TeaserFront/Split.md
+++ b/src/components/TeaserFront/Split.md
@@ -6,7 +6,7 @@ Supported props:
 - `bgColor`: The background color to use in stacked mode.
 - `portrait`: Whether to use the portrait layout.
 - `reverse`: Whether the layout should be reversed (i.e. the image appears to the right).
-- `frame`: Whether to use the canonical frame margins.
+- `feuilleton`: Whether to use the canonical feuilleton margins.
 
 A `<TeaserFrontSplitHeadline />` should be used.
 
@@ -150,11 +150,11 @@ A `<TeaserFrontSplitHeadline />` should be used.
 </TeaserFrontSplit>
 ```
 
-### Frame
+### Feuilleton
 
 ```react
 <TeaserFrontSplit
-  frame
+  feuilleton
   image='/static/rothaus_portrait.jpg'
   byline='Foto: Laurent Burst'
   color='#fff' bgColor='#000'>
@@ -171,7 +171,7 @@ A `<TeaserFrontSplitHeadline />` should be used.
 
 ```react
 <TeaserFrontSplit
-  frame
+  feuilleton
   image='/static/rothaus_landscape.jpg'
   reverse
   byline='Foto: Laurent Burst'

--- a/src/components/TeaserFront/index.js
+++ b/src/components/TeaserFront/index.js
@@ -13,6 +13,7 @@ export { default as TeaserFrontTypo } from './Typo'
 export { default as TeaserFrontSplit } from './Split'
 export { default as TeaserFrontTile, TeaserFrontTileRow } from './Tile'
 
+export { default as TeaserFrontFormat } from './Format'
 export { default as TeaserFrontLead } from './Lead'
 export { default as TeaserFrontSubject } from './Subject'
 export { default as TeaserFrontCredit } from './Credit'

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -9,7 +9,6 @@ import {
 } from 'mdast-react-render/lib/utils'
 
 import colors from '../../theme/colors'
-import * as Editorial from '../../components/Typography/Editorial'
 
 import {
   TeaserFrontImage,
@@ -21,6 +20,7 @@ import {
   TeaserFrontTile,
   TeaserFrontTileHeadline,
   TeaserFrontTileRow,
+  TeaserFrontFormat,
   TeaserFrontLead,
   TeaserFrontCredit,
   TeaserFrontCreditLink,
@@ -64,7 +64,7 @@ export const subject = {
     const teaser = ancestors.find(matchTeaser)
     return {
       color: teaser && teaser.data.color,
-      collapsedColor: teaser && teaser.data.frame && '#000',
+      collapsedColor: teaser && teaser.data.feuilleton && '#000',
       columns:  teaserGroup ? teaserGroup.data.columns : undefined
     }
   },
@@ -105,7 +105,7 @@ const createSchema = ({
             color: teaser
               ? teaser.data.color
               : colors.primary,
-            collapsedColor: teaser && teaser.data.frame
+            collapsedColor: teaser && teaser.data.feuilleton
               ? '#000'
               : undefined
           }
@@ -180,20 +180,22 @@ const createSchema = ({
 
   const format = {
     matchMdast: matchHeading(6),
-    component: ({ children, attributes, href }) =>
-      <Editorial.Format attributes={attributes}>
+    component: ({ children, attributes, href, color, collapsedColor }) =>
+      <TeaserFrontFormat color={color} collapsedColor={collapsedColor}>
         <Link href={href} passHref>
           <a href={href} {...styles.link}>
             {children}
           </a>
         </Link>
-      </Editorial.Format>,
+      </TeaserFrontFormat>,
     props (node, index, parent, { ancestors }) {
       const teaser = ancestors.find(matchTeaser)
       return {
         href: teaser
           ? teaser.data.formatUrl
-          : undefined
+          : undefined,
+        color: teaser && teaser.data.feuilleton && teaser.data.color,
+        collapsedColor: teaser && teaser.data.feuilleton && '#000'
       }
     },
     editorModule: 'headline',
@@ -234,7 +236,7 @@ const createSchema = ({
         'image',
         'byline',
         'onlyImage',
-        'frame'
+        'feuilleton'
       ]
     },
     rules: [
@@ -291,7 +293,7 @@ const createSchema = ({
         'titleSize',
         'reverse',
         'portrait',
-        'frame'
+        'feuilleton'
       ]
     },
     rules: [
@@ -339,7 +341,8 @@ const createSchema = ({
         'color',
         'bgColor',
         'kind',
-        'titleSize'
+        'titleSize',
+        'feuilleton'
       ]
     },
     rules: [
@@ -397,7 +400,8 @@ const createSchema = ({
         'onlyImage',
         'image',
         'byline',
-        'kind'
+        'kind',
+        'feuilleton'
       ]
     },
     rules: [


### PR DESCRIPTION
Design requires the format on feuilleton teasers to be gray (analogue to the Subject component). Currently the format on front teasers just inherits the container color.

Significant changes:
- Rename `framed` flag to `feuilleton` (so we have one combined flag to trigger any feuilleton-specific styles)
- Add `feuilleton` checkbox to FrontTile and FrontTypo teasers as well
- If the teaser is `feuilleton`, mix the color (analogue to the Subject component), otherwise inherit as before.

![screen shot 2018-08-21 at 10 41 19](https://user-images.githubusercontent.com/23520051/44391704-e099f700-a530-11e8-8d11-d2e1a25d01dd.png)
![screen shot 2018-08-21 at 10 41 41](https://user-images.githubusercontent.com/23520051/44391727-e7c10500-a530-11e8-8690-428f529bb322.png)
