### PR TITLE
fix(MediaPlayers): load user progress from promise and remove unused startSeconds prop

### DIFF
--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -364,25 +364,18 @@ class AudioPlayer extends Component {
       audio.load()
     }
   }
-  getStartTime() {
-    return new Promise((resolve, reject) => {
-      if (this.props.mediaId && this.context.getMediaProgress) {
-        this.context.getMediaProgress(this.props.mediaId)
-          .then((startSeconds) => {
-            if (startSeconds) {
-              this.setState(() => ({ startSeconds }))
-              !!startSeconds && this.setTime(startSeconds)
-            }
-            resolve()
-          }
-        ).catch(() => {
-          resolve()
-        })
-      } else {
-        resolve()
-      }
-
-    })
+  initStartTime() {
+    if (this.props.mediaId && this.context.getMediaProgress) {
+      return this.context.getMediaProgress(this.props.mediaId).then((startSeconds) => {
+        if (startSeconds) {
+          this.setState(() => ({ startSeconds }))
+          !!startSeconds && this.setTime(startSeconds)
+        }
+      }).catch(() => {
+        return undefined // ignore errors
+      })
+    }
+    return Promise.resolve()
   }
   setFormattedTimes() {
     if (!this.audio || !this.audio.duration) {
@@ -402,7 +395,7 @@ class AudioPlayer extends Component {
     this.audio.addEventListener('canplaythrough', this.onCanPlay)
     this.audio.addEventListener('loadedmetadata', this.onLoadedMetaData)
 
-    this.getStartTime().then(() => {
+    this.initStartTime().then(() => {
       this.setFormattedTimes()
       if (this.audio && !this.audio.paused) {
         this.onPlay()

--- a/src/components/AudioPlayer/docs.md
+++ b/src/components/AudioPlayer/docs.md
@@ -16,7 +16,6 @@ Props:
 - `timePosition`: `right` (default) or `left`.
 - `height`: number; The player height in pixels.
 - `controlsPadding`: number; The horizontal padding between controls and container, defaults to 0.
-- `startSeconds`: number; Playback position of track (in seconds), defaults to 0.
 
 ```react
 <AudioPlayer
@@ -33,16 +32,6 @@ Props:
     mp3: 'https://cdn.republik.space/s3/republik-assets/assets/audio-artikel/republik_diktator_fichter.mp3'
   }}
   timePosition='left'
-  t={t}
-/>
-```
-
-```react
-<AudioPlayer
-  src={{
-    mp3: 'https://cdn.republik.space/s3/republik-assets/assets/audio-artikel/Republik_Der-Klima-Code__Bastani_Hess.mp3'
-  }}
-  startSeconds={300}
   t={t}
 />
 ```

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -318,25 +318,18 @@ class VideoPlayer extends Component {
       this._textTrackMode = subtitles
     }
   }
-  getStartTime() {
-    return new Promise((resolve, reject) => {
-      if (this.props.mediaId && this.context.getMediaProgress) {
-        this.context.getMediaProgress(this.props.mediaId)
-          .then((startSeconds) => {
-            if (startSeconds) {
-              this.setState(() => ({ startSeconds }))
-              !!startSeconds && this.setTime(startSeconds)
-            }
-            resolve()
-          }
-        ).catch(() => {
-          resolve()
-        })
-      } else {
-        resolve()
-      }
-
-    })
+  initStartTime() {
+    if (this.props.mediaId && this.context.getMediaProgress) {
+      return this.context.getMediaProgress(this.props.mediaId).then((startSeconds) => {
+        if (startSeconds) {
+          this.setState(() => ({ startSeconds }))
+          !!startSeconds && this.setTime(startSeconds)
+        }
+      }).catch(() => {
+        return undefined // ignore errors
+      })
+    }
+    return Promise.resolve()
   }
   setMuted(muted) {
     const next = {
@@ -375,7 +368,7 @@ class VideoPlayer extends Component {
 
     this.setTextTracksMode()
 
-    this.getStartTime().then(() => {
+    this.initStartTime().then(() => {
       if (this.video && !this.video.paused) {
         this.onPlay()
       }

--- a/src/components/VideoPlayer/docs.md
+++ b/src/components/VideoPlayer/docs.md
@@ -13,7 +13,6 @@ Props:
 - `forceMuted`: Boolean, mutes the player and hides the mute interfaces.
 - `cinemagraph`: Boolean, whether the video is a cinemagraph. Forces `loop`, `muted`, `autoPlay` and `playsInline`.
 - `attributes`: Object, arbitrary attributes mapped to the video tag like playsinline, specific ones win
-- `startSeconds`: number; Playback position of track (in seconds), defaults to 0
 
 
 ```react
@@ -38,20 +37,6 @@ Props:
     subtitles: '/static/main.vtt'
   }}
   showPlay={false}
-/>
-```
-
-#### startSeconds
-
-```react
-<VideoPlayer
-  startSeconds={30}
-  src={{
-    hls: 'https://player.vimeo.com/external/213080233.m3u8?s=40bdb9917fa47b39119a9fe34b9d0fb13a10a92e',
-    mp4: 'https://player.vimeo.com/external/213080233.hd.mp4?s=ab84df0ac9134c86bb68bd9ea7ac6b9df0c35774&profile_id=175',
-    thumbnail: `/static/video.jpg`,
-    subtitles: '/static/main.vtt'
-  }}
 />
 ```
 


### PR DESCRIPTION
Removes the unused `startSeconds` prop and loads startSeconds via promise provided by frontend context.