### PR TITLE
feat: add discussionClosed flag to article and discussion template

### DIFF
--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -587,6 +587,11 @@ const createSchema = ({
       ref: 'bool'
     },
     {
+      label: 'Diskussion geschlossen',
+      key: 'discussionClosed',
+      ref: 'bool'
+    },
+    {
       label: 'Format',
       key: 'format',
       ref: 'repo'

--- a/src/templates/Discussion/index.js
+++ b/src/templates/Discussion/index.js
@@ -38,6 +38,11 @@ const createSchema = ({
         ref: 'repo'
       },
       {
+      label: 'Diskussion geschlossen',
+        key: 'discussionClosed',
+        ref: 'bool'
+      },
+      {
         label: 'Lange Beiträge zuklappen',
         key: 'collapsable',
         ref: 'bool'


### PR DESCRIPTION
Depends on https://github.com/orbiting/backends/pull/159

This will allow to close (and re-open) a discussion via the Publikator UI. If template is `article`, the auto-discussion will be closed. If template is `discussion`, the classic discussion will be closed.

republik-frontend is ready to handle dialog box and linkedDiscussion icon appropriately:
https://github.com/orbiting/republik-frontend/commit/d7c8a293bf39b8c158f2e2853450679a2bcd5373