### PR TITLE
feat(Autocomplete): support icon and autocomplete props

### DIFF
--- a/src/components/Form/Autocomplete.js
+++ b/src/components/Form/Autocomplete.js
@@ -17,7 +17,9 @@ const Autocomplete = ({
   value,
   onChange,
   filter,
-  onFilterChange
+  onFilterChange,
+  icon,
+  autoComplete
 }) => {
   return (
     <Downshift
@@ -46,10 +48,12 @@ const Autocomplete = ({
               <Field
                 label={label}
                 value={isOpen ? filter : (value && value.text) || ''}
+                icon={icon}
                 renderInput={fieldProps => (
                   <input
                     {...getInputProps({
                       ...fieldProps,
+                      autoComplete,
                       placeholder: selectedItem
                           ? itemToString(selectedItem)
                           : ''
@@ -94,7 +98,13 @@ Autocomplete.propTypes = {
   filter: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onFilterChange:
-    PropTypes.func.isRequired
+    PropTypes.func.isRequired,
+  icon: PropTypes.object,
+  autoComplete: PropTypes.string
+}
+
+Autocomplete.defaultProps = {
+  autoComplete: 'off'
 }
 
 export default Autocomplete

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -530,6 +530,8 @@ Properties:
   * **`filter`** - String that will be shown in the filter text input, or `null`.
   * **`onChange`** - Function with signature `nextValue => Void`.
   * **`onFilterChange`** - Function with signature `nextFilter => Void`.
+  * **`icon`** - An icon to display on the right side of the input field, or `undefined`.
+  * **`autoComplete`** - The `autocomplete` HTML5 attribute of the input field, defaults to `off` for suppressing the browser autocomplete dropdown.
 
 `<Autocomplete />` does not incorporate any filter logic itself. Also, it can't be used as uncontrolled component. Both the `value` and the `filter` prop have to be passed in order for the component to behave correctly.
 
@@ -571,5 +573,55 @@ state: {
     onFilterChange={
       filter => setState({...state, filter})
     }
+/>
+```
+
+```react
+state: {
+  value: null,
+  filter: '',
+  items: [
+    {text: 'Januar', value: '01'},
+    {text: 'Februar', value: '02'},
+    {text: 'März', value: '03'},
+    {text: 'April', value: '04'},
+    {text: 'Mai', value: '05'},
+    {text: 'Juni', value: '06'},
+    {text: 'Juli', value: '07'},
+    {text: 'August', value: '08'},
+    {text: 'September', value: '09'},
+    {text: 'Oktober', value: '10'},
+    {text: 'November', value: '10'},
+    {text: 'Dezember', value: '10'}
+  ]
+}
+---
+<Autocomplete
+    label='Monat'
+    value={state.value}
+    filter={state.filter}
+    items={
+      state.items.filter(
+        ({text}) =>
+          !state.filter || text.toLowerCase().includes(state.filter.toLowerCase())
+      )
+    }
+    onChange={
+      value => {
+        setState({...state, value})
+      }
+    }
+    onFilterChange={
+      filter => setState({...state, filter})
+    }
+    icon={
+      <SearchIcon
+        size={30}
+        onClick={() => {
+          console.log('search')
+        }}
+      />
+    }
+    autoComplete='on'
 />
 ```


### PR DESCRIPTION
`icon` is already supported on `Input`, just piping it through (needed for new dialog page).

Docs preview: https://r-styleguide-pr-194.herokuapp.com/forms#autocomplete

#### With annoying browser autocomplete (Chrome)
<img width="449" alt="screenshot 2018-11-21 at 11 54 11" src="https://user-images.githubusercontent.com/23520051/48841220-1ef1bd00-ed91-11e8-82ab-0051a61d6f65.png">

#### With autocomplete off (now the default)
<img width="332" alt="screenshot 2018-11-21 at 11 54 46" src="https://user-images.githubusercontent.com/23520051/48841222-1ef1bd00-ed91-11e8-9f30-57a272df6fc1.png">
