### PR TITLE
Chart Entry Point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # production
 /build
 /lib
+/chart.js
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   },
   "files": [
     "lib",
-    "src"
+    "src",
+    "chart.js"
   ],
   "main": "./lib/lib.js",
   "author": "Thomas Preusse <t@preus.se> (https://t.preus.se/)",
@@ -84,7 +85,7 @@
   },
   "scripts": {
     "commit": "git-cz",
-    "prepublishOnly": "npm run prebuild && npm run build:lib",
+    "prepublishOnly": "npm run prebuild && npm run build:lib && cp ./lib/chart.js ./chart.js",
     "prebuild": "rimraf lib",
     "build:lib": "babel src --out-dir lib",
     "build": "npm run build:lib && react-scripts build",

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,0 +1,1 @@
+export { default as Chart, ChartTitle, ChartLead } from './components/Chart'

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -2,7 +2,7 @@
 <div>
   <ChartTitle>Abgabenquote im internationalen Vergleich</ChartTitle>
   <ChartLead>in Prozent des BIP 2015</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": ".0%",
@@ -30,7 +30,7 @@ Irland,0.236
 <div>
   <ChartTitle>Themenstruktur der verschiedenen Formen der Weiterbildung 2014</ChartTitle>
   <ChartLead>in Prozent</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "color": "type",
@@ -72,7 +72,7 @@ nicht oder nur einstellig klassifizierbar,Betriebliche Weiterbildung,0.04
 ```react
 <div>
   <ChartTitle>Kriminalitätsfurcht 2012</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": "%",
@@ -116,7 +116,7 @@ Use `colorLegendValues` to only label specific colors:
 
 ```react
 <div>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": "%",
@@ -154,7 +154,7 @@ mehr,0.1
 <div>
   <ChartTitle>Velobeschluss</ChartTitle>
   <ChartLead>Angenommen mit 73.6% Ja</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": ".1%",
@@ -185,7 +185,7 @@ Luzern,Nein,0.313,
 ```react
 <div>
   <ChartTitle>Häufigste Namen bei der Republik</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": "s",
@@ -211,7 +211,7 @@ Daniel,415,https://www.republik.ch/~daniel
 <div>
   <ChartTitle>Wie positiv ist Alkoholkonsum?</ChartTitle>
   <ChartLead>Konstruktivität durch scharfe, negative Kritik</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": ".0%",
@@ -236,7 +236,7 @@ Absinth,-0.8
 <div>
   <ChartTitle>Ein undurchsichtiger durchsichtiger Hack</ChartTitle>
   <ChartLead>in Prozent</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Bar",
       "numberFormat": ".0%",

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -138,7 +138,7 @@ const BarChart = (props) => {
     width,
     mini,
     children,
-    t,
+    tLabel,
     description,
     band,
     bandLegend,
@@ -296,7 +296,7 @@ const BarChart = (props) => {
     x.nice(3)
   }
 
-  const xAxis = calculateAxis(props.numberFormat, t, x.domain())
+  const xAxis = calculateAxis(props.numberFormat, tLabel, x.domain())
 
   // stack bars
   groupedData.forEach(group => {
@@ -548,7 +548,7 @@ BarChart.propTypes = {
   filter: PropTypes.string,
   minInnerWidth: PropTypes.number.isRequired,
   columns: PropTypes.number.isRequired,
-  t: PropTypes.func.isRequired,
+  tLabel: PropTypes.func.isRequired,
   description: PropTypes.string,
   showBarValues: PropTypes.bool
 }

--- a/src/components/Chart/Lines.docs.md
+++ b/src/components/Chart/Lines.docs.md
@@ -1,7 +1,7 @@
 ```react
 <div>
   <ChartTitle>Entwicklung der Lebenserwartung bei Geburt</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Line",
       "unit": "Jahre",
@@ -100,7 +100,7 @@ year,gender,at_age,value
 ```react
 <div>
   <ChartTitle>BitCoin-Preis</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "unit": "US-Dollar",
       "x": "date",
@@ -487,7 +487,7 @@ Use a `band` column base name with `_lower` and `_upper` data to display bands, 
 ```react
 <div>
   <ChartTitle>Entwicklung der Arbeitszufriedenheit nach Einkommensgruppen</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "numberFormat": ".2f",
       "color": "category",

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -6,12 +6,12 @@ import { range, min, max } from 'd3-array'
 import { scaleOrdinal, scalePoint, scaleTime } from 'd3-scale'
 import { line as lineShape, area as areaShape } from 'd3-shape'
 import { timeYear } from 'd3-time'
-import { timeFormat } from 'd3-time-format'
 
 import {
   sansSerifRegular12, sansSerifMedium14, sansSerifMedium22
 } from '../Typography/styles'
 import colors from '../../theme/colors'
+import { timeFormat } from '../../lib/timeFormat'
 
 import layout, {
   LABEL_FONT, VALUE_FONT,

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -498,7 +498,7 @@ LineChart.propTypes = {
     x: PropTypes.string,
     dy: PropTypes.string
   })),
