### PR TITLE
fix(articleCollection): trigger correct subject font-size for 3-column layout

### DIFF
--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -964,15 +964,15 @@ Von [Urs Bruderer](/~7b0d6a74-f57b-4498-8eb7-455936672736) (Text) und Adam Higto
 }
 \`\`\`
 
-###### 
+###### Fotobuch
 
-# Planet versus Portemonnaie
+# Wir Übermenschen
 
-## 
+## Matthieu Gafsou: «H+»
 
-#### Sie glauben, wir müssen uns entscheiden zwischen  Wirtschaftswachstum und der Rettung der Erde? Falsch. Die Zahlen sprechen eine andere Sprache.
+#### Die Aufnahmen des Lausanners bilden eine skurrile, geheimnisvolle und manchmal unheimliche Wirklichkeit ab.
 
-Von [Thomas Hebsgaard](https://www.zetland.dk/skribent/ae6XddK5), «Zetland» (Text), und Doris Wöhncke (Übersetzung), 09.08.2018
+Von [Barbara Villiger Heilig](/~5f45d6a3-ff52-4e67-9925-92447f43d2e1 "Barbara Villiger Heilig"), 04.09.2018
 
 <hr /></section>
 

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -12,6 +12,7 @@ import {
 
 import {
   matchTeaser,
+  matchTeaserGroup,
   matchTeaserType,
   extractImage,
   globalInlines,
@@ -37,6 +38,20 @@ import { subject } from '../Front'
 import { Breakout } from '../../components/Center'
 
 import * as Editorial from '../../components/Typography/Editorial'
+
+
+const articleTileSubject = {
+  ...subject,
+  props: (node, index, parent, { ancestors }) => {
+    const teaserGroup = ancestors.find(matchTeaserGroup)
+    const teaser = ancestors.find(matchTeaser)
+    return {
+      color: teaser && teaser.data.color,
+      collapsedColor: teaser && teaser.data.feuilleton && '#000',
+      columns:  3
+    }
+  }
+}
 
 const createTeasers = ({
   t,
@@ -182,7 +197,7 @@ const createTeasers = ({
           )
         }
       ),
-      subject,
+      articleTileSubject,
       articleTileLead,
       teaserFormat,
       teaserCredit


### PR DESCRIPTION
Fixes https://github.com/orbiting/publikator-frontend/issues/181

The front's `subject` rule relies on the number of `columns` stored in the teasergroup data. Since we don't store `columns` data for articleCollections, we hardcode `columns: 3` here to trigger the correct font-size.

## Before fix: subject too large
<img width="973" alt="screenshot 2018-11-21 at 16 00 02" src="https://user-images.githubusercontent.com/23520051/48850094-18bb0b00-eda8-11e8-89bc-0f220eec7dac.png">

## After fix: expected font-size
<img width="971" alt="screenshot 2018-11-21 at 15 58 08" src="https://user-images.githubusercontent.com/23520051/48850117-2c667180-eda8-11e8-9c5e-13591e8ebea7.png">
