### PR TITLE
Audio Cover

### DIFF
--- a/src/components/Button/docs.md
+++ b/src/components/Button/docs.md
@@ -124,3 +124,25 @@ To fit, e.g. in a header, it's permissible to set an explicit height.
   Weiss
 </Button>
 ```
+
+## Plain Button
+
+```react|span-3
+<button
+  {...plainButtonRule}
+  onClick={() => alert('A11Y ftw')}
+  title="Artikel anhören">
+  <AudioIcon />
+</button>
+```
+
+```react|span-3
+<button
+  {...merge(plainButtonRule,
+    { backgroundColor: '#000', borderRadius: '50%', width: 50, height: 50 }
+  )}>
+  <AudioIcon fill='#fff' />
+</button>
+```
+
+Use [glamors `css` or `merge`](https://github.com/threepointone/glamor/blob/master/docs/howto.md#combined-selectors) to ensure your `border`, `background`, `padding` and other styles take precedence over the plain rule.

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -3,8 +3,16 @@ import {css, merge, simulate} from 'glamor'
 import colors from '../../theme/colors'
 import {fontFamilies} from '../../theme/fonts'
 
-const buttonStyle = css({
+export const plainButtonRule = css({
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
   outline: 'none',
+  appearance: 'none',
+  padding: 0
+})
+
+const buttonStyle = css(plainButtonRule, {
   verticalAlign: 'bottom',
   padding: '10px 20px 10px 20px',
   minWidth: 160,
@@ -18,7 +26,6 @@ const buttonStyle = css({
   border: `1px solid ${colors.secondary}`,
   borderRadius: 0,
   color: colors.secondary,
-  cursor: 'pointer',
   ':hover': {
     backgroundColor: colors.primary,
     borderColor: colors.primary,

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -256,3 +256,38 @@ Supports `breakout` sizes:
   </FigureGroup>
 </Center>
 ```
