### PR TITLE
fix(Front): enforce centered text for mobile feuilleton teasers

### DIFF
--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -83,7 +83,12 @@ const ImageBlock = ({
         </FigureByline>}
       </div>
       {!onlyImage && <div {...(feuilleton ? styles.textContainerFeuilleton : styles.textContainer)}>
-        <Text position={textPosition} color={color} collapsedColor={feuilleton && colors.text} center={center} feuilleton={feuilleton}>
+        <Text
+          position={textPosition}
+          color={color}
+          collapsedColor={feuilleton && colors.text}
+          center={center}
+          feuilleton={feuilleton}>
           {children}
         </Text>
       </div>}

--- a/src/components/TeaserFront/Image.js
+++ b/src/components/TeaserFront/Image.js
@@ -83,7 +83,7 @@ const ImageBlock = ({
         </FigureByline>}
       </div>
       {!onlyImage && <div {...(feuilleton ? styles.textContainerFeuilleton : styles.textContainer)}>
-        <Text position={textPosition} color={color} collapsedColor={feuilleton && colors.text} center={center}>
+        <Text position={textPosition} color={color} collapsedColor={feuilleton && colors.text} center={center} feuilleton={feuilleton}>
           {children}
         </Text>
       </div>}

--- a/src/components/TeaserFront/Split.js
+++ b/src/components/TeaserFront/Split.js
@@ -132,7 +132,7 @@ const Split = ({
             : reverse ? styles.contentReverse : {}
         )}
       >
-        <Text color={color} center={center}>
+        <Text color={color} center={center} feuilleton={feuilleton}>
           {children}
         </Text>
       </div>

--- a/src/components/TeaserFront/Text.js
+++ b/src/components/TeaserFront/Text.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { tUp } from './mediaQueries'
+import { mUp, tUp } from './mediaQueries'
 import colors from '../../theme/colors'
 
 const TEXT_PADDING = 50
@@ -83,6 +83,15 @@ const styles = {
       ...positionFullWidth,
       bottom: `${TEXT_PADDING}px`
     }
+  }),
+  center: css({
+    textAlign: 'center'
+  }),
+  centerMobileOnly: css({
+    textAlign: 'center',
+    [mUp]: {
+      textAlign: 'inherit'
+    }
   })
 }
 
@@ -94,9 +103,12 @@ const Text = ({
   color,
   collapsedColor,
   maxWidth,
-  margin
+  margin,
+  feuilleton
 }) => {
-  const textAlign = center ? 'center' : undefined
+  const textAlignStyle = feuilleton && !center
+    ? styles.centerMobileOnly
+    : center ? styles.center : undefined
   const rootStyles = position ? styles.rootPosition : {}
   const middleStyles = position === 'middle' ? styles.rootMiddle : {}
 
@@ -112,8 +124,9 @@ const Text = ({
       <div
         {...attributes}
         {...colorStyle}
+        {...textAlignStyle}
         {...css(styles.positioned, position ? styles[position] : {})}
-        style={{ color: !collapsedColor ? color : undefined, textAlign, maxWidth, margin }}
+        style={{ color: !collapsedColor ? color : undefined, maxWidth, margin }}
       >
         {children}
       </div>
@@ -133,10 +146,12 @@ Text.propTypes = {
     'middle',
     'bottom'
   ]),
+  center: PropTypes.bool,
   color: PropTypes.string,
   collapsedColor: PropTypes.string,
   maxWidth: PropTypes.string,
-  margin: PropTypes.string
+  margin: PropTypes.string,
+  feuilleton: PropTypes.bool
 }
 
 Text.defaultProps = {


### PR DESCRIPTION
Only affects FrontImageTeaser and FrontSplit (FrontTypo and FrontTile are always centered).

#### Before
<img width="387" alt="screen shot 2018-09-04 at 16 41 34" src="https://user-images.githubusercontent.com/23520051/45038523-a9176880-b061-11e8-8b0d-69eb3019a2b4.png">

#### After
<img width="386" alt="screen shot 2018-09-04 at 16 42 34" src="https://user-images.githubusercontent.com/23520051/45038539-b16fa380-b061-11e8-9334-a3acd8f8c941.png">