-  t: PropTypes.func.isRequired,
+  tLabel: PropTypes.func.isRequired,
   description: PropTypes.string
 }
 

--- a/src/components/Chart/Lines.layout.js
+++ b/src/components/Chart/Lines.layout.js
@@ -113,12 +113,12 @@ export default (props) => {
   }
   const color = scaleOrdinal(colorRange).domain(colorValues)
 
-  const {unit, t} = props
+  const { unit, tLabel } = props
   let yCut
   if (!props.zero) {
-    yCut = t('styleguide/charts/y-cut')
+    yCut = tLabel('Achse gekürzt')
   }
-  const yAxis = calculateAxis(props.numberFormat, t, y.domain(), unit)
+  const yAxis = calculateAxis(props.numberFormat, tLabel, y.domain(), unit)
   const {format: yFormat} = yAxis
 
   const startValue = !mini && props.startValue

--- a/src/components/Chart/Lollipops.docs.md
+++ b/src/components/Chart/Lollipops.docs.md
@@ -3,7 +3,7 @@ Lollipop charts are just lighter bar charts. The circle at the end makes it idea
 ```react
 <div>
   <ChartTitle>Armutsrisikoquote nach Altersgruppen 2014</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Lollipop",
       "numberFormat": "%",

--- a/src/components/Chart/ScatterPlots.docs.md
+++ b/src/components/Chart/ScatterPlots.docs.md
@@ -5,7 +5,7 @@ Go forth and make correlations visible, and tell everyone it proofs nothing!
 <div>
   <ChartTitle>Einkommen und CO<Sub>2</Sub>-Emissionen pro Kopf im Jahr 2014</ChartTitle>
   <ChartLead>Mit mehr Einkommen sind bisher meist auch mehr Emissionen verbunden.</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "ScatterPlot",
       "label": "geo",

--- a/src/components/Chart/ScatterPlots.js
+++ b/src/components/Chart/ScatterPlots.js
@@ -159,7 +159,7 @@ class ScatterPlot extends Component {
       description,
       children,
       values,
-      t, tLabel,
+      tLabel,
       opacity
     } = props
 
@@ -198,7 +198,7 @@ class ScatterPlot extends Component {
     if (xNice) {
       x.nice(xNice)
     }
-    const xAxis = calculateAxis(props.xNumberFormat || props.numberFormat, t, x.domain()) // xUnit is rendered separately
+    const xAxis = calculateAxis(props.xNumberFormat || props.numberFormat, tLabel, x.domain()) // xUnit is rendered separately
     const xTicks = props.xTicks || (props.xScale === 'log' ? get3EqualDistTicks(x) : xAxis.ticks)
     // ensure highest value is last: the last value is labled with the unit
     xTicks.sort(ascending)
@@ -217,7 +217,7 @@ class ScatterPlot extends Component {
     if (yNice) {
       y.nice(yNice)
     }
-    const yAxis = calculateAxis(props.yNumberFormat || props.numberFormat, t, y.domain(), tLabel(props.yUnit))
+    const yAxis = calculateAxis(props.yNumberFormat || props.numberFormat, tLabel, y.domain(), tLabel(props.yUnit))
     const yTicks = props.yTicks || (props.yScale === 'log' ? get3EqualDistTicks(y) : yAxis.ticks)
     // ensure highest value is last: the last value is labled with the unit
     yTicks.sort(ascending)
@@ -382,7 +382,7 @@ ScatterPlot.propTypes = {
   size: PropTypes.string.isRequired,
   sizeRange: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired,
   label: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
+  tLabel: PropTypes.func.isRequired,
   description: PropTypes.string
 }
 

--- a/src/components/Chart/Slopes.docs.md
+++ b/src/components/Chart/Slopes.docs.md
@@ -2,7 +2,7 @@
 <div>
   <ChartTitle>Lebenserwartung bei Geburt</ChartTitle>
   <ChartLead>Ein Vergleich zwischen 1990 und 2015.</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "Slope",
       "unit": "Jahre",
@@ -28,7 +28,7 @@ year,gender,at_age,value
 ```
 
 ```react
-<CsvChart t={t}
+<CsvChart
     config={{
       "color": "country",
       "colorSort": "none",

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -4,7 +4,7 @@ Vertical bars are a nice line chart alternative for change over time of one (sta
 <div>
   <ChartTitle>Entwicklung der Treibhausgas-Emissionen in Deutschland</ChartTitle>
   <ChartLead>in Millionen Tonnen CO<Sub>2eq</Sub> pro Jahr</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "TimeBar",
       "color": "gas",
@@ -226,7 +226,7 @@ By default a four digit year column is expected. Use `x`, `timeParse` and `timeF
 ```react
 <div>
   <ChartTitle>Devisenanlagen der SNB</ChartTitle>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "TimeBar",
       "color": "bilanzposition",
@@ -469,7 +469,7 @@ Note: You should specify the `xInterval` prop when you have gaps in your data. A
 <div>
   <ChartTitle>Ordentliches Finanzierungsergebnis des Bundes</ChartTitle>
   <ChartLead>in Milliarden CHF</ChartLead>
-  <CsvChart t={t}
+  <CsvChart
     config={{
       "type": "TimeBar",
       "color": "type",
@@ -518,7 +518,7 @@ year,value,type
 ### Diverging Stacks
 
 ```react
