### PR TITLE
Field Cleanup

### DIFF
--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -153,7 +153,6 @@ class Field extends Component {
       renderInput,
       onInc,
       onDec,
-      isFocused: isFocusedFromProps,
       icon
     } = this.props
 
@@ -162,9 +161,6 @@ class Field extends Component {
     if (sim) {
       isFocused = sim.indexOf('focus') !== -1
       simulationClassName = simulate(sim).toString()
-    }
-    if (isFocusedFromProps !== undefined) {
-      isFocused = isFocusedFromProps
     }
 
     const {isValidating, isDirty} = this.state

--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -180,7 +180,7 @@ class Field extends Component {
     const hasIncrease = !!onInc
     const hasDecrease = !!onDec
     const hasError = !!error
-    const valueIsPresent = value !== undefined && value.length !== 0
+    const valueIsPresent = value !== undefined && value !== null && String(value).length !== 0
     const labelStyle = (isFocused || valueIsPresent || hasError)
       ? merge(
           labelTextStyle, labelTextTopStyle,

--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -165,7 +165,9 @@ class Field extends Component {
 
     const {isValidating, isDirty} = this.state
 
-    const value = this.props.value !== undefined ? this.props.value : this.state.value
+    const value = this.props.value !== undefined
+      ? this.props.value
+      : this.state.value
 
     let colorStyle
     if (this.props.black) {
@@ -178,7 +180,8 @@ class Field extends Component {
     const hasIncrease = !!onInc
     const hasDecrease = !!onDec
     const hasError = !!error
-    const labelStyle = (isFocused || value || hasError)
+    const valueIsPresent = value !== undefined && value.length !== 0
+    const labelStyle = (isFocused || valueIsPresent || hasError)
       ? merge(
           labelTextStyle, labelTextTopStyle,
           isFocused && labelTextFocusedStyle,

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -4,29 +4,31 @@
 <Field label='Label' />
 ```
 
-
-```react|span-3
-<Field
-    label='E-Mail-Adresse'
-    error='Geben sie eine gültige E-Mail-Adresse an' />
-```
-
 ```react|span-3
 <Field label='Label' simulate='focus' />
 ```
 
 ```react|span-3
+<Field label='Label' value={'string'} />
+```
+
+```react|span-3
+<Field label='Label' value={0} />
+```
+
+```react|span-3
+<Field
+  label='E-Mail-Adresse'
+  error='Geben sie eine gültige E-Mail-Adresse an' />
+```
+
+```react|span-3
 <Field
   label='Label'
-  icon={
-    <SearchIcon
-      size={30}
-      onClick={() => {
-        console.log('search')
-      }}
-    />
-  } />
+  icon={<SearchIcon size={30} />} />
 ```
+
+Normally `value` should be a string. Even if you pass in numbers, you'll recieve strings on change by default.
 
 Please note: `simulate` is for testing and documentation purposes only. It will not work in production environments.
 

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -9,7 +9,7 @@
 ```
 
 ```react|span-3
-<Field label='Label' value={'string'} />
+<Field label='Label' value='string' />
 ```
 
 ```react|span-3
@@ -28,7 +28,7 @@
   icon={<SearchIcon size={30} />} />
 ```
 
-Normally `value` should be a string. Even if you pass in numbers, you'll recieve strings on change by default.
+Normally `value` should be a string. Even if you pass in numbers, you'll receive strings on change by default.
 
 Please note: `simulate` is for testing and documentation purposes only. It will not work in production environments.
 

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -11,14 +11,6 @@
     error='Geben sie eine gültige E-Mail-Adresse an' />
 ```
 
-Override the inner focus state by explicitly passing `isFocused`.
-
-Pass css pseudo states as `simulate` property to test or display behavior. Please note that the pseudo state simulator is a developer documentation helper and not meant to be used in production.
-
-```react|span-3
-<Field label='Label' isFocused={true} />
-```
-
 ```react|span-3
 <Field label='Label' simulate='focus' />
 ```
@@ -35,6 +27,8 @@ Pass css pseudo states as `simulate` property to test or display behavior. Pleas
     />
   } />
 ```
+
+Please note: `simulate` is for testing and documentation purposes only. It will not work in production environments.
 
 ### Increase and Decrease
 


### PR DESCRIPTION
- remove no longer used `isFocused` prop https://github.com/orbiting/styleguide/issues/174
- fix label overlap with `0` value
- clean up docs a bit

<img width="827" alt="screenshot 2019-01-16 at 11 36 55" src="https://user-images.githubusercontent.com/410211/51243504-0bbf3000-1983-11e9-903a-7dc95ab142ed.png">
