### PR TITLE
fix(Format): reflect format color in Publikator teaser

### DIFF
--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -617,7 +617,10 @@ const createSchema = ({
                     padding: '30px 30px 1px'
                   }}
                 >
-                  <TeaserFeed {...props} />
+                  <TeaserFeed
+                    {...props}
+                    color={props.color ? props.color : props.kind ? colors[props.kind] : undefined}
+                  />
                 </div>
               )
             }


### PR DESCRIPTION
This is actually a Publikator fix to reflect the default format colors in the preview teaser.  (The teaser itself needs some work to actually show something more meaningful than it currently does, but for now the only goal is to make colors visible.)

<img width="665" alt="screen shot 2018-08-29 at 13 27 39" src="https://user-images.githubusercontent.com/23520051/44785072-f9895480-ab8f-11e8-84de-93474b190e1f.png">
<img width="658" alt="screen shot 2018-08-29 at 13 27 59" src="https://user-images.githubusercontent.com/23520051/44785073-f9895480-ab8f-11e8-8cfd-0b37438f70c3.png">
<img width="659" alt="screen shot 2018-08-29 at 13 28 20" src="https://user-images.githubusercontent.com/23520051/44785074-fa21eb00-ab8f-11e8-976b-514ad1d49f13.png">
