### PR TITLE
feat(Article): add Publikator flags to indicate video/gallery and disable text progress

### DIFF
--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -582,8 +582,23 @@ const createSchema = ({
   documentEditorOptions = {},
   customMetaFields = [
     {
-      label: 'Bildergalerie',
+      label: 'Bildergalerie aktiv',
       key: 'gallery',
+      ref: 'bool'
+    },
+    {
+      label: 'Icon: Bildergalerie',
+      key: 'indicateGallery',
+      ref: 'bool'
+    },
+    {
+      label: 'Icon: Video',
+      key: 'indicateVideo',
+      ref: 'bool'
+    },
+    {
+      label: 'Keine Leseposition (z.B. für Videoartikel)',
+      key: 'disableTextProgress',
       ref: 'bool'
     },
     {


### PR DESCRIPTION
Allows to tag existing articles ahead of launching the reading list. We will infer the audio icon from audioSrc… meta field(s) until there's a use case for a manual flag.

<img width="453" alt="screenshot 2019-01-03 at 16 45 29" src="https://user-images.githubusercontent.com/23520051/50647019-dc1e2a00-0f77-11e9-8212-33bbfc4ba7fb.png">