-<CsvChart t={t}
+<CsvChart
   config={{
     "type": "TimeBar",
     "color": "typ",

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -83,7 +83,6 @@ const TimeBarChart = (props) => {
     width,
     mini,
     children,
-    t,
     tLabel,
     description,
     yAnnotations,
@@ -171,7 +170,7 @@ const TimeBarChart = (props) => {
     })
   })
 
-  const yAxis = calculateAxis(props.numberFormat, t, y.domain(), tLabel(props.unit))
+  const yAxis = calculateAxis(props.numberFormat, tLabel, y.domain(), tLabel(props.unit))
   const yTicks = props.yTicks || yAxis.ticks
   // ensure highest value is last
   // - the last value is labled with the unit
@@ -440,7 +439,6 @@ TimeBarChart.propTypes = {
   unit: PropTypes.string,
   numberFormat: PropTypes.string.isRequired,
   filter: PropTypes.string,
-  t: PropTypes.func.isRequired,
   tLabel: PropTypes.func.isRequired,
   description: PropTypes.string
 }

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { css } from 'glamor'
-import { timeParse, timeFormat } from 'd3-time-format'
 
 import { max, min, ascending } from 'd3-array'
 import { scaleLinear, scaleOrdinal, scaleBand } from 'd3-scale'
