### PR TITLE
Improve visibility of inactive radio button

### DIFF
--- a/src/components/Form/Radio.js
+++ b/src/components/Form/Radio.js
@@ -23,22 +23,21 @@ const styles = {
   })
 }
 
-const Radio = ({checked, disabled, black}) => (
+const Radio = ({checked, disabled}) => (
   <svg width='24' height='24' viewBox='0 0 24 24'>
     <circle fill='#fff' stroke='#fff' strokeWidth='6' cx='12' cy='12' r='9' />
     {checked && (
-      <circle fill={disabled ? colors.disabled : colors.primary} cx='12' cy='12' r='6' />
+      <circle fill={ disabled ? colors.disabled : '#000' } cx='12' cy='12' r='6'/>
     )}
-    <circle fill='none'
-            stroke={ checked && !disabled ? colors.primary : (black && !disabled ? '#000' : colors.divider) }
-            cx='12' cy='12' r='11.5' />
+    <circle fill='none' stroke={ disabled ? colors.divider : '#000' }
+            cx='12' cy='12' r='11.5'/>
   </svg>
 )
 
-export default ({children, style, name, value, checked, disabled, black, onChange}) => (
+export default ({children, style, name, value, checked, disabled, onChange}) => (
   <label {...styles.label} style={{color: disabled ? colors.disabled : colors.text, ...style}}>
     <span {...styles.box}>
-      <Radio checked={ checked } disabled={ disabled } black={ black }/>
+      <Radio checked={ checked } disabled={ disabled }/>
     </span>
     <input
       {...styles.input}

--- a/src/components/Form/Radio.js
+++ b/src/components/Form/Radio.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import {css} from 'glamor'
+import { css } from 'glamor'
 import colors from '../../theme/colors'
-import {fontFamilies} from '../../theme/fonts'
+import { fontFamilies } from '../../theme/fonts'
 
 const styles = {
   label: css({
@@ -23,21 +23,22 @@ const styles = {
   })
 }
 
-const Radio = ({checked, disabled}) => (
+const Radio = ({checked, disabled, black}) => (
   <svg width='24' height='24' viewBox='0 0 24 24'>
     <circle fill='#fff' stroke='#fff' strokeWidth='6' cx='12' cy='12' r='9' />
     {checked && (
       <circle fill={disabled ? colors.disabled : colors.primary} cx='12' cy='12' r='6' />
     )}
-    <circle fill='none' stroke={checked && !disabled ? colors.primary : colors.divider}
-      cx='12' cy='12' r='11.5' />
+    <circle fill='none'
+            stroke={ checked && !disabled ? colors.primary : (black && !disabled ? '#000' : colors.divider) }
+            cx='12' cy='12' r='11.5' />
   </svg>
 )
 
-export default ({children, style, name, value, checked, disabled, onChange}) => (
+export default ({children, style, name, value, checked, disabled, black, onChange}) => (
   <label {...styles.label} style={{color: disabled ? colors.disabled : colors.text, ...style}}>
     <span {...styles.box}>
-      <Radio checked={checked} disabled={disabled} />
+      <Radio checked={ checked } disabled={ disabled } black={ black }/>
     </span>
     <input
       {...styles.input}

--- a/src/components/Form/Radio.js
+++ b/src/components/Form/Radio.js
@@ -29,7 +29,7 @@ const Radio = ({checked, disabled}) => (
     {checked && (
       <circle fill={ disabled ? colors.disabled : colors.primary } cx='12' cy='12' r='6'/>
     )}
-    <circle fill='none' stroke={ checked && !disabled ? colors.primary : disabled ? colors.divider : '#000' }
+    <circle fill='none' stroke={ checked && !disabled ? colors.primary : disabled ? colors.divider : colors.secondary }
             cx='12' cy='12' r='11.5'/>
   </svg>
 )

--- a/src/components/Form/Radio.js
+++ b/src/components/Form/Radio.js
@@ -27,9 +27,9 @@ const Radio = ({checked, disabled}) => (
   <svg width='24' height='24' viewBox='0 0 24 24'>
     <circle fill='#fff' stroke='#fff' strokeWidth='6' cx='12' cy='12' r='9' />
     {checked && (
-      <circle fill={ disabled ? colors.disabled : '#000' } cx='12' cy='12' r='6'/>
+      <circle fill={ disabled ? colors.disabled : colors.primary } cx='12' cy='12' r='6'/>
     )}
-    <circle fill='none' stroke={ disabled ? colors.divider : '#000' }
+    <circle fill='none' stroke={ checked && !disabled ? colors.primary : disabled ? colors.divider : '#000' }
             cx='12' cy='12' r='11.5'/>
   </svg>
 )

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -176,14 +176,6 @@ state: {value: 'yes'}
   </Radio>
   <br />
   <Radio
-    black
-    value='black'
-    checked={state.value === 'black'}
-    onChange={(event) => setState({value: event.target.value})}>
-    Schwarz
-  </Radio>
-  <br />
-  <Radio
     value='maybe'
     disabled={true}
     onChange={(event) => setState({value: event.target.value})}>

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -176,6 +176,14 @@ state: {value: 'yes'}
   </Radio>
   <br />
   <Radio
+    black
+    value='black'
+    checked={state.value === 'black'}
+    onChange={(event) => setState({value: event.target.value})}>
+    Schwarz
+  </Radio>
+  <br />
+  <Radio
     value='maybe'
     disabled={true}
     onChange={(event) => setState({value: event.target.value})}>


### PR DESCRIPTION
Without a label, an inactive radio button is indistinguishable from a disabled one. A black border adds visibility to the `Radio` component and aligns its design with the `Checkbox` component.

<img width="138" alt="image" src="https://user-images.githubusercontent.com/299766/46907278-7427ec80-cf10-11e8-8e50-66b60b6fc710.png">

Alternatively, a `black` prop could be added to the component to make it black and white (like on the `Button` component).