### PR TITLE
Bars with Inline Text

### DIFF
--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -144,6 +144,28 @@ Luzern,Nein,0.313,
 </div>
 ```
 
+## Links
+
+```react
+<div>
+  <ChartTitle>Häufigste Namen bei der Republik</ChartTitle>
+  <CsvChart t={t}
+    config={{
+      "type": "Bar",
+      "numberFormat": "s",
+      "link": "href",
+      "showBarValues": true,
+      "y": "name"
+    }}
+    values={`
+name,value,href
+Thomas,494,https://www.republik.ch/suche?q=thomas&filters=type%253AUser&sort=relevance%253A
+Peter,464,https://www.republik.ch/suche?q=peter&filters=type%253AUser&sort=relevance%253A
+    `.trim()} />
+  <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></Editorial.Note>
+</div>
+```
+
 ## Negative Values
 
 ```react

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -112,6 +112,37 @@ Sexuelle Belästigung,sehr stark,0.093
 </div>
 ```
 
+## Inline Values and Labels
+
+```react
+<div>
+  <ChartTitle>Velobeschluss</ChartTitle>
+  <ChartLead>Angenommen mit 73.6% Ja</ChartLead>
+  <CsvChart t={t}
+    config={{
+      "type": "Bar",
+      "numberFormat": ".1%",
+      "color": "vote",
+      "colorRange": "diverging1",
+      "inlineValue": true,
+      "inlineLabel": "vote",
+      "inlineSecondaryLabel": "count",
+      "y": "canton"
+    }}
+    values={`
+canton,vote,value,count
+,Ja,0.736,1 475 165 Stimmen
+,Nein,0.264,529 268 Stimmen
+Zürich,Ja,0.719,
+Zürich,Nein,0.281,
+Bern,Ja,0.722,
+Bern,Nein,0.278,
+Luzern,Ja,0.687,
+Luzern,Nein,0.313,
+    `.trim()} />
+  <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></Editorial.Note>
+</div>
+```
 
 ## Negative Values
 

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -161,9 +161,9 @@ Luzern,Nein,0.313,
     }}
     values={`
 name,value,href
-Thomas,494,https://www.republik.ch/suche?q=thomas&filters=type%253AUser&sort=relevance%253A
-Peter,464,https://www.republik.ch/suche?q=peter&filters=type%253AUser&sort=relevance%253A
-Daniel,415,https://www.republik.ch/suche?q=daniel&filters=type%253AUser&sort=relevance%253A
+Thomas,494,https://www.republik.ch/~tpreusse
+Peter,464
+Daniel,415,https://www.republik.ch/~daniel
     `.trim()} />
   <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></Editorial.Note>
 </div>

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -153,14 +153,17 @@ Luzern,Nein,0.313,
     config={{
       "type": "Bar",
       "numberFormat": "s",
+      "sort": "descending",
       "link": "href",
-      "showBarValues": true,
+      "inlineValue": true,
+      "inlineValueUnit": "Konten",
       "y": "name"
     }}
     values={`
 name,value,href
 Thomas,494,https://www.republik.ch/suche?q=thomas&filters=type%253AUser&sort=relevance%253A
 Peter,464,https://www.republik.ch/suche?q=peter&filters=type%253AUser&sort=relevance%253A
