### PR TITLE
feat(Comment): misc improvements (collapsing, upvotes/downvotes, share)

### DIFF
--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -74,22 +74,26 @@ class Comment extends Component {
     this.commentBodyRef = ref => { this.commentBody = ref }
 
     this.measure = () => {
+      let measured = {}
       if (this.commentBody) {
         const rect = this.commentBody.getBoundingClientRect()
-        this.commentBodyHeight = rect.height
-        this.isMobile = window.innerWidth < mBreakPoint
+        measured = {
+          commentBodyHeight: rect.height,
+          isMobile: window.innerWidth < mBreakPoint
+        }
       }
+      return measured
     }
 
     this.maybeCollapse = () => {
       if (!this.props.onShouldCollapse) {
         return
       }
-      this.measure()
+      const { commentBodyHeight, isMobile } = this.measure()
       if (
-        this.commentBodyHeight &&
-        this.commentBodyHeight >
-          (this.isMobile ? COLLAPSED_HEIGHT.mobile : COLLAPSED_HEIGHT.desktop) +
+        commentBodyHeight &&
+        commentBodyHeight >
+          (isMobile ? COLLAPSED_HEIGHT.mobile : COLLAPSED_HEIGHT.desktop) +
             COLLAPSED_HEIGHT.threshold
       ) {
         this.props.onShouldCollapse && this.props.onShouldCollapse()

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -11,8 +11,7 @@ import ReplyIcon from 'react-icons/lib/md/reply'
 import ShareIcon from 'react-icons/lib/md/share'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
-import { Label, linkRule } from '../Typography'
-import { ellipsize } from '../../lib/styleMixins'
+import { Label } from '../Typography'
 
 const config = {
   right: 36,

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -87,7 +87,19 @@ const styles = {
   })
 }
 
-export const CommentActions = ({t, score, onAnswer, onEdit, onUnpublish, onUpvote, onDownvote, replyBlockedMsg, highlighted, collapsed, onToggleCollapsed}) => {
+export const CommentActions = ({
+  t,
+  score,
+  onAnswer,
+  onEdit,
+  onUnpublish,
+  onUpvote,
+  onDownvote,
+  replyBlockedMsg,
+  highlighted,
+  collapsed,
+  onToggleCollapsed
+}) => {
   const collapsable = collapsed !== undefined
   return (
     <div {...styles.root} {...(collapsable && collapsed && !highlighted ? styles.collapsed : undefined)}>

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -7,6 +7,7 @@ import UnpublishIcon from 'react-icons/lib/md/visibility-off'
 import EditIcon from 'react-icons/lib/md/edit'
 import ReplyIcon from 'react-icons/lib/md/reply'
 import colors from '../../theme/colors'
+import { mUp } from '../../theme/mediaQueries'
 import {Label, linkRule} from '../Typography'
 
 const config = {
@@ -14,7 +15,7 @@ const config = {
   left: 20
 }
 
-const actionsMinWidth = 76
+const actionsMinWidth = 86
 
 const buttonStyle = {
   outline: 'none',
@@ -105,11 +106,11 @@ export const CommentActions = ({t, score, onAnswer, onEdit, onUnpublish, onUpvot
       </IconButton>}
       </div>
       {collapsable && (
-        <div>
-          <button {...styles.collapseButton} onClick={onToggleCollapsed}>
-            <Label><span {...linkRule}>{t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)}</span></Label>
-          </button>
-        </div>
+        <button {...styles.collapseButton} onClick={onToggleCollapsed}>
+          <Label>
+            <span {...linkRule}>{t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)}</span>
+          </Label>
+        </button>
         )
       }
       <div {...styles.rightActions}>

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -1,22 +1,19 @@
 import React from 'react'
 import {css} from 'glamor'
-import ExpandIcon from 'react-icons/lib/md/keyboard-arrow-down'
-import CollapseIcon from 'react-icons/lib/md/keyboard-arrow-up'
-import MdKeyboardArrowDown from 'react-icons/lib/md/arrow-drop-down'
-import MdKeyboardArrowUp from 'react-icons/lib/md/arrow-drop-up'
+import MdKeyboardArrowDown from 'react-icons/lib/md/keyboard-arrow-down'
+import MdKeyboardArrowUp from 'react-icons/lib/md/keyboard-arrow-up'
 // options: speaker-notes-off, block, clear, visibility-off, remove-circle
 import UnpublishIcon from 'react-icons/lib/md/visibility-off'
 import EditIcon from 'react-icons/lib/md/edit'
 import ReplyIcon from 'react-icons/lib/md/reply'
 import ShareIcon from 'react-icons/lib/md/share'
 import colors from '../../theme/colors'
-import { mUp } from '../../theme/mediaQueries'
+import { ellipsize } from '../../lib/styleMixins'
 import { Label } from '../Typography'
 
 const config = {
-  right: 36,
-  left: 20,
-  center: 30
+  right: 26,
+  left: 20
 }
 
 const buttonStyle = {
@@ -99,18 +96,11 @@ const styles = {
   }),
   centerButton: css({
     ...buttonStyle,
-    height: `${config.center}px`,
-    display: 'flex',
-    alignItems: 'center',
-    flexShrink: 0
+    ...ellipsize,
+    flex: '1 0 20px'
   }),
   centerLabel: css({
-    color: colors.text,
-    display: 'none',
-    [mUp]: {
-      display: 'block',
-      lineHeight: `${config.center}px`
-    }
+    color: colors.primary
   })
 }
 
@@ -130,7 +120,6 @@ export const CommentActions = ({
   onToggleCollapsed
 }) => {
   const collapsable = collapsed !== undefined
-  const CollapsableIcon = collapsed ? ExpandIcon : CollapseIcon
   const collapseLabel = t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)
   return (
     <div {...styles.root} {...(collapsable && !highlighted ? styles.collapsable : undefined)}>
@@ -154,7 +143,6 @@ export const CommentActions = ({
       </div>
       {collapsable && (
         <button {...styles.centerButton} onClick={onToggleCollapsed} title={collapseLabel}>
-          <CollapsableIcon size={config.center} />
           <Label>
             <span {...styles.centerLabel}>{collapseLabel}</span>
           </Label>

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -7,11 +7,23 @@ import UnpublishIcon from 'react-icons/lib/md/visibility-off'
 import EditIcon from 'react-icons/lib/md/edit'
 import ReplyIcon from 'react-icons/lib/md/reply'
 import colors from '../../theme/colors'
-import {Label} from '../Typography'
+import {Label, linkRule} from '../Typography'
 
 const config = {
   right: 26,
   left: 20
+}
+
+const actionsMinWidth = 76
+
+const buttonStyle = {
+  outline: 'none',
+  WebkitAppearance: 'none',
+  background: 'transparent',
+  border: 'none',
+  padding: '0',
+  display: 'block',
+  cursor: 'pointer'
 }
 
 const styles = {
@@ -22,12 +34,18 @@ const styles = {
       display: 'block'
     }
   }),
-  actions: css({
+  rightActions: css({
     display: 'flex',
     alignItems: 'center',
     fontSize: '18px',
     lineHeight: '1',
     marginLeft: 'auto',
+    minWidth: `${actionsMinWidth}px`
+  }),
+  leftActions: css({
+    display: 'flex',
+    marginRight: 'auto',
+    minWidth: `${actionsMinWidth}px`
   }),
   votes: css({
     display: 'flex',
@@ -36,13 +54,7 @@ const styles = {
     marginLeft: 10
   }),
   iconButton: css({
-    outline: 'none',
-    WebkitAppearance: 'none',
-    background: 'transparent',
-    border: 'none',
-    padding: '0',
-    display: 'block',
-    cursor: 'pointer',
+    ...buttonStyle,
     margin: '0 4px',
     '& svg': {
       margin: '0 auto'
@@ -64,37 +76,56 @@ const styles = {
     width: `${config.left}px`,
     fontSize: `${config.left}px`,
     lineHeight: `${config.left}px`
+  }),
+  collapsed: css({
+    borderTop: `1px solid ${colors.divider}`,
+    paddingTop: '6px'
+  }),
+  collapseButton: css({
+    ...buttonStyle
   })
 }
 
-export const CommentActions = ({t, score, onAnswer, onEdit, onUnpublish, onUpvote, onDownvote, replyBlockedMsg}) => (
-  <div {...styles.root}>
-    {onAnswer && <IconButton type='left' onClick={replyBlockedMsg ? null : onAnswer}
-      title={replyBlockedMsg || t('styleguide/CommentActions/answer')}>
-      <ReplyIcon fill={replyBlockedMsg ? colors.disabled : colors.text} />
-    </IconButton>}
-    {onEdit && <IconButton type='left' onClick={onEdit}
-      title={t('styleguide/CommentActions/edit')}>
-      <EditIcon />
-    </IconButton>}
-    {onUnpublish && <IconButton type='left' onClick={onUnpublish}
-      title={t('styleguide/CommentActions/unpublish')}>
-      <UnpublishIcon />
-    </IconButton>}
-
-    <div {...styles.actions}>
-      <div {...styles.votes}>
-        <IconButton onClick={onUpvote} title={t('styleguide/CommentActions/upvote')}>
-          <MdKeyboardArrowUp />
-        </IconButton>
-        <Label>{score}</Label>
-        <IconButton onClick={onDownvote} title={t('styleguide/CommentActions/downvote')}>
-          <MdKeyboardArrowDown />
-        </IconButton>
+export const CommentActions = ({t, score, onAnswer, onEdit, onUnpublish, onUpvote, onDownvote, replyBlockedMsg, highlighted, collapsed, onToggleCollapsed}) => {
+  const collapsable = collapsed !== undefined
+  return (
+    <div {...styles.root} {...(collapsable && collapsed && !highlighted ? styles.collapsed : undefined)}>
+      <div {...styles.leftActions}>
+      {onAnswer && <IconButton type='left' onClick={replyBlockedMsg ? null : onAnswer}
+        title={replyBlockedMsg || t('styleguide/CommentActions/answer')}>
+        <ReplyIcon fill={replyBlockedMsg ? colors.disabled : colors.text} />
+      </IconButton>}
+      {onEdit && <IconButton type='left' onClick={onEdit}
+        title={t('styleguide/CommentActions/edit')}>
+        <EditIcon />
+      </IconButton>}
+      {onUnpublish && <IconButton type='left' onClick={onUnpublish}
+        title={t('styleguide/CommentActions/unpublish')}>
+        <UnpublishIcon />
+      </IconButton>}
+      </div>
+      {collapsable && (
+        <div>
+          <button {...styles.collapseButton} onClick={onToggleCollapsed}>
+            <Label><span {...linkRule}>{t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)}</span></Label>
+          </button>
+        </div>
+        )
+      }
+      <div {...styles.rightActions}>
+        <div {...styles.votes}>
+          <IconButton onClick={onUpvote} title={t('styleguide/CommentActions/upvote')}>
+            <MdKeyboardArrowUp />
+          </IconButton>
+          <Label>{score}</Label>
+          <IconButton onClick={onDownvote} title={t('styleguide/CommentActions/downvote')}>
+            <MdKeyboardArrowDown />
+          </IconButton>
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 // Use the 'iconSize' to adjust the visual weight of the icon. For example
 // the 'MdShareIcon' looks much larger next to 'MdKeyboardArrowUp' if both

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -6,16 +6,16 @@ import MdKeyboardArrowUp from 'react-icons/lib/md/keyboard-arrow-up'
 import UnpublishIcon from 'react-icons/lib/md/visibility-off'
 import EditIcon from 'react-icons/lib/md/edit'
 import ReplyIcon from 'react-icons/lib/md/reply'
+import ShareIcon from 'react-icons/lib/md/share'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
-import {Label, linkRule} from '../Typography'
+import { Label, linkRule } from '../Typography'
+import { ellipsize } from '../../lib/styleMixins'
 
 const config = {
   right: 26,
   left: 20
 }
-
-const actionsMinWidth = 86
 
 const buttonStyle = {
   outline: 'none',
@@ -40,19 +40,26 @@ const styles = {
     alignItems: 'center',
     fontSize: '18px',
     lineHeight: '1',
-    marginLeft: 'auto',
-    minWidth: `${actionsMinWidth}px`
+    marginLeft: 'auto'
   }),
   leftActions: css({
     display: 'flex',
     marginRight: 'auto',
-    minWidth: `${actionsMinWidth}px`
+    flexWrap: 'nowrap'
   }),
   votes: css({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginLeft: 10
+  }),
+  vote: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginLeft: 4,
+    [mUp]: {
+      marginLeft: 10
+    }
   }),
   iconButton: css({
     ...buttonStyle,
@@ -70,7 +77,8 @@ const styles = {
     height: `${config.right}px`,
     width: `${config.right}px`,
     fontSize: `${config.right}px`,
-    lineHeight: `${config.right}px`
+    lineHeight: `${config.right}px`,
+    margin: 0
   }),
   leftButton: css({
     height: `${config.left}px`,
@@ -83,16 +91,19 @@ const styles = {
     paddingTop: '6px'
   }),
   collapseButton: css({
+    ...ellipsize,
     ...buttonStyle
   })
 }
 
 export const CommentActions = ({
   t,
-  score,
+  downVotes,
+  upVotes,
   onAnswer,
   onEdit,
   onUnpublish,
+  onShare,
   onUpvote,
   onDownvote,
   replyBlockedMsg,
@@ -116,6 +127,10 @@ export const CommentActions = ({
         title={t('styleguide/CommentActions/unpublish')}>
         <UnpublishIcon />
       </IconButton>}
+      {onShare && <IconButton type='left' onClick={onShare}
+        title={t('styleguide/CommentActions/share')}>
+        <ShareIcon />
+      </IconButton>}
       </div>
       {collapsable && (
         <button {...styles.collapseButton} onClick={onToggleCollapsed}>
@@ -127,13 +142,18 @@ export const CommentActions = ({
       }
       <div {...styles.rightActions}>
         <div {...styles.votes}>
-          <IconButton onClick={onUpvote} title={t('styleguide/CommentActions/upvote')}>
-            <MdKeyboardArrowUp />
-          </IconButton>
-          <Label>{score}</Label>
-          <IconButton onClick={onDownvote} title={t('styleguide/CommentActions/downvote')}>
-            <MdKeyboardArrowDown />
-          </IconButton>
+          <div {...styles.vote}>
+            <Label title={t.pluralize('styleguide/CommentActions/upvote/count', {count: upVotes})}>{upVotes}</Label>
+            <IconButton onClick={onUpvote} title={t('styleguide/CommentActions/upvote')}>
+              <MdKeyboardArrowUp />
+            </IconButton>
+          </div>
+          <div {...styles.vote}>
+            <Label title={t.pluralize('styleguide/CommentActions/downvote/count', {count: downVotes})}>{downVotes}</Label>
+            <IconButton onClick={onDownvote} title={t('styleguide/CommentActions/downvote')}>
+              <MdKeyboardArrowDown />
+            </IconButton>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import {css} from 'glamor'
-import MdKeyboardArrowDown from 'react-icons/lib/md/keyboard-arrow-down'
-import MdKeyboardArrowUp from 'react-icons/lib/md/keyboard-arrow-up'
+import ExpandIcon from 'react-icons/lib/md/keyboard-arrow-down'
+import CollapseIcon from 'react-icons/lib/md/keyboard-arrow-up'
+import MdKeyboardArrowDown from 'react-icons/lib/md/arrow-drop-down'
+import MdKeyboardArrowUp from 'react-icons/lib/md/arrow-drop-up'
 // options: speaker-notes-off, block, clear, visibility-off, remove-circle
 import UnpublishIcon from 'react-icons/lib/md/visibility-off'
 import EditIcon from 'react-icons/lib/md/edit'
@@ -13,8 +15,9 @@ import { Label, linkRule } from '../Typography'
 import { ellipsize } from '../../lib/styleMixins'
 
 const config = {
-  right: 26,
-  left: 20
+  right: 36,
+  left: 20,
+  center: 30
 }
 
 const buttonStyle = {
@@ -55,11 +58,11 @@ const styles = {
   vote: css({
     display: 'flex',
     justifyContent: 'space-between',
-    alignItems: 'center',
-    marginLeft: 4,
-    [mUp]: {
-      marginLeft: 10
-    }
+    alignItems: 'center'
+  }),
+  voteDivider: css({
+    color: colors.disabled,
+    padding: '0 2px'
   }),
   iconButton: css({
     ...buttonStyle,
@@ -74,11 +77,16 @@ const styles = {
     }
   }),
   rightButton: css({
+    display: 'flex',
+    justifyContent: 'center',
     height: `${config.right}px`,
-    width: `${config.right}px`,
+    width: '24px',
     fontSize: `${config.right}px`,
     lineHeight: `${config.right}px`,
-    margin: 0
+    margin: 0,
+    '& > svg': {
+      flexShrink: 0
+    }
   }),
   leftButton: css({
     height: `${config.left}px`,
@@ -86,13 +94,24 @@ const styles = {
     fontSize: `${config.left}px`,
     lineHeight: `${config.left}px`
   }),
-  collapsed: css({
+  collapsable: css({
     borderTop: `1px solid ${colors.divider}`,
     paddingTop: '6px'
   }),
-  collapseButton: css({
-    ...ellipsize,
-    ...buttonStyle
+  centerButton: css({
+    ...buttonStyle,
+    height: `${config.center}px`,
+    display: 'flex',
+    alignItems: 'center',
+    flexShrink: 0
+  }),
+  centerLabel: css({
+    color: colors.text,
+    display: 'none',
+    [mUp]: {
+      display: 'block',
+      lineHeight: `${config.center}px`
+    }
   })
 }
 
@@ -112,8 +131,10 @@ export const CommentActions = ({
   onToggleCollapsed
 }) => {
   const collapsable = collapsed !== undefined
+  const CollapsableIcon = collapsed ? ExpandIcon : CollapseIcon
+  const collapseLabel = t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)
   return (
-    <div {...styles.root} {...(collapsable && collapsed && !highlighted ? styles.collapsed : undefined)}>
+    <div {...styles.root} {...(collapsable && !highlighted ? styles.collapsable : undefined)}>
       <div {...styles.leftActions}>
       {onAnswer && <IconButton type='left' onClick={replyBlockedMsg ? null : onAnswer}
         title={replyBlockedMsg || t('styleguide/CommentActions/answer')}>
@@ -133,9 +154,10 @@ export const CommentActions = ({
       </IconButton>}
       </div>
       {collapsable && (
-        <button {...styles.collapseButton} onClick={onToggleCollapsed}>
+        <button {...styles.centerButton} onClick={onToggleCollapsed} title={collapseLabel}>
+          <CollapsableIcon size={config.center} />
           <Label>
-            <span {...linkRule}>{t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)}</span>
+            <span {...styles.centerLabel}>{collapseLabel}</span>
           </Label>
         </button>
         )
@@ -143,13 +165,14 @@ export const CommentActions = ({
       <div {...styles.rightActions}>
         <div {...styles.votes}>
           <div {...styles.vote}>
-            <Label title={t.pluralize('styleguide/CommentActions/upvote/count', {count: upVotes})}>{upVotes}</Label>
             <IconButton onClick={onUpvote} title={t('styleguide/CommentActions/upvote')}>
               <MdKeyboardArrowUp />
             </IconButton>
+            <Label title={t.pluralize('styleguide/CommentActions/upvote/count', {count: upVotes})}>{upVotes}</Label>
           </div>
+          <div {...styles.voteDivider}>/</div>
           <div {...styles.vote}>
-            <Label title={t.pluralize('styleguide/CommentActions/downvote/count', {count: downVotes})}>{downVotes}</Label>
+          <Label title={t.pluralize('styleguide/CommentActions/downvote/count', {count: downVotes})}>{downVotes}</Label>
             <IconButton onClick={onDownvote} title={t('styleguide/CommentActions/downvote')}>
               <MdKeyboardArrowDown />
             </IconButton>

--- a/src/components/Comment/docs.md
+++ b/src/components/Comment/docs.md
@@ -229,7 +229,8 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
 <CommentActions
   t={t}
 
-  score={8}
+  upVotes={8}
+  downVotes={3}
 
   onAnswer={undefined}
   onUpvote={undefined}
@@ -240,7 +241,8 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
 <CommentActions
   t={t}
 
-  score={8}
+  upVotes={8}
+  downVotes={3}
 
   onAnswer={() => {}}
   onUpvote={undefined}
@@ -251,7 +253,8 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
 <CommentActions
   t={t}
 
-  score={8}
+  upVotes={8}
+  downVotes={3}
 
   onAnswer={() => {}}
   onUpvote={() => {}}
@@ -262,11 +265,13 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
 <CommentActions
   t={t}
 
-  score={8}
+  upVotes={8}
+  downVotes={3}
 
   onAnswer={() => {}}
-  onUpvote={undefined}
-  onDownvote={undefined}
+  onShare={() => {}}
+  onUpvote={() => {}}
+  onDownvote={() => {}}
   collapsed={true}
 />
 ```
@@ -274,11 +279,13 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
 <CommentActions
   t={t}
 
-  score={8}
+  upVotes={8}
+  downVotes={3}
 
   onAnswer={() => {}}
-  onUpvote={undefined}
-  onDownvote={undefined}
+  onShare={() => {}}
+  onUpvote={() => {}}
+  onDownvote={() => {}}
   collapsed={false}
 />
 ```

--- a/src/components/Comment/docs.md
+++ b/src/components/Comment/docs.md
@@ -258,3 +258,27 @@ The profile picture in the `<CommentHeader />` has a white border so that we can
   onDownvote={() => {}}
 />
 ```
+```react|noSource,span-2
+<CommentActions
+  t={t}
+
+  score={8}
+
+  onAnswer={() => {}}
+  onUpvote={undefined}
+  onDownvote={undefined}
+  collapsed={true}
+/>
+```
+```react|noSource,span-2
+<CommentActions
+  t={t}
+
+  score={8}
+
+  onAnswer={() => {}}
+  onUpvote={undefined}
+  onDownvote={undefined}
+  collapsed={false}
+/>
+```

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -154,7 +154,7 @@ class RowState extends PureComponent {
       composerState: 'idle', // idle | focused | submitting | error
       composerError: undefined, // or string
       shouldCollapse: false,
-      collapsed: true
+      collapsed: !!props.collapsable
     }
 
     this.openComposer = () => {

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -17,9 +17,37 @@ const styles = {
   }),
 }
 
-const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, composerError, onEditPreferences, onAnswer, edit, onUnpublish, onUpvote, onDownvote, dismissComposer, submitComment, highlighted, timeago, maxLength, replyBlockedMsg, Link, secondaryActions, collapsed, onToggleCollapsed, onShouldCollapse}) => {
+const Row = ({
+  t,
+  visualDepth,
+  head,
+  tail,
+  otherChild,
+  comment,
+  displayAuthor,
+  showComposer,
+  composerError,
+  onEditPreferences,
+  onAnswer,
+  edit,
+  onUnpublish,
+  onShare,
+  onUpvote,
+  onDownvote,
+  dismissComposer,
+  submitComment,
+  highlighted,
+  timeago,
+  maxLength,
+  replyBlockedMsg,
+  Link,
+  secondaryActions,
+  collapsed,
+  onToggleCollapsed,
+  onShouldCollapse
+}) => {
   const isEditing = edit && edit.isEditing
-  const { score } = comment
+  const { downVotes, upVotes } = comment
 
   const barCount = visualDepth - (otherChild ? 1 : 0)
 
@@ -56,10 +84,12 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
         <div style={{marginLeft: profilePictureSize + profilePictureMargin}}>
           <CommentActions
             t={t}
-            score={score}
+            downVotes={downVotes}
+            upVotes={upVotes}
             onAnswer={onAnswer}
             onEdit={edit && edit.start}
             onUnpublish={onUnpublish}
+            onShare={onShare}
             onUpvote={onUpvote}
             onDownvote={onDownvote}
             replyBlockedMsg={replyBlockedMsg}
@@ -98,13 +128,21 @@ Row.propTypes = {
   composerError: PropTypes.string,
   onEditPreferences: PropTypes.func.isRequired,
   onAnswer: PropTypes.func,
+  onUnpublish: PropTypes.func,
+  onShare: PropTypes.func,
   onUpvote: PropTypes.func,
   onDownvote: PropTypes.func,
   dismissComposer: PropTypes.func.isRequired,
   submitComment: PropTypes.func.isRequired,
+  highlighted: PropTypes.bool,
   timeago: PropTypes.func.isRequired,
   maxLength: PropTypes.number,
-  replyBlockedMsg: PropTypes.string
+  replyBlockedMsg: PropTypes.string,
+  Link: PropTypes.func,
+  secondaryActions: PropTypes.func,
+  collapsed: PropTypes.bool,
+  onToggleCollapsed: PropTypes.func,
+  onShouldCollapse: PropTypes.func
 }
 
 class Composer extends PureComponent {
@@ -214,6 +252,7 @@ class RowState extends PureComponent {
       otherChild,
       displayAuthor,
       onEditPreferences,
+      onShare,
       isAdmin,
       maxLength,
       replyBlockedMsg,
@@ -278,6 +317,7 @@ class RowState extends PureComponent {
         onUpvote={(!displayAuthor || userVote === 'UP') ? undefined : this.upvoteComment}
         onDownvote={(!displayAuthor || userVote === 'DOWN') ? undefined : this.downvoteComment}
         onUnpublish={(isAdmin || comment.userCanEdit) && comment.published && (() => this.props.unpublishComment(comment.id))}
+        onShare={onShare ? (() => onShare(comment.id)) : undefined}
         dismissComposer={this.dismissComposer}
         submitComment={this.submitComment}
         edit={edit}

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -139,7 +139,7 @@ Row.propTypes = {
   maxLength: PropTypes.number,
   replyBlockedMsg: PropTypes.string,
   Link: PropTypes.func,
-  secondaryActions: PropTypes.func,
+  secondaryActions: PropTypes.object,
   collapsed: PropTypes.bool,
   onToggleCollapsed: PropTypes.func,
   onShouldCollapse: PropTypes.func

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -240,7 +240,11 @@ class RowState extends PureComponent {
     }
   }
 
-
+  componentWillReceiveProps (nextProps) {
+    if (!!nextProps.highlighted) {
+      this.setState({collapsed: false})
+    }
+  }
 
   render () {
     const {

--- a/src/components/CommentTree/Row.js
+++ b/src/components/CommentTree/Row.js
@@ -17,7 +17,7 @@ const styles = {
   }),
 }
 
-const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, composerError, onEditPreferences, onAnswer, edit, onUnpublish, onUpvote, onDownvote, dismissComposer, submitComment, highlighted, timeago, maxLength, replyBlockedMsg, Link, secondaryActions}) => {
+const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, showComposer, composerError, onEditPreferences, onAnswer, edit, onUnpublish, onUpvote, onDownvote, dismissComposer, submitComment, highlighted, timeago, maxLength, replyBlockedMsg, Link, secondaryActions, collapsed, onToggleCollapsed, onShouldCollapse}) => {
   const isEditing = edit && edit.isEditing
   const { score } = comment
 
@@ -33,6 +33,8 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
           Link={Link}
           timeago={timeago}
           t={t}
+          collapsed={collapsed}
+          onShouldCollapse={onShouldCollapse}
         />}
         {isEditing && (
           <div style={{marginBottom: 20}}>
@@ -61,6 +63,9 @@ const Row = ({t, visualDepth, head, tail, otherChild, comment, displayAuthor, sh
             onUpvote={onUpvote}
             onDownvote={onDownvote}
             replyBlockedMsg={replyBlockedMsg}
+            highlighted={highlighted}
+            collapsed={collapsed}
+            onToggleCollapsed={onToggleCollapsed}
           />
 
           {(displayAuthor && showComposer) &&
@@ -147,7 +152,9 @@ class RowState extends PureComponent {
 
     this.state = {
       composerState: 'idle', // idle | focused | submitting | error
-      composerError: undefined // or string
+      composerError: undefined, // or string
+      shouldCollapse: false,
+      collapsed: true
     }
 
     this.openComposer = () => {
@@ -186,7 +193,16 @@ class RowState extends PureComponent {
         }
       )
     }
+    this.toggleCollapsed = () => {
+      this.setState({collapsed: !this.state.collapsed})
+    }
+
+    this.onShouldCollapse = () => {
+      this.setState({shouldCollapse: true})
+    }
   }
+
+
 
   render () {
     const {
@@ -202,9 +218,10 @@ class RowState extends PureComponent {
       maxLength,
       replyBlockedMsg,
       Link,
-      secondaryActions
+      secondaryActions,
+      collapsable
     } = this.props
-    const {composerState, composerError} = this.state
+    const {composerState, composerError, collapsed, shouldCollapse} = this.state
     const {userVote} = comment
 
     const edit = comment.userCanEdit && {
@@ -236,6 +253,14 @@ class RowState extends PureComponent {
       error: this.state.editError
     }
 
+    const collapseAttributes = collapsable
+      ? {
+          collapsed: shouldCollapse ? collapsed : undefined,
+          onShouldCollapse: this.onShouldCollapse,
+          onToggleCollapsed: this.toggleCollapsed
+        }
+      : undefined
+
     return (
       <Row
         t={t}
@@ -261,6 +286,7 @@ class RowState extends PureComponent {
         replyBlockedMsg={replyBlockedMsg}
         Link={Link}
         secondaryActions={secondaryActions}
+        {...collapseAttributes}
       />
     )
   }

--- a/src/components/CommentTree/comments.js
+++ b/src/components/CommentTree/comments.js
@@ -7,7 +7,8 @@ export const mkComment = (n, children, pageInfo) => ({
     name: `${n} – Christof Moser`,
     credential: {description: 'Journalist, Autor, Diktator, Rebel und Republikaner', verified: true}
   },
-  score: 8,
+  upVotes: 8,
+  downVotes: 3,
   userVote: 'DOWN',
   content: 'Journalismus strebt nach Klarheit, er ist der Feind der uralten Angst vor dem Neuen.',
   comments: children.length === 0

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-10-11T12:41:32.900Z",
+  "updated": "2018-10-17T11:46:59.317Z",
   "title": "live",
   "data": [
     {
@@ -35,8 +35,32 @@
       "value": "+1"
     },
     {
+      "key": "styleguide/CommentActions/upvote/count/0",
+      "value": "Keine Stimmen dafür"
+    },
+    {
+      "key": "styleguide/CommentActions/upvote/count/1",
+      "value": "Eine Stimme dafür"
+    },
+    {
+      "key": "styleguide/CommentActions/upvote/count/other",
+      "value": "{count} Stimmen dafür"
+    },
+    {
       "key": "styleguide/CommentActions/downvote",
       "value": "-1"
+    },
+    {
+      "key": "styleguide/CommentActions/downvote/count/0",
+      "value": "Keine Gegenstimmen"
+    },
+    {
+      "key": "styleguide/CommentActions/downvote/count/1",
+      "value": "Eine Gegenstimme"
+    },
+    {
+      "key": "styleguide/CommentActions/downvote/count/other",
+      "value": "{count} Gegenstimmen"
     },
     {
       "key": "styleguide/CommentActions/expand",

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-10-17T11:46:59.317Z",
+  "updated": "2018-10-22T14:21:38.726Z",
   "title": "live",
   "data": [
     {
@@ -64,7 +64,7 @@
     },
     {
       "key": "styleguide/CommentActions/expand",
-      "value": "Alles lesen"
+      "value": "Mehr"
     },
     {
       "key": "styleguide/CommentActions/collapse",

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-06-13T22:14:01.275Z",
+  "updated": "2018-10-11T12:41:32.900Z",
   "title": "live",
   "data": [
     {
@@ -37,6 +37,14 @@
     {
       "key": "styleguide/CommentActions/downvote",
       "value": "-1"
+    },
+    {
+      "key": "styleguide/CommentActions/expand",
+      "value": "Alles lesen"
+    },
+    {
+      "key": "styleguide/CommentActions/collapse",
+      "value": "Weniger"
     },
     {
       "key": "styleguide/CommentTeaser/commentLink",

--- a/src/templates/Discussion/index.js
+++ b/src/templates/Discussion/index.js
@@ -37,6 +37,11 @@ const createSchema = ({
         key: 'dossier',
         ref: 'repo'
       },
+      {
+        label: 'Lange Beiträge zuklappen',
+        key: 'collapsable',
+        ref: 'bool'
+      },
       ...customMetaFields
     ],
     ...args


### PR DESCRIPTION
Related to
https://github.com/orbiting/republik-frontend/pull/200
https://github.com/orbiting/backends/pull/118

#### Three features:
- add optional "collapsable" UI 
- explicit upvotes/downvotes instead of single score
- share icon in actions bar

#### Collapsing logic in a nutshell:
- A discussion can be flagged as `collapsable` in Publikator
- If a discussion is collapsable, the comment component measures whether its body is significantly higher than the max height and therefore `shouldCollapse`, and reports that back to the HOC row
- the row passes `collapsed` prop down to `Comment` and `CommentActions` (note that `true/false` triggers the respective UI while `undefined` triggers nothing)

#### Styleguide deploy
https://r-styleguide-pr-181.herokuapp.com/components/comment#ltcommentactions-gt

#### in republik-frontend
<img width="858" alt="screen shot 2018-10-17 at 13 54 01" src="https://user-images.githubusercontent.com/23520051/47084677-86f23800-d214-11e8-9296-9fe93460f141.png">
<img width="441" alt="screen shot 2018-10-17 at 13 54 30" src="https://user-images.githubusercontent.com/23520051/47084679-878ace80-d214-11e8-8fd1-78e3a7dd16f7.png">
<img width="378" alt="screen shot 2018-10-17 at 13 55 06" src="https://user-images.githubusercontent.com/23520051/47084680-878ace80-d214-11e8-8345-be8e6b93c5ed.png">

#### Ellipsizing with all icons present on small screen
<img width="392" alt="screen shot 2018-10-17 at 13 56 27" src="https://user-images.githubusercontent.com/23520051/47084681-878ace80-d214-11e8-9652-4fad99a91f32.png">

