### PR TITLE
fix(subSup): avoid illegible multi-line mess while preserving no underline in link

### DIFF
--- a/src/components/Typography/docs.md
+++ b/src/components/Typography/docs.md
@@ -383,6 +383,12 @@ UI elements and structured information uses the sans serif cuts. Without margins
 <div>
   <Interaction.P>40 µg/m<Sup>3</Sup></Interaction.P>
   <Editorial.P>CO<Sub>2eq</Sub></Editorial.P>
+  <Editorial.P>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see <Editorial.Emphasis>40 µg/m<Sup>3</Sup> and CO<Sub>2eq</Sub></Editorial.Emphasis> and <Editorial.A href='#'>40 µg/m<Sup>3</Sup> and CO<Sub>2eq</Sub></Editorial.A>.
+  </Editorial.P>
+  <Editorial.P>
+    <Sub>One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly.</Sub>
+  </Editorial.P>
 </div>
 ```
 

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -48,7 +48,7 @@ const subSupStyles = {
     display: 'inline-block',
     textDecoration: 'none',
     fontSize: '75%',
-    lineHeight: 'initial',
+    lineHeight: '1.4em',
     position: 'relative',
     verticalAlign: 'baseline'
   }),

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -48,7 +48,7 @@ const subSupStyles = {
     display: 'inline-block',
     textDecoration: 'none',
     fontSize: '75%',
-    lineHeight: '0',
+    lineHeight: 'initial',
     position: 'relative',
     verticalAlign: 'baseline'
   }),


### PR DESCRIPTION
Preview in context: https://r-styleguide-pr-204.herokuapp.com/typography#sub-and-super-script

### Before
<img width="667" alt="screenshot 2018-12-18 at 16 38 35" src="https://user-images.githubusercontent.com/23520051/50164801-eee00000-02e3-11e9-8d91-6b8258e30473.png">

### After
<img width="671" alt="screenshot 2018-12-18 at 16 38 54" src="https://user-images.githubusercontent.com/23520051/50164817-f7383b00-02e3-11e9-84f2-bb1dd264b117.png">
