### PR TITLE
fix(CommentActions): hairline only if comment is collapsed

### DIFF
--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -91,7 +91,7 @@ const styles = {
     lineHeight: `${config.left}px`
   }),
   collapsed: css({
-    borderTop: `1px solid ${colors.divider}`,
+    borderTop: `1px solid ${colors.primary}`,
     paddingTop: '6px'
   }),
   centerButton: css({
@@ -122,7 +122,7 @@ export const CommentActions = ({
   const collapsable = collapsed !== undefined
   const collapseLabel = t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)
   return (
-    <div {...styles.root} {...(collapsable && collapsed && !highlighted ? styles.collapsed : undefined)}>
+    <div {...styles.root} {...(collapsable && collapsed && !highlighted && styles.collapsed)}>
       <div {...styles.leftActions}>
       {onAnswer && <IconButton type='left' onClick={replyBlockedMsg ? null : onAnswer}
         title={replyBlockedMsg || t('styleguide/CommentActions/answer')}>

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -90,7 +90,7 @@ const styles = {
     fontSize: `${config.left}px`,
     lineHeight: `${config.left}px`
   }),
-  collapsable: css({
+  collapsed: css({
     borderTop: `1px solid ${colors.divider}`,
     paddingTop: '6px'
   }),
@@ -122,7 +122,7 @@ export const CommentActions = ({
   const collapsable = collapsed !== undefined
   const collapseLabel = t(`styleguide/CommentActions/${ collapsed ? 'expand' : 'collapse'}`)
   return (
-    <div {...styles.root} {...(collapsable && !highlighted ? styles.collapsable : undefined)}>
+    <div {...styles.root} {...(collapsable && collapsed && !highlighted ? styles.collapsed : undefined)}>
       <div {...styles.leftActions}>
       {onAnswer && <IconButton type='left' onClick={replyBlockedMsg ? null : onAnswer}
         title={replyBlockedMsg || t('styleguide/CommentActions/answer')}>

--- a/src/components/Comment/CommentActions.js
+++ b/src/components/Comment/CommentActions.js
@@ -91,7 +91,7 @@ const styles = {
     lineHeight: `${config.left}px`
   }),
   collapsed: css({
-    borderTop: `1px solid ${colors.primary}`,
+    borderTop: `1px solid ${colors.divider}`,
     paddingTop: '6px'
   }),
   centerButton: css({


### PR DESCRIPTION
Minor UI fix which makes collapsed and expanded state better distinguishable without reading the label. (Think: There's a line, so it can be expanded.) Suggested by users.

#### Before
<img width="691" alt="screen shot 2018-11-01 at 15 58 00" src="https://user-images.githubusercontent.com/23520051/47859594-f2303280-ddee-11e8-81cd-7c86f79ebc66.png">

#### After
<img width="694" alt="screen shot 2018-11-01 at 15 57 08" src="https://user-images.githubusercontent.com/23520051/47859552-db89db80-ddee-11e8-927f-5df262188a43.png">
