### PR TITLE
fix(AudioPlayer): tentative fix for autoplay issues

### DIFF
--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -208,16 +208,14 @@ class AudioPlayer extends Component {
       if (!audio) {
         return
       }
-      this.setState(() => {
-        const progress = audio.currentTime / audio.duration
-        this.props.onProgress && this.props.onProgress(progress)
-        this.props.mediaId && this.context.saveMediaProgress && this.context.saveMediaProgress(
-          this.props.mediaId, audio.currentTime
-        )
-        return {
-          progress,
-          buffered: audio.buffered
-        }
+      const progress = audio.currentTime / audio.duration
+      this.props.onProgress && this.props.onProgress(progress)
+      this.context.saveMediaProgress && this.context.saveMediaProgress(
+        this.props, audio
+      )
+      this.setState({
+        progress,
+        buffered: audio.buffered
       })
       this.formattedCurrentTime = getFormattedTime(audio.currentTime)
     }
@@ -363,8 +361,8 @@ class AudioPlayer extends Component {
     }
   }
   getStartTime() {
-    if (this.props.mediaId && this.context.getMediaProgress) {
-      return this.context.getMediaProgress(this.props.mediaId).catch(() => {
+    if (this.context.getMediaProgress) {
+      return this.context.getMediaProgress(this.props).catch(() => {
         return undefined // ignore errors
       })
     }
@@ -581,7 +579,6 @@ class AudioPlayer extends Component {
 }
 
 AudioPlayer.propTypes = {
-  mediaId: PropTypes.string,
   src: PropTypes.shape({
     mp3: PropTypes.string,
     aac: PropTypes.string,

--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -268,6 +268,9 @@ class AudioPlayer extends Component {
     }
     this.onCanPlay = () => {
       this.state.startSeconds && !this.state.initialized && this.setTime(this.state.startSeconds)
+      if (this.props.autoPlay) {
+        this.play()
+      }
       this.setState(() => ({
         initialized: true,
         playEnabled: true,
@@ -470,7 +473,6 @@ class AudioPlayer extends Component {
           {...styles.audio}
           {...attributes}
           ref={this.ref}
-          autoPlay={autoPlay}
           onLoadedMetadata={this.onLoadedMetaData}
           crossOrigin="anonymous"
         >
@@ -482,7 +484,6 @@ class AudioPlayer extends Component {
           {...styles.audio}
           {...attributes}
           ref={this.ref}
-          autoPlay={autoPlay}
           onLoadedMetadata={this.onLoadedMetaData}
           crossOrigin="anonymous"
           playsInline

--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -209,7 +209,7 @@ class AudioPlayer extends Component {
         return
       }
       const progress = audio.currentTime / audio.duration
-      this.props.onProgress && this.props.onProgress(progress)
+      this.props.onProgress && this.props.onProgress(progress, audio)
       this.context.saveMediaProgress && this.context.saveMediaProgress(
         this.props, audio
       )

--- a/src/components/AudioPlayer/docs.md
+++ b/src/components/AudioPlayer/docs.md
@@ -7,7 +7,7 @@ Props:
 -- `ogg`: The ogg source URL of the audio.
 -- `hls`: The hls source URL (when using a video).
 -- `mp4`: The mp4 source URL (when using a video).
-- `autoPlay`: Boolean, mapped to the audio tag.
+- `autoPlay`: Boolean, trigger play once after the source and context start time is ready
 - `size`: optional, `narrow` or `tiny`.
 - `attributes`: Object, arbitrary attributes mapped to the audio tag.
 - `closeHandler`: Function; If provided, a close icon is displayed that calls the handler on click.
@@ -16,6 +16,11 @@ Props:
 - `timePosition`: `right` (default) or `left`.
 - `height`: number; The player height in pixels.
 - `controlsPadding`: number; The horizontal padding between controls and container, defaults to 0.
+- `mediaId`: an ID for media progress synching via context
+
+Context:
+- `getMediaProgress(mediaId)`: a function that is expected to return a `Promise` of a `Number`. If present with an `mediaId` prop the player will retrieve the start time on `componentDidMount` from it and wait on it before potentially auto playing.
+- `saveMediaProgress(mediaId, currentTime)`: will be constantly called during playback if present with an `mediaId` prop.
 
 ```react
 <AudioPlayer

--- a/src/components/AudioPlayer/docs.md
+++ b/src/components/AudioPlayer/docs.md
@@ -16,11 +16,10 @@ Props:
 - `timePosition`: `right` (default) or `left`.
 - `height`: number; The player height in pixels.
 - `controlsPadding`: number; The horizontal padding between controls and container, defaults to 0.
-- `mediaId`: an ID for media progress synching via context
 
 Context:
-- `getMediaProgress(mediaId)`: a function that is expected to return a `Promise` of a `Number`. If present with an `mediaId` prop the player will retrieve the start time on `componentDidMount` from it and wait on it before potentially auto playing.
-- `saveMediaProgress(mediaId, currentTime)`: will be constantly called during playback if present with an `mediaId` prop.
+- `getMediaProgress(props)`: a function that is expected to return a `Promise` of a `Number`. If present it will be called with the component props to retrieve the start time on `componentDidMount` from it.
+- `saveMediaProgress(props, HTMLMediaElement)`: will be constantly called during playback if present.
 
 ```react
 <AudioPlayer

--- a/src/components/AudioPlayer/globalState.js
+++ b/src/components/AudioPlayer/globalState.js
@@ -1,0 +1,8 @@
+let globalState = {
+  playingRef: undefined,
+  muted: false, // video only
+  subtitles: false, // currently video only
+  instances: []
+}
+
+export default globalState

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -149,7 +149,7 @@ class VideoPlayer extends Component {
         return
       }
       const progress = video.currentTime / video.duration
-      this.props.onProgress && this.props.onProgress(progress)
+      this.props.onProgress && this.props.onProgress(progress, video)
       this.context.saveMediaProgress && this.context.saveMediaProgress(
         this.props, video
       )

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -279,7 +279,10 @@ class VideoPlayer extends Component {
         this.toggle()
       }
       if (
-        event.key === 'f'
+        (event.key === 'f' || event.key === 'F') &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey
       ) {
         this.toggleFullscreen(event)
       }

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -278,6 +278,30 @@ class VideoPlayer extends Component {
         event.stopPropagation()
         this.toggle()
       }
+      if (
+        event.key === 'f'
+      ) {
+        this.toggleFullscreen(event)
+      }
+    }
+    this.toggleFullscreen = (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const { fullscreen, isFull } = this.state
+      const fullWindow = this.props.fullWindow || !fullscreen
+      if (fullWindow) {
+        const { onFull } = this.props
+        const shouldBeFull = !isFull
+        this.setState({ isFull: shouldBeFull })
+        onFull && onFull(shouldBeFull, false)
+      } else {
+        if (isFull) {
+          fullscreen.exit()
+        } else {
+          fullscreen.request(this.video)
+        }
+      }
+      this.captureFocus()
     }
     this.captureFocus = () => {
       this.video.focus()
@@ -506,19 +530,7 @@ class VideoPlayer extends Component {
             <span
               role="button"
               title="Vollbild"
-              onClick={e => {
-                e.preventDefault()
-                e.stopPropagation()
-                if (fullWindow) {
-                  const { onFull } = this.props
-                  const shouldBeFull = !isFull
-                  this.setState({ isFull: shouldBeFull })
-                  onFull && onFull(shouldBeFull, false)
-                } else {
-                  fullscreen.request(this.video)
-                }
-                this.captureFocus()
-              }}
+              onClick={this.toggleFullscreen}
             >
               <Fullscreen off={!isFull} />
             </span>

--- a/src/components/VideoPlayer/Player.js
+++ b/src/components/VideoPlayer/Player.js
@@ -148,16 +148,12 @@ class VideoPlayer extends Component {
       if (!video) {
         return
       }
-      this.setState(() => {
-        const progress = video.currentTime / video.duration
-        this.props.onProgress && this.props.onProgress(progress)
-        this.context.saveMediaProgress && this.context.saveMediaProgress(
-          this.props.mediaId, video.currentTime
-        )
-        return {
-          progress
-        }
-      })
+      const progress = video.currentTime / video.duration
+      this.props.onProgress && this.props.onProgress(progress)
+      this.context.saveMediaProgress && this.context.saveMediaProgress(
+        this.props, video
+      )
+      this.setState({ progress })
     }
     this.syncProgress = () => {
       this.readTimeout = setTimeout(() => {
@@ -325,8 +321,8 @@ class VideoPlayer extends Component {
     }
   }
   getStartTime() {
-    if (this.props.mediaId && this.context.getMediaProgress) {
-      return this.context.getMediaProgress(this.props.mediaId).catch(() => {
+    if (this.context.getMediaProgress) {
+      return this.context.getMediaProgress(this.props).catch(() => {
         return undefined // ignore errors
       })
     }

--- a/src/components/VideoPlayer/docs.md
+++ b/src/components/VideoPlayer/docs.md
@@ -13,7 +13,11 @@ Props:
 - `forceMuted`: Boolean, mutes the player and hides the mute interfaces.
 - `cinemagraph`: Boolean, whether the video is a cinemagraph. Forces `loop`, `muted`, `autoPlay` and `playsInline`.
 - `attributes`: Object, arbitrary attributes mapped to the video tag like playsinline, specific ones win
+- `mediaId`: an ID for media progress synching via context
 
+Context:
+- `getMediaProgress(mediaId)`: a function that is expected to return a `Promise` of a `Number`. If present with an `mediaId` prop the player will retrieve the start time on `componentDidMount` from it.
+- `saveMediaProgress(mediaId, currentTime)`: will be constantly called during playback if present with an `mediaId` prop.
 
 ```react
 <VideoPlayer

--- a/src/components/VideoPlayer/docs.md
+++ b/src/components/VideoPlayer/docs.md
@@ -13,11 +13,10 @@ Props:
 - `forceMuted`: Boolean, mutes the player and hides the mute interfaces.
 - `cinemagraph`: Boolean, whether the video is a cinemagraph. Forces `loop`, `muted`, `autoPlay` and `playsInline`.
 - `attributes`: Object, arbitrary attributes mapped to the video tag like playsinline, specific ones win
-- `mediaId`: an ID for media progress synching via context
 
 Context:
-- `getMediaProgress(mediaId)`: a function that is expected to return a `Promise` of a `Number`. If present with an `mediaId` prop the player will retrieve the start time on `componentDidMount` from it.
-- `saveMediaProgress(mediaId, currentTime)`: will be constantly called during playback if present with an `mediaId` prop.
+- `getMediaProgress(props)`: a function that is expected to return a `Promise` of a `Number`. If present it will be called with the component props to retrieve the start time on `componentDidMount` from it.
+- `saveMediaProgress(props, HTMLMediaElement)`: will be constantly called during playback if present.
 
 ```react
 <VideoPlayer

--- a/src/components/VideoPlayer/fullscreen.js
+++ b/src/components/VideoPlayer/fullscreen.js
@@ -89,6 +89,9 @@ export const setupFullscreen = ({ onChange, video }) => {
       const subject = elem || document.documentElement
       subject[api.requestFullscreen]()
     },
+    exit() {
+      document[api.exitFullscreen]()
+    },
     element() {
       return document[api.fullscreenElement]
     },

--- a/src/lib/warn.js
+++ b/src/lib/warn.js
@@ -1,0 +1,5 @@
+export default (...args) => {
+  try {
+    console.warn(...args)
+  } catch(e) {}
+}

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -122,6 +122,15 @@ const getProgressProps = (node, index, parent, { ancestors }) => {
   } : {}
 }
 
+const addProgressProps = rule => ({
+  ...rule,
+  props: rule.props
+    ? (...args) => ({
+      ...rule.props(...args),
+      ...getProgressProps(...args)
+    })
+    : getProgressProps
+})
 
 const paragraph = {
   matchMdast: matchParagraph,
@@ -192,12 +201,9 @@ const figureCaption = {
 const figure = {
   matchMdast: matchFigure,
   component: Figure,
-  props: (node, index, parent, { ancestors }) => {
-    return {
-      size: node.data.size,
-      ...getProgressProps(node, index, parent, { ancestors })
-    }
-  },
+  props: node => ({
+    size: node.data.size
+  }),
   editorModule: 'figure',
   editorOptions: {
     pixelNote:
@@ -319,8 +325,7 @@ const infoBox = {
       ? node.data.figureSize ||
         INFOBOX_DEFAULT_IMAGE_SIZE
       : undefined,
-    figureFloat: node.data.figureFloat,
-    ...getProgressProps(node, index, parent, { ancestors })
+    figureFloat: node.data.figureFloat
   }),
   editorModule: 'infobox',
   editorOptions: {
@@ -416,8 +421,7 @@ const pullQuote = {
     size: node.data.size,
     hasFigure: !!node.children.find(
       matchFigure
-    ),
-    ...getProgressProps(node, index, parent, { ancestors })
+    )
   }),
   editorModule: 'quote',
   editorOptions: {
@@ -841,17 +845,15 @@ const createSchema = ({
                   depth: 2,
                   formatButtonText: 'Zwischentitel'
                 },
-                props: getProgressProps,
                 rules: globalInlines
               },
               {
                 matchMdast: matchZone('FIGUREGROUP'),
                 component: FigureGroup,
-                props: (node, index, parent, { ancestors }) => {
+                props: node => {
                   return {
                     size: 'breakout',
-                    columns: node.data.columns,
-                    ...getProgressProps(node, index, parent, { ancestors })
+                    columns: node.data.columns
                   }
                 },
                 rules: [figure, centerFigureCaption],
@@ -866,13 +868,12 @@ const createSchema = ({
               {
                 matchMdast: matchType('list'),
                 component: List,
-                props: (node, index, parent, { ancestors }) => ({
+                props: node => ({
                   data: {
                     ordered: node.ordered,
                     start: node.start,
                     compact: !node.loose
-                  },
-                  ...getProgressProps(node, index, parent, { ancestors })
+                  }
                 }),
                 editorModule: 'list',
                 rules: [
@@ -1121,13 +1122,13 @@ const createSchema = ({
                 dynamicComponentRequire,
                 insertButtonText: 'Dynamic Component'
               })
-            ]
+            ].map(addProgressProps)
           },
-          centerFigure,
-          createDynamicComponent({
+          addProgressProps(centerFigure),
+          addProgressProps(createDynamicComponent({
             t,
             dynamicComponentRequire
-          }),
+          })),
           {
             matchMdast: () => false,
             editorModule: 'specialchars'


### PR DESCRIPTION
_Update Thomas_

Focus on `AudioPlayer`. Also see updated docs. 

Additional Changes
- share global play state between audio and video player (prevent them playing on top of each other)
- `f` key for full screen in video player
- progress props on all center children and root elements except cover & title block 