### PR TITLE
fix(articleCollection): support formatColor 

### DIFF
--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -45,7 +45,6 @@ const Subject = ({ children, color, collapsedColor, columns }) => {
       color: labColor.l > 50 ? labColor.darker(2.0) : labColor.brighter(3.0),
     }
   })
-
   return (
     <span {...style} {...(columns === 3 ? subjectSmall : subject)}>
       {children}

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -45,6 +45,7 @@ const Subject = ({ children, color, collapsedColor, columns }) => {
       color: labColor.l > 50 ? labColor.darker(2.0) : labColor.brighter(3.0),
     }
   })
+
   return (
     <span {...style} {...(columns === 3 ? subjectSmall : subject)}>
       {children}
@@ -57,6 +58,10 @@ Subject.propTypes = {
   color: PropTypes.string,
   collapsedColor: PropTypes.string,
   columns: PropTypes.number
+}
+
+Subject.defaultProps = {
+  color: '#000'
 }
 
 export default Subject

--- a/src/components/TeaserFront/Subject.js
+++ b/src/components/TeaserFront/Subject.js
@@ -59,8 +59,4 @@ Subject.propTypes = {
   columns: PropTypes.number
 }
 
-Subject.defaultProps = {
-  color: '#000'
-}
-
 export default Subject

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -43,7 +43,7 @@ const articleTileSubject = {
   props: (node, index, parent, { ancestors }) => {
     const teaser = ancestors.find(matchTeaser)
     return {
-      color: teaser && teaser.data.color ? teaser.data.color : undefined,
+      color: teaser && teaser.data.color ? teaser.data.color : '#000',
       columns:  3
     }
   }

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -12,7 +12,6 @@ import {
 
 import {
   matchTeaser,
-  matchTeaserGroup,
   matchTeaserType,
   extractImage,
   globalInlines,
@@ -42,11 +41,9 @@ import * as Editorial from '../../components/Typography/Editorial'
 const articleTileSubject = {
   ...subject,
   props: (node, index, parent, { ancestors }) => {
-    const teaserGroup = ancestors.find(matchTeaserGroup)
     const teaser = ancestors.find(matchTeaser)
     return {
-      color: teaser && teaser.data.color,
-      collapsedColor: teaser && teaser.data.feuilleton && '#000',
+      color: teaser && teaser.data.color ? teaser.data.color : undefined,
       columns:  3
     }
   }
@@ -67,7 +64,9 @@ const createTeasers = ({
     props (node, index, parent, { ancestors }) {
       const teaser = ancestors.find(matchTeaser)
       return {
-        kind: parent.data.kind,
+        kind: parent.data.kind === 'feuilleton'
+          ? 'editorial'
+          : parent.data.kind,
         titleSize: parent.data.titleSize,
         href: teaser
           ? teaser.data.url
@@ -103,8 +102,8 @@ const createTeasers = ({
 
   const teaserFormat = {
     matchMdast: matchHeading(6),
-    component: ({ children, attributes, href }) =>
-      <Editorial.Format attributes={attributes}>
+    component: ({ children, attributes, formatColor, href }) =>
+      <Editorial.Format attributes={attributes} color={formatColor}>
         <Link href={href} passHref>
           <a href={href} {...styles.link}>
             {children}
@@ -115,6 +114,13 @@ const createTeasers = ({
       const teaser = ancestors.find(matchTeaser)
       const data = teaser && teaser.data
       return {
+        formatColor: data
+          ? data.formatColor
+            ? data.formatColor
+            : data.kind
+              ? colors[data.kind]
+              : undefined
+          : undefined,
         href: data ? data.formatUrl : undefined
       }
     },
@@ -185,6 +191,7 @@ const createTeasers = ({
       teaserType: 'articleTile',
       showUI: false,
       formOptions: [
+        'formatColor',
         'showImage',
         'image',
         'kind'


### PR DESCRIPTION
Prerequisite for https://github.com/orbiting/publikator-frontend/pull/185

- sets `formatColor` on subject from teaser data
- enables `formatColor` color picker on editor
- remove `collapsedColor` which is irrelevant for article collection tiles