### PR TITLE
feat(FormatTag): move format tag to styleguide

### DIFF
--- a/src/components/Format/Tag.js
+++ b/src/components/Format/Tag.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+
+import {
+  sansSerifMedium12,
+  sansSerifMedium14,
+  sansSerifMedium16,
+  sansSerifMedium19
+} from '../Typography/styles'
+import { mUp } from '../../theme/mediaQueries'
+
+const styles = {
+  container: css({
+    ...sansSerifMedium16,
+    display: 'inline-block',
+    padding: 0,
+    margin: '0 10px 5px 0',
+    [mUp]: {
+      ...sansSerifMedium19,
+      margin: '0 20px 5px 0'
+    }
+  }),
+  count: css({
+    ...sansSerifMedium12,
+    color: '#b4b4b4',
+    marginLeft: 5,
+    [mUp]: {
+      ...sansSerifMedium14
+    }
+  })
+}
+
+class FormatTag extends Component {
+  render () {
+    const { label, count, color } = this.props
+    return (
+      <div {...styles.container} style={{ color }}>
+        {label}
+        {count !== undefined && (
+          <span {...styles.count}>{count}</span>
+        )}
+      </div>
+    )
+  }
+}
+
+FormatTag.propTypes = {
+  label: PropTypes.string.isRequired,
+  count: PropTypes.number,
+  color: PropTypes.string
+}
+
+export default FormatTag

--- a/src/components/Format/docs.md
+++ b/src/components/Format/docs.md
@@ -1,0 +1,55 @@
+Props:
+- `label`: string, the label of the tag.
+- `count`: optional number, the count.
+- `color`: optional string, the color of the label.
+
+```react
+<FormatTag
+  label='Aus der Redaktion'
+  count={17}
+  color='#008899'
+/>
+```
+
+```react
+<FormatTag
+  label='Aus der Redaktion'
+  count={17}
+/>
+```
+
+```react
+<FormatTag
+  label='Aus der Redaktion'
+/>
+```
+
+```react
+<div>
+  <FormatTag
+    label='Aus der Redaktion'
+    count={9}
+    color='#008899'
+  />
+  <FormatTag
+    label='Hinter den Kulissen'
+    count={17}
+    color='#aa6600'
+  />
+  <FormatTag
+    label='Am Ereignishorizont'
+    count={12}
+    color='#dc2543'
+  />
+  <FormatTag
+    label='Auf der Bühne'
+    count={28}
+    color='#8B008B'
+  />
+  <FormatTag
+    label='Weltgeschehen'
+    count={87}
+    color='#0359ae'
+  />
+</div>
+```

--- a/src/components/Format/index.js
+++ b/src/components/Format/index.js
@@ -1,0 +1,1 @@
+export { default as FormatTag } from './Tag'

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,14 @@ ReactDOM.render(
             src: require('./components/Button/docs.md')
           },
           {
+            path: '/format',
+            title: 'FormatTag',
+            imports: {
+              ...require('./components/Format')
+            },
+            src: require('./components/Format/docs.md')
+          },
+          {
             path: '/forms',
             title: 'Forms',
             imports: {

--- a/src/lib.js
+++ b/src/lib.js
@@ -75,6 +75,9 @@ export {
   TeaserFrontCreditLink
 } from './components/TeaserFront'
 export {
+  FormatTag
+} from './components/Format'
+export {
   TeaserFrontDossier,
   TeaserFrontDossierIntro,
   TeaserFrontDossierHeadline,

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -584,7 +584,8 @@ const createSchema = ({
   Link = DefaultLink,
   getPath = getDatePath,
   t = () => '',
-  dynamicComponentRequire
+  dynamicComponentRequire,
+  previewTeaser
 } = {}) => {
   const teasers = createTeasers({
     t,
@@ -610,19 +611,16 @@ const createSchema = ({
             editorOptions: {
               series,
               customFields: customMetaFields,
-              teaser: props => (
+              teaser: previewTeaser || (props => (
                 <div
                   style={{
                     backgroundColor: '#fff',
                     padding: '30px 30px 1px'
                   }}
                 >
-                  <TeaserFeed
-                    {...props}
-                    color={props.color ? props.color : props.kind ? colors[props.kind] : undefined}
-                  />
+                  <TeaserFeed {...props} />
                 </div>
-              )
+              ))
             }
           },
           cover,

--- a/src/templates/Format/index.js
+++ b/src/templates/Format/index.js
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import colors from '../../theme/colors'
+import { FormatTag } from '../../components/Format'
 import TitleBlock from '../../components/TitleBlock'
 import * as Interaction from '../../components/Typography/Interaction'
 
@@ -88,6 +90,20 @@ const createSchema = ({
         }
       ]
     },
+    previewTeaser: props => (
+      <div
+        style={{
+          backgroundColor: '#fff',
+          padding: '30px'
+        }}
+      >
+        <FormatTag
+          label={props.title}
+          count={17}
+          color={props.color ? props.color : props.kind ? colors[props.kind] : undefined}
+        />
+      </div>
+    ),
     ...args
   })
 }


### PR DESCRIPTION
Docs: https://r-styleguide-pr-166.herokuapp.com/format

Moves the component over from https://github.com/orbiting/republik-frontend/pull/176 so it can be re-used both on 
- republik-frontend (Rubriken page) and 
- publikator-frontend (format teaser preview)

<img width="676" alt="screen shot 2018-08-30 at 11 17 34" src="https://user-images.githubusercontent.com/23520051/44842505-55aeb000-ac46-11e8-8c57-b21263a0e798.png">