### PR TITLE
feat(inQuotes)

### DIFF
--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -6,6 +6,7 @@ import NewPage from 'react-icons/lib/md/open-in-new'
 
 import colors from '../../theme/colors'
 import { ellipsize, underline } from '../../lib/styleMixins'
+import { inQuotes } from '../../lib/inQuotes'
 import { linkRule } from '../Typography/'
 import { serifRegular14, sansSerifRegular14 } from '../Typography/styles'
 import { CommentBodyParagraph } from '../CommentBody/web'
@@ -164,7 +165,7 @@ export const CommentTeaser = ({
                 passHref
               >
                 <a {...linkRule}>
-                  «{discussion.title}»
+                  {inQuotes(discussion.title)}
                   {newPage && (
                     <span {...styles.icon}>
                       <NewPage size={ICON_SIZE} fill={colors.disabled} />

--- a/src/index.js
+++ b/src/index.js
@@ -669,6 +669,15 @@ ReactDOM.render(
             path: '/z-index',
             title: 'z-index',
             src: require('./theme/zIndex.docs.md')
+          },
+          {
+            path: '/dev/inQuotes',
+            title: 'inQuotes',
+            src: require('./lib/inQuotes.docs.md'),
+            imports: {
+              ...require('./components/Typography'),
+              ...require('./lib/inQuotes')
+            }
           }
         ]
       }

--- a/src/lib.js
+++ b/src/lib.js
@@ -7,6 +7,7 @@ export const mediaQueries = allMediaQueries
 export {fontFamilies, fontFaces} from './theme/fonts'
 
 export {slug} from './lib/slug'
+export {inQuotes} from './lib/inQuotes'
 export {createFormatter, createPlaceholderFormatter} from './lib/translate'
 
 export {default as Logo} from './components/Logo'

--- a/src/lib/inQuotes.docs.md
+++ b/src/lib/inQuotes.docs.md
@@ -1,0 +1,38 @@
+Utility function for wrapping a string in quotation marks and avoiding double quoting. Ignores already quoted strings (of the same quotation marks pattern) and replaces nested quotation marks. No support for third level quotation marks.
+
+```code|lang-js
+import {inQuotes} from '@project-r/styleguide'
+
+const quotedTitle = inQuotes('My title')  // '«My title»'
+```
+
+
+```react
+<Editorial.Subhead>{inQuotes('An der Bar')}</Editorial.Subhead>
+```
+
+```react
+<Editorial.Subhead>{inQuotes('«An der Bar»')}</Editorial.Subhead>
+```
+
+```react
+<Editorial.Subhead>{inQuotes('«An der Bar» mit Carla Del Ponte')}</Editorial.Subhead>
+```
+
+```react
+<Editorial.Subhead>{inQuotes('An der «Republik-Bar» mit Carla Del Ponte')}</Editorial.Subhead>
+```
+
+```react
+<Editorial.Subhead>
+  {inQuotes(
+    'An der „Republik-Bar“ mit Carla Del Ponte',
+    {
+      outerOpening: '„',
+      outerClosing: '“',
+      innerOpening: '‚',
+      innerClosing: '‘'
+    }
+  )}
+</Editorial.Subhead>
+```

--- a/src/lib/inQuotes.docs.md
+++ b/src/lib/inQuotes.docs.md
@@ -1,4 +1,4 @@
-Utility function for wrapping a string in quotation marks and avoiding double quoting. Ignores already quoted strings (of the same quotation marks pattern) and replaces nested quotation marks. No support for third level quotation marks.
+Utility function for wrapping a string in quotation marks and avoiding double quoting. Ignores already quoted strings of the same quotation marks pattern and replaces nested quotation marks. No support for third level nested quotation marks or transformations between different quotation mark patterns.
 
 ```code|lang-js
 import {inQuotes} from '@project-r/styleguide'

--- a/src/lib/inQuotes.js
+++ b/src/lib/inQuotes.js
@@ -1,0 +1,23 @@
+const defaultMarks = {
+  outerOpening: '«',
+  outerClosing: '»',
+  innerOpening: '‹',
+  innerClosing: '›'
+}
+
+export const inQuotes = (
+  str,
+  marks = defaultMarks
+) => {
+  let quotedStr = str.trim()
+  if (
+    quotedStr.startsWith(marks.outerOpening) &&
+    quotedStr.endsWith(marks.outerClosing)
+  ) {
+    return quotedStr
+  }
+  quotedStr = quotedStr
+    .replace(marks.outerOpening, marks.innerOpening)
+    .replace(marks.outerClosing, marks.innerClosing)
+  return marks.outerOpening + quotedStr + marks.outerClosing
+}


### PR DESCRIPTION
Utility function for wrapping a string in quotation marks and avoiding double quoting. Ignores already quoted strings of the same quotation marks pattern and replaces nested quotation marks.

Docs: https://r-styleguide-pr-203.herokuapp.com/dev/inQuotes

## Examples

### Before
<img width="501" alt="screenshot 2018-12-18 at 12 30 54" src="https://user-images.githubusercontent.com/23520051/50159434-f77e0980-02d6-11e9-9c9e-9f25da8dee70.png">

### After
<img width="498" alt="screenshot 2018-12-18 at 12 31 45" src="https://user-images.githubusercontent.com/23520051/50159442-fea51780-02d6-11e9-8a99-aeb9d75f9035.png">


### Before
<img width="500" alt="screenshot 2018-12-18 at 12 00 57" src="https://user-images.githubusercontent.com/23520051/50159382-d4ebf080-02d6-11e9-9b06-b797597a46b0.png">

### After
<img width="487" alt="screenshot 2018-12-18 at 15 15 15" src="https://user-images.githubusercontent.com/23520051/50159772-c6520900-02d7-11e9-9d2e-4611f6b3869f.png">