+
+### `<FigureCover />`
+
+#### `text`
+
+```react|responsive
+<Fragment>
+  <FigureCover text={{
+    anchor: 'bottom',
+    offset: '10%',
+    element: <Editorial.Headline style={{color: '#fff'}}>
+      Desktop on Top
+    </Editorial.Headline>
+  }}>
+    <FigureImage src='/static/desert.jpg' alt='' />
+  </FigureCover>
+  <CoverTextTitleBlockHeadline>
+    <Editorial.Headline>Mobile Below</Editorial.Headline>
+  </CoverTextTitleBlockHeadline>
+</Fragment>
+```
+
+#### `audio`
+
+```react|responsive
+<Fragment>
+  <FigureCover audio={{
+    color: '#fff',
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    onClick: () => alert('Play!')
+  }}>
+    <FigureImage src='/static/desert.jpg' alt='' />
+  </FigureCover>
+</Fragment>
+```

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css, merge } from 'glamor'
+
+import AudioIcon from 'react-icons/lib/md/volume-up'
+
 import { mUp } from '../../theme/mediaQueries'
 import {
   breakoutStyles,
@@ -8,6 +11,10 @@ import {
   PADDING,
   BREAKOUT_SIZES
 } from '../Center'
+
+import {
+  plainButtonRule
+} from '../Button'
 
 export { default as FigureImage } from './Image'
 export { default as FigureCaption } from './Caption'
@@ -55,6 +62,27 @@ const styles = {
     display: 'block',
     [mUp]: {
       display: 'none'
+    }
+  }),
+  coverAudio: css(plainButtonRule, {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    borderRadius: '50%',
+    marginLeft: -35,
+    marginTop: -35,
+    width: 70,
+    height: 70,
+    padding: 20,
+    [mUp]: {
+      marginLeft: -50,
+      marginTop: -50,
+      width: 100,
+      height: 100,
+      padding: 30
+    },
+    ':hover': {
+      animationIterationCount: 'infinite'
     }
   }),
   col2: css({
@@ -134,13 +162,33 @@ const textPosStyle = ({anchor, offset}) => {
 export const CoverTextTitleBlockHeadline = ({children, attributes}) =>
   <div {...attributes} {...styles.coverTextTitleBlockHeadline}>{children}</div>
 
-export const FigureCover = ({size, text, ...props}) => {
+const AudioButton = ({ color, backgroundColor, onClick }) => {
+  const pulse = css.keyframes({
+    '0%': {boxShadow: `0 0 0 0 ${backgroundColor}`},
+    '70%': {boxShadow: `0 0 0 10px transparent`},
+    '100%': {boxShadow: `0 0 0 0 transparent`},
+  })
+
+  return (
+    <button {...styles.coverAudio} onClick={onClick} style={{
+      color,
+      backgroundColor
+    }} {...css({
+      animation: `${pulse} 2s 3`
+    })}>
+      <AudioIcon size='100%' />
+    </button>
+  )
+}
+
+export const FigureCover = ({size, text, audio, ...props}) => {
   const sizeStyle = size ? size === 'breakout' ? styles.coverBreakout : styles.coverSize : undefined
   return <div {...styles.cover} {...sizeStyle}>
     <Figure size={size} {...props} />
     {text && <div style={textPosStyle(text)} {...styles.coverText}>
       {text.element}
     </div>}
+    {audio && <AudioButton {...audio} />}
   </div>
 }
 

--- a/src/global.css
+++ b/src/global.css
@@ -1,6 +1,9 @@
 *, *:before, *:after {
   box-sizing: inherit;
 }
+* {
+  -webkit-tap-highlight-color: transparent;
+}
 html {
   box-sizing: border-box;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import ReactDOM from 'react-dom'
 import { Catalog, ReactSpecimen } from 'catalog'
 import { simulations, speedy, css, merge } from 'glamor'
@@ -365,7 +365,8 @@ ReactDOM.render(
               css,
               ...require('./components/Typography'),
               ...require('./components/Figure'),
-              Center: require('./components/Center')
+              Center: require('./components/Center'),
+              Fragment
             },
             src: require('./components/Figure/docs.md')
           },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Catalog, ReactSpecimen } from 'catalog'
-import { simulations, speedy, css } from 'glamor'
+import { simulations, speedy, css, merge } from 'glamor'
 import theme from './catalogTheme'
 import './global.css'
 import './catalogTheme.css'
@@ -115,7 +115,11 @@ ReactDOM.render(
             path: '/components/button',
             title: 'Button',
             imports: {
-              Button: require('./components/Button')
+              css,
+              merge,
+              Button: require('./components/Button'),
+              AudioIcon: require('react-icons/lib/md/volume-up'),
+              plainButtonRule: require('./components/Button').plainButtonRule
             },
             src: require('./components/Button/docs.md')
           },

--- a/src/lib.js
+++ b/src/lib.js
@@ -12,7 +12,7 @@ export {createFormatter, createPlaceholderFormatter} from './lib/translate'
 
 export {default as Logo} from './components/Logo'
 export {default as BrandMark, DEFAULT_PROFILE_PICTURE} from './components/Logo/BrandMark'
-export {default as Button} from './components/Button'
+export {default as Button, plainButtonRule} from './components/Button'
 export {default as Field} from './components/Form/Field'
 export {default as FieldSet} from './components/Form/FieldSet'
 export {default as Radio} from './components/Form/Radio'

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -476,7 +476,7 @@ const mdastToString = node => node
   )
   : ''
 
-const cover = {
+const createCover = ({ onAudioCoverClick }) => ({
   matchMdast: (node, index) => (
     matchFigure(node) &&
     index === 0
@@ -512,7 +512,11 @@ const cover = {
     }
     return {
       size: node.data.size,
-      text
+      text,
+      audio: meta.audioCover && {
+        ...meta.audioCover,
+        onClick: onAudioCoverClick
+      }
     }
   },
   editorModule: 'figure',
@@ -567,7 +571,7 @@ const cover = {
     },
     figureCaption
   ]
-}
+})
 
 const logbook = {
   matchMdast: matchZone('LOGBOOK'),
@@ -668,12 +672,15 @@ const createSchema = ({
   t = () => '',
   dynamicComponentRequire,
   previewTeaser,
-  getVideoPlayerProps = props => props
+  getVideoPlayerProps = props => props,
+  onAudioCoverClick
 } = {}) => {
   const teasers = createTeasers({
     t,
     Link
   })
+
+  const cover = createCover({onAudioCoverClick})
 
   return {
     repoPrefix,
@@ -748,7 +755,9 @@ const createSchema = ({
                   const element = <Headline attributes={attributes}>{children}</Headline>
 
                   if (coverText) {
-                    return <CoverTextTitleBlockHeadline>{element}</CoverTextTitleBlockHeadline>
+                    return <CoverTextTitleBlockHeadline>
+                      {element}
+                    </CoverTextTitleBlockHeadline>
                   }
 
                   return element


### PR DESCRIPTION
changes
- support audio cover via document meta data
- export plain button css rule

<img width="905" alt="Screenshot 2019-04-25 at 19 07 50" src="https://user-images.githubusercontent.com/410211/56754516-8d4a0980-678d-11e9-9865-67165c8edb09.png">

<img width="928" alt="Screenshot 2019-04-25 at 19 08 54" src="https://user-images.githubusercontent.com/410211/56754526-963adb00-678d-11e9-9570-659e25447a83.png">
