### PR TITLE
fix(Editorial): bump up mobile font-size from 16px to 17px

### DIFF
--- a/src/components/Dossier/Lead.js
+++ b/src/components/Dossier/Lead.js
@@ -2,11 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { mUp } from '../TeaserFront/mediaQueries'
-import { serifRegular16, serifRegular23 } from '../Typography/styles'
+import { serifRegular17, serifRegular23 } from '../Typography/styles'
 
 const styles = {
   lead: css({
-    ...serifRegular16,
+    ...serifRegular17,
     margin: '0 0 10px 0',
     [mUp]: {
       ...serifRegular23,

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -51,7 +51,7 @@ const styles = {
     color: colors.text,
     paddingLeft: `${WIDTH}px`,
     position: 'relative',
-    ...serifRegular16,
+    ...serifRegular17,
     [mUp]: {
       ...serifRegular19,
       paddingLeft: 0
@@ -65,6 +65,7 @@ const styles = {
       margin: '12px 0',
       [mUp]: {
         ...serifRegular17,
+        lineHeight: '28px',
         margin: '14px 0'
       }
     },

--- a/src/components/TeaserFeed/Lead.js
+++ b/src/components/TeaserFeed/Lead.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import colors from '../../theme/colors'
 import { mUp } from '../../theme/mediaQueries'
-import { serifRegular16, serifRegular19 } from '../Typography/styles'
+import { serifRegular17, serifRegular19 } from '../Typography/styles'
 
 const styles = {
   main: css({
-    ...serifRegular16,
+    ...serifRegular17,
     margin: '0 0 5px 0',
     [mUp]: {
       ...serifRegular19

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -132,7 +132,7 @@ export const Format = ({ children, color, attributes, ...props }) => (
 const paragraph = css({
   color: colors.text,
   margin: '22px 0 22px 0',
-  ...styles.serifRegular16,
+  ...styles.serifRegular17,
   [mUp]: {
     ...styles.serifRegular19,
     margin: '30px 0 30px 0'
@@ -154,7 +154,7 @@ export const P = ({ children, attributes, ...props }) => (
 )
 
 const question = css({
-  ...styles.serifBold16,
+  ...styles.serifBold17,
   margin: '36px 0 -14px 0',
   [mUp]: {
     ...styles.serifBold19,

--- a/src/components/Typography/docs.md
+++ b/src/components/Typography/docs.md
@@ -73,7 +73,7 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 <div {...css(styles.serifTitle20)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
-#### `serifBold{52,36,28,24,19,16}`
+#### `serifBold{52,36,28,24,19,17}`
 ```react|noSource,plain
 <div {...css(styles.serifBold52)}>The quick brown fox jumps over</div>
 ```
@@ -90,10 +90,10 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 <div {...css(styles.serifBold19)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
-<div {...css(styles.serifBold16)}>The quick brown fox jumps over the lazy dog</div>
+<div {...css(styles.serifBold17)}>The quick brown fox jumps over the lazy dog</div>
 ```
 
-#### `serifRegular{25,23,21,19,18,16,14}`
+#### `serifRegular{25,23,21,19,18,17,16,14}`
 ```react|noSource,plain
 <div {...css(styles.serifRegular25)}>The quick brown fox jumps over the lazy dog</div>
 ```
@@ -108,6 +108,9 @@ import {colors: {text}, fontStyles: {serifRegular21}} from '@project-r/styleguid
 ```
 ```react|noSource,plain
 <div {...css(styles.serifRegular18)}>The quick brown fox jumps over the lazy dog</div>
+```
+```react|noSource,plain
+<div {...css(styles.serifRegular17)}>The quick brown fox jumps over the lazy dog</div>
 ```
 ```react|noSource,plain
 <div {...css(styles.serifRegular16)}>The quick brown fox jumps over the lazy dog</div>

--- a/src/components/Typography/styles.js
+++ b/src/components/Typography/styles.js
@@ -86,7 +86,7 @@ export const serifRegular18 = {
 export const serifRegular17 = {
   fontFamily: fontFamilies.serifRegular,
   fontSize: 17,
-  lineHeight: '28px'
+  lineHeight: '25px'
 }
 export const serifRegular16 = {
   fontFamily: fontFamilies.serifRegular,
@@ -131,13 +131,13 @@ export const serifBold19 = {
   fontFamily: fontFamilies.serifBold,
   fontWeight: 'normal',
   fontSize: 19,
-  lineHeight: '24px'
+  lineHeight: '25px'
 }
-export const serifBold16 = {
+export const serifBold17 = {
   fontFamily: fontFamilies.serifBold,
   fontWeight: 'normal',
-  fontSize: 16,
-  lineHeight: '24px'
+  fontSize: 17,
+  lineHeight: '25px'
 }
 
 // sansSerifRegular

--- a/src/components/Typography/styles.js
+++ b/src/components/Typography/styles.js
@@ -86,7 +86,7 @@ export const serifRegular18 = {
 export const serifRegular17 = {
   fontFamily: fontFamilies.serifRegular,
   fontSize: 17,
-  lineHeight: '25px'
+  lineHeight: '26px'
 }
 export const serifRegular16 = {
   fontFamily: fontFamilies.serifRegular,
@@ -131,13 +131,13 @@ export const serifBold19 = {
   fontFamily: fontFamilies.serifBold,
   fontWeight: 'normal',
   fontSize: 19,
-  lineHeight: '25px'
+  lineHeight: '24px'
 }
 export const serifBold17 = {
   fontFamily: fontFamilies.serifBold,
   fontWeight: 'normal',
   fontSize: 17,
-  lineHeight: '25px'
+  lineHeight: '26px'
 }
 
 // sansSerifRegular


### PR DESCRIPTION
Also updating 
- closely related elements (Editorial.UL, Editorial.OL, Editorial.Question)
- similar `16/19` font-size pairs (TeaserFeed.Lead)
- other 16px mobile serif fonts (TeaserFrontDossierLead)

I didn't touch InfoBox which still looks good to me (slightly losing visual weight on mobile compared to normal text), but open for suggestions here. FYI, InfoBox title is (still) 16px, InfoBox text is (still) 15px.

FYI, existing `serifRegular17` with higher line-height only used on List, so no side effects expected from there: https://github.com/search?q=org%3Aorbiting+serifRegular17&type=Code

## Article before vs. after
![screenshot 2018-11-27 at 10 18 15](https://user-images.githubusercontent.com/23520051/49075108-703cf900-f236-11e8-9d1b-2bda14b35c4d.png)
![screenshot 2018-11-27 at 11 40 07](https://user-images.githubusercontent.com/23520051/49076416-40432500-f239-11e8-989e-5262cbf9994a.png)


## List before vs. after
![screenshot 2018-11-27 at 10 44 52](https://user-images.githubusercontent.com/23520051/49075192-a11d2e00-f236-11e8-97b8-b415141d47a0.png)
![screenshot 2018-11-27 at 10 45 09](https://user-images.githubusercontent.com/23520051/49075194-a11d2e00-f236-11e8-8eec-16d838d3b897.png)

## TeaserFeed before vs. after
![screenshot 2018-11-27 at 11 10 41](https://user-images.githubusercontent.com/23520051/49075267-c1e58380-f236-11e8-9eac-efbf3e6b7088.png)
![screenshot 2018-11-27 at 11 10 54](https://user-images.githubusercontent.com/23520051/49075268-c1e58380-f236-11e8-8c3a-13440849de5e.png)

## Unchanged InfoBox before vs. after
![screenshot 2018-11-27 at 11 26 09](https://user-images.githubusercontent.com/23520051/49075615-6bc51000-f237-11e8-870a-c1c296b49cb7.png)
![screenshot 2018-11-27 at 11 26 26](https://user-images.githubusercontent.com/23520051/49075617-6bc51000-f237-11e8-83ef-4c62b57c679c.png)