### PR TITLE
VideoPlayer: Full Window Mode

### DIFF
--- a/src/components/VideoPlayer/docs.md
+++ b/src/components/VideoPlayer/docs.md
@@ -40,6 +40,29 @@ Props:
 />
 ```
 
+#### fullWindow
+
+Force the usage of the full window mode even when fullscreen API is available. This can for example be used when the fullscreen API does not work in a Android web view.
+
+```react|responsive
+<Center>
+  <VideoPlayer
+    src={{
+      hls: 'https://player.vimeo.com/external/213080233.m3u8?s=40bdb9917fa47b39119a9fe34b9d0fb13a10a92e',
+      mp4: 'https://player.vimeo.com/external/213080233.hd.mp4?s=ab84df0ac9134c86bb68bd9ea7ac6b9df0c35774&profile_id=175',
+      thumbnail: `/static/video.jpg`,
+      subtitles: '/static/main.vtt'
+    }}
+    fullWindow
+    onFull={(isFull, isFullscreen) => {
+      console.log('isFull', isFull, isFullscreen)
+    }}
+  />
+</Center>
+```
+
+_`onFull` is fired in the full window and fullscreen case._
+
 #### cinemagraph
 
 Cinemagraphs are still video clips in which minor movement occurs. `isCinemagraph` activates `autoPlay`, `loop`, `playsInline` and `mute` properties and hides the progress bar.

--- a/src/components/VideoPlayer/fullscreen.js
+++ b/src/components/VideoPlayer/fullscreen.js
@@ -49,13 +49,14 @@ const apiSurfaces = [
 const getFullscreenApi = () => {
   let api = {}
   const canonicalSurface = apiSurfaces[0]
-  apiSurfaces.forEach(apiSurface => {
+  apiSurfaces.some(apiSurface => {
     if (!document[apiSurface[1]]) {
-      return
+      return false
     }
     apiSurface.forEach((method, index) => {
       api[canonicalSurface[index]] = apiSurface[index]
     })
+    return true
   })
   return api.requestFullscreen ? api : null
 }

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -22,6 +22,7 @@ const schema = createArticleSchema({
   This will be wrapped around links. You should attach an `onClick` handler within, if you wish to do client side routing and or prefetching. The component recieves following props:
   - `href` String, target url or path
   - `passHref` Boolean, indicates this will eventually end in an a tag and you may overwrite href
+- `getVideoPlayerProps`, a [prop getter](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf) for the video player. Make sure to forward, modified or unmodified, the props that are passed to the function.
 
 # Example
 

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -585,7 +585,8 @@ const createSchema = ({
   getPath = getDatePath,
   t = () => '',
   dynamicComponentRequire,
-  previewTeaser
+  previewTeaser,
+  getVideoPlayerProps = props => props
 } = {}) => {
   const teasers = createTeasers({
     t,
@@ -850,7 +851,7 @@ const createSchema = ({
                     return (
                       <VideoPlayer
                         attributes={attributes}
-                        {...data}
+                        {...getVideoPlayerProps(data)}
                         t={t}
                       />
                     )


### PR DESCRIPTION
Changes
- add new full window mode and make it the default fallback when fullscreen API is not available
- ensure the first found fullscreen api (newest) is used and not the last supported on (oldest)
- allow to inject props to video players in a template via `getVideoPlayerProps`

![screencapture-localhost-3003-videoplayer-2018-09-08-16_22_30](https://user-images.githubusercontent.com/410211/45255190-80ee7900-b383-11e8-8e79-2999ac47f320.png)