@@ -9,6 +8,7 @@ import * as d3Intervals from 'd3-time'
 
 import { sansSerifRegular12, sansSerifMedium12 } from '../Typography/styles'
 import colors from '../../theme/colors'
+import { timeFormat, timeParse } from '../../lib/timeFormat'
 
 import {
   calculateAxis,

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -69,8 +69,6 @@ export const ChartLead = ({children, ...props}) => (
   <p {...props} {...styles.p}>{children}</p>
 )
 
-const tLabel = identity => identity
-
 class Chart extends Component {
   constructor(props) {
     super(props)
@@ -85,7 +83,7 @@ class Chart extends Component {
     })
   }
   render() {
-    const {width: fixedWidth, config, t} = this.props
+    const {width: fixedWidth, config, tLabel} = this.props
 
     const width = fixedWidth || this.state.width
     const ReactChart = ReactCharts[config.type]
@@ -96,7 +94,6 @@ class Chart extends Component {
       }}>
         {!!width && (
           <ReactChart {...config}
-            t={t}
             tLabel={tLabel}
             colorRanges={colorRanges}
             width={width}
@@ -116,7 +113,11 @@ Chart.propTypes = {
     maxWidth: PropTypes.number
   }).isRequired,
   width: PropTypes.number,
-  t: PropTypes.func.isRequired
+  tLabel: PropTypes.func.isRequired
+}
+
+Chart.defaultProps = {
+  tLabel: identity => identity
 }
 
 export default Chart

--- a/src/components/DynamicComponent/docs.md
+++ b/src/components/DynamicComponent/docs.md
@@ -19,6 +19,7 @@ By default modules can only be loaded from relative or absolute paths. Following
 - `prop-types`
 - `glamor`
 - `@project-r/styleguide` (everything exposed in `lib.js`)
+- `@project-r/styleguide/chart` (everything exposed in `chart.js`)
 
 Set a `SG_DYNAMIC_COMPONENT_BASE_URLS` environment variable with comma-separated base urls to whitelist CDNs.
 

--- a/src/components/DynamicComponent/index.js
+++ b/src/components/DynamicComponent/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import * as glamor from 'glamor'
 import * as styleguide from '../../lib.js'
+import * as styleguideChart from '../../chart.js'
 
 import { requireFrom } from './require'
 import Loader from '../Loader'
@@ -23,7 +24,8 @@ export const createRequire = (whitelist = DEFAULT_WHITELIST) => {
     react: React,
     'prop-types': PropTypes,
     glamor,
-    '@project-r/styleguide': styleguide
+    '@project-r/styleguide': styleguide,
+    '@project-r/styleguide/chart': styleguideChart
   })
 }
 

--- a/src/lib/timeFormat.js
+++ b/src/lib/timeFormat.js
@@ -1,4 +1,7 @@
 import { timeFormatLocale } from 'd3-time-format'
 import timeDefinition from 'd3-time-format/locale/de-CH'
 
-export const timeFormat = timeFormatLocale(timeDefinition).format
+const locale = timeFormatLocale(timeDefinition)
+
+export const timeFormat = locale.format
+export const timeParse = locale.parse

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-12-13T09:17:12.676Z",
+  "updated": "2019-01-04T22:33:09.377Z",
   "title": "live",
   "data": [
     {
@@ -154,10 +154,6 @@
     {
       "key": "styleguide/video/dnt/player/vimeo",
       "value": "Vimeo"
-    },
-    {
-      "key": "styleguide/charts/y-cut",
-      "value": "Achse gekürzt"
     },
     {
       "key": "styleguide/charts/error",


### PR DESCRIPTION
Refactoring
- remove `t` dependency from charts, only use `tLabel` (an transform function that could translate)

Fix
- use de ch time format

Feat
- expose chart via dedicated end point
- allow to use in dynamic component