+Daniel,415,https://www.republik.ch/suche?q=daniel&filters=type%253AUser&sort=relevance%253A
     `.trim()} />
   <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></Editorial.Note>
 </div>

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -369,6 +369,7 @@ const BarChart = (props) => {
                               (segment.value < 0 && i !== 0)
                             )
                             const inlineFill = getTextColor(segment.color)
+                            const inlineEndAnchor = isLast && i !== 0
 
                             return (
                               <g key={`seg${i}`} transform={`translate(0,${bar.y})`}>
@@ -376,12 +377,12 @@ const BarChart = (props) => {
                                 {(inlineValue || inlineLabel) && (
                                   <Fragment>
                                     <text {...styles.inlineLabel}
-                                      x={segment.x + (isLast ? segment.width - 5 : 5)}
+                                      x={segment.x + (inlineEndAnchor ? segment.width - 5 : 5)}
                                       y={bar.style.inlineTop}
                                       dy='1em'
                                       fontSize={bar.style.fontSize}
                                       fill={inlineFill}
-                                      textAnchor={isLast
+                                      textAnchor={inlineEndAnchor
                                         ? 'end'
                                         : 'start'}>
                                       {subsup.svg([
@@ -392,12 +393,12 @@ const BarChart = (props) => {
                                     </text>
                                     {inlineSecondaryLabel && (
                                       <text {...styles.inlineLabel}
-                                        x={segment.x + (isLast ? segment.width - 5 : 5)}
+                                        x={segment.x + (inlineEndAnchor ? segment.width - 5 : 5)}
                                         y={bar.style.inlineTop + bar.style.fontSize + 5}
                                         dy='1em'
                                         fontSize={bar.style.secondaryFontSize}
                                         fill={inlineFill}
-                                        textAnchor={isLast
+                                        textAnchor={inlineEndAnchor
                                           ? 'end'
                                           : 'start'}>
                                         {subsup.svg(segment.datum[inlineSecondaryLabel])}

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -136,6 +136,7 @@ const BarChart = (props) => {
     confidence,
     showBarValues,
     inlineValue,
+    inlineValueUnit,
     inlineLabel,
     inlineSecondaryLabel
   } = props
@@ -371,9 +372,11 @@ const BarChart = (props) => {
                                     textAnchor={isLast
                                       ? 'end'
                                       : 'start'}>
-                                    {inlineValue && xAxis.format(segment.value)}
-                                    {inlineValue && inlineLabel && ' '}
-                                    {inlineLabel && subsup.svg(segment.datum[inlineLabel])}
+                                    {subsup.svg([
+                                      inlineValue && xAxis.format(segment.value),
+                                      inlineValueUnit && inlineValueUnit,
+                                      inlineLabel && segment.datum[inlineLabel]
+                                    ].join(' '))}
                                   </text>
                                   {inlineSecondaryLabel && (
                                     <text {...styles.inlineLabel}

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -191,7 +191,9 @@ const BarChart = (props) => {
 
       gY += marginBottom
       let labelY = gY
-      gY += BAR_LABEL_HEIGHT
+      if (first.label) {
+        gY += BAR_LABEL_HEIGHT
+      }
       gY += style.marginTop
       let y = gY
       if (firstBarY === undefined) {
@@ -280,13 +282,13 @@ const BarChart = (props) => {
       group.x = column * (columnWidth + COLUMN_PADDING)
     })
 
-    yPos += height + AXIS_BOTTOM_HEIGHT
+    yPos += height + (props.xAxis ? AXIS_BOTTOM_HEIGHT : 0)
   })
 
   const isLollipop = props.barStyle === 'lollipop'
 
   const xTicks = props.xTicks || xAxis.ticks
-  const highlightZero = xTicks[0] !== 0
+  const highlightZero = xTicks.indexOf(0) !== -1 && xTicks[0] !== 0
 
   return (
     <div>
@@ -354,7 +356,7 @@ const BarChart = (props) => {
                     </g>
                   ))
                 }
-                <g transform={`translate(0,${group.groupHeight + AXIS_BOTTOM_PADDING})`}>
+                {props.xAxis && <g transform={`translate(0,${group.groupHeight + AXIS_BOTTOM_PADDING})`}>
                   {
                     xTicks.map((tick, i) => {
                       let textAnchor = 'middle'
@@ -387,7 +389,7 @@ const BarChart = (props) => {
                       )
                     })
                   }
-                </g>
+                </g>}
               </g>
             )
           })
@@ -420,6 +422,7 @@ BarChart.propTypes = {
   mini: PropTypes.bool,
   domain: PropTypes.array,
   y: PropTypes.string.isRequired,
+  xAxis: PropTypes.bool.isRequired,
   xTicks: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number])),
   barStyle: PropTypes.oneOf(Object.keys(BAR_STYLES)),
   confidence: PropTypes.oneOf([95]),
@@ -452,6 +455,7 @@ BarChart.propTypes = {
 }
 
 BarChart.defaultProps = {
+  xAxis: true,
   columns: 1,
   minInnerWidth: 140,
   barStyle: 'small',

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -104,7 +104,7 @@ const styles = {
   barLabelLink: css({
     ...underline,
     ':hover': {
-      color: colors.lightText
+      fill: colors.lightText
     }
   }),
   inlineLabel: css({
@@ -348,15 +348,16 @@ const BarChart = (props) => {
                 <text dy='1.5em' {...styles.groupTitle}>{group.title}</text>
                 {
                   group.bars.map(bar => {
-                    let barLabel = <text {...styles.barLabel} {...(link && styles.barLabelLink)}
+                    const href = bar.first.datum[link]
+                    let barLabel = <text {...styles.barLabel} {...(href && styles.barLabelLink)}
                       y={bar.labelY}
                       dy='0.9em'
                       x={x(0) + (highlightZero ? (bar.max <= 0 ? -2 : 2) : 0)}
                       textAnchor={bar.max <= 0 ? 'end' : 'start'}>
                       {subsup.svg(bar.first.label)}
                     </text>
-                    if (link) {
-                      barLabel = <a xlinkHref={bar.first.datum[link]}>{barLabel}</a>
+                    if (href) {
+                      barLabel = <a xlinkHref={href}>{barLabel}</a>
                     }
                     return (
                       <g key={`bar${bar.y}`}>

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -75,7 +75,7 @@ const BAR_STYLES = {
     withSecondary: {
       marginTop: 0,
       height: 50,
-      marginBottom: 16,
+      marginBottom: 9,
       fontSize: 16,
       secondaryFontSize: 12,
       inlineTop: 6

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -25,8 +25,8 @@ export const ReactCharts = {
 const createRanges = ({neutral, sequential3, opposite3, discrete}) => {
   const oppositeReversed = [].concat(opposite3).reverse()
   return {
-    diverging1: [sequential3[0], opposite3[0]],
-    diverging1n: [sequential3[0], neutral, opposite3[0]],
+    diverging1: [sequential3[1], opposite3[1]],
+    diverging1n: [sequential3[1], neutral, opposite3[1]],
     diverging2: [...sequential3.slice(0, 2), ...oppositeReversed.slice(0, 2)],
     diverging3: [...sequential3, ...oppositeReversed],
     sequential3,

--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -1,5 +1,6 @@
 import { formatLocale, formatSpecifier, precisionFixed } from 'd3-format'
 import { ascending, descending, max as d3Max } from 'd3-array'
+import { rgb } from 'd3-color'
 import React, { createElement, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import colors from '../../theme/colors'
@@ -233,3 +234,9 @@ export const deduplicate = (d, i, all) => all.indexOf(d) === i
 //   currently: filter, columnFilter.test, category, highlight
 // eslint-disable-next-line no-new-func
 export const unsafeDatumFn = code => new Function('datum', `return ${code}`)
+
+export const getTextColor = bgColor => {
+  const color = rgb(bgColor)
+  const yiq = (color.r * 299 + color.g * 587 + color.b * 114) / 1000
+  return yiq >= 128 ? 'black' : 'white'
+}


### PR DESCRIPTION
Add inline text support for nice voting and election bars. [Docs](https://r-styleguide-pr-185.herokuapp.com/charts/bars#inline-values-and-labels).

<img width="803" alt="screen shot 2018-10-30 at 01 58 22" src="https://user-images.githubusercontent.com/410211/47688793-4d8fd400-dbe7-11e8-8c89-0c6294df0af2.png">

Even with links for candidate profiles:

<img width="805" alt="screen shot 2018-10-30 at 01 58 36" src="https://user-images.githubusercontent.com/410211/47688801-5680a580-dbe7-11e8-9f18-d7ca73f0a74d.png">
