### PR TITLE
fix(articleCollection): don't show generic unauthorized message 

### DIFF
--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -209,9 +209,11 @@ const createTeasers = ({
     articleCollection: {
       matchMdast: matchZone('ARTICLECOLLECTION'),
       component: ({ children, attributes, unauthorized, unauthorizedText }) => unauthorized
-      ? <Interaction.P style={{backgroundColor: colors.primaryBg, padding: '10px 20px'}}>
-        {unauthorizedText || t('styleguide/templates/unauthorizedZone')}
-      </Interaction.P>
+      ? unauthorizedText
+        ? <Interaction.P style={{backgroundColor: colors.primaryBg, padding: '10px 20px'}}>
+          {unauthorizedText}
+        </Interaction.P>
+        : null
       : <Breakout size='breakout' attributes={attributes}>
         {children}
       </Breakout>,


### PR DESCRIPTION
Several people here agreed we should 
- not show a generic message that basically says "Here's something you don't get" 
- rather only show a meaningful message if defined in Publikator

### Before (both default and a specified message are shown)
<img width="686" alt="screen shot 2018-09-12 at 15 14 19" src="https://user-images.githubusercontent.com/23520051/45427665-accd6f80-b69f-11e8-928a-276021eca160.png">

### After (the default message doesn't show anymore)
<img width="679" alt="screen shot 2018-09-12 at 15 16 51" src="https://user-images.githubusercontent.com/23520051/45427667-accd6f80-b69f-11e8-8532-337beffabc5e.png">
