### PR TITLE
fix(Article): support sub/sup in link, strong and emphasis

### DIFF
--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -45,6 +45,8 @@ export const Label = ({children, ...props}) => (
 
 const subSupStyles = {
   base: css({
+    display: 'inline-block',
+    textDecoration: 'none',
     fontSize: '75%',
     lineHeight: '0',
     position: 'relative',

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -60,6 +60,7 @@ import {
   getDisplayWidth,
   extractImage,
   globalInlines,
+  nestedInlines,
   styles,
   getDatePath
 } from './utils'
@@ -70,13 +71,13 @@ import createDynamicComponent from './dynamicComponent'
 
 const link = {
   matchMdast: matchType('link'),
-
   props: node => ({
     title: node.title,
     href: node.url
   }),
   component: Editorial.A,
-  editorModule: 'link'
+  editorModule: 'link',
+  rules: nestedInlines
 }
 
 const paragraph = {
@@ -95,7 +96,8 @@ const paragraph = {
       editorOptions: {
         type: 'STRONG',
         mdastType: 'strong'
-      }
+      },
+      rules: nestedInlines
     },
     {
       matchMdast: matchType('emphasis'),
@@ -104,7 +106,8 @@ const paragraph = {
       editorOptions: {
         type: 'EMPHASIS',
         mdastType: 'emphasis'
-      }
+      },
+      rules: nestedInlines
     },
     link
   ]

--- a/src/templates/Article/utils.js
+++ b/src/templates/Article/utils.js
@@ -58,7 +58,7 @@ export const getDisplayWidth = ancestors => {
   return FIGURE_SIZES.center
 }
 
-export const globalInlines = [
+export const nestedInlines = [
   {
     matchMdast: matchType('sub'),
     component: Sub,
@@ -75,6 +75,10 @@ export const globalInlines = [
       type: 'sup'
     }
   },
+]
+
+export const globalInlines = [
+  ...nestedInlines,
   {
     matchMdast: matchType('break'),
     component: () => <br />,


### PR DESCRIPTION
#### Preview:
<img width="697" alt="screenshot 2018-11-15 at 16 45 44" src="https://user-images.githubusercontent.com/23520051/48564312-70fc9380-e8f6-11e8-8ca3-8aae02869bd9.png">

I've disabled underlines for sub/sups for now. Here's how they would look like with a regular link underline:
<img width="698" alt="screenshot 2018-11-15 at 16 44 50" src="https://user-images.githubusercontent.com/23520051/48564311-70fc9380-e8f6-11e8-8100-d65727641316.png">

Ideally, a sup nested inside linked text shouldn't interrupt the main underline.



