### PR TITLE
feat(Article): support Subject in article titleblock

### DIFF
--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -51,6 +51,7 @@ export const Subhead = ({ children, attributes, ...props }) => (
 
 const lead = css({
   ...styles.serifRegular19,
+  display: 'inline',
   margin: '0 0 10px 0',
   [mUp]: {
     ...styles.serifRegular23,
@@ -64,6 +65,26 @@ export const Lead = ({ children, attributes, ...props }) => (
     {children}
   </p>
 )
+
+const subject = css({
+  color: '#8c8c8c',
+  display: 'inline',
+  margin: 0,
+  ...styles.sansSerifRegular19,
+  lineHeight: '27px',
+  [mUp]: {
+    ...styles.sansSerifRegular23,
+  }
+})
+
+export const Subject = ({ children, attributes, ...props }) => {
+  const style = { paddingRight: (children && children.length > 0 ? '.5em': undefined)}
+  return (
+    <h2 {...attributes} {...props} {...subject} style={style}>
+      {children}
+    </h2>
+  )
+}
 
 const credit = css({
   margin: '10px 0 0 0',

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -71,9 +71,9 @@ const subject = css({
   display: 'inline',
   margin: 0,
   ...styles.sansSerifRegular19,
-  lineHeight: '27px',
   [mUp]: {
     ...styles.sansSerifRegular23,
+    lineHeight: '27px'
   }
 })
 

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -103,6 +103,22 @@ Von [Franz Kafka](<>) (Text) und [Everett Collection](<>) (Bilder), 13. Juli 201
 `}</Markdown>
 ```
 
+```react|noSource
+<Markdown schema={schema}>{`
+<section><h6>TITLE</h6>
+
+# Gregor Samsa eines Morgens aus unruhigen Träumen
+
+## Kafkas «Verwandlung»
+
+Jemand musste Josef K. verleumdet haben, denn ohne dass er etwas Böses getan hätte, wurde er eines Morgens verhaftet. «Wie ein Hund!» sagte er, es war, als sollte die Scham ihn überleben.
+
+Von [Franz Kafka](<>) (Text) und [Everett Collection](<>) (Bilder), 13. Juli 2017
+
+<hr /></section>
+`}</Markdown>
+```
+
 ### `center`
 
 Values: `falsy` (default), `true`

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -685,6 +685,21 @@ const createSchema = ({
                 }
               },
               {
+                matchMdast: matchHeading(2),
+                component: ({ children, attributes, ...props }) =>
+                  <Editorial.Subject attributes={attributes} {...props}>
+                    {children}
+                  </Editorial.Subject>,
+                editorModule: 'headline',
+                editorOptions: {
+                  type: 'SUBJECT',
+                  placeholder: 'Subject',
+                  depth: 2,
+                  isStatic: true
+                },
+                rules: globalInlines
+              },
+              {
                 matchMdast: (node, index, parent) => {
                   const numHeadings = parent.children.filter(
                     child => child.type === 'heading'

--- a/src/templates/Front/docs.md
+++ b/src/templates/Front/docs.md
@@ -45,7 +45,7 @@ This will be wrapped around and links (headlines and credits) and the whole teas
 
 # Welt-Bilder
 
-### Premiere im Rothaus
+## Premiere im Rothaus
 
 #### Und es war ihnen wie eine Bestätigung ihrer neuen Träume und guten Absichten.
 
@@ -115,7 +115,7 @@ Von [Laurent Burst](/~349ef65b-119a-4d3e-9176-26517855d342 "Laurent Burst")
 
 # Mavie
 
-### Premiere im Rothaus
+## Premiere im Rothaus
 
 #### Republik-Verlegerin, 8 Monate
 

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -54,7 +54,7 @@ const image = {
 }
 
 export const subject = {
-  matchMdast: matchHeading(3),
+  matchMdast: matchHeading(2),
   component: ({ children, attributes, ...props }) =>
     <TeaserFrontSubject attributes={attributes} {...props}>
       {children}
@@ -72,7 +72,7 @@ export const subject = {
   editorOptions: {
     type: 'FRONTSUBJECT',
     placeholder: 'Subject',
-    depth: 3,
+    depth: 2,
     isStatic: true
   },
   rules: globalInlines


### PR DESCRIPTION
### Comparison of local PR changes vs. current production article

#### Desktop
<img width="1430" alt="screen shot 2018-08-22 at 10 10 22" src="https://user-images.githubusercontent.com/23520051/44452146-0b01b800-a5f6-11e8-8f79-c829b84750e5.png">


#### Mobile
<img width="885" alt="screen shot 2018-08-22 at 09 50 33" src="https://user-images.githubusercontent.com/23520051/44450327-ed7e1f80-a5f0-11e8-85f1-65a67fdcaa44.png">
