### PR TITLE
Fix TeaserFrontTileRow layout

### DIFF
--- a/src/components/Center/index.js
+++ b/src/components/Center/index.js
@@ -28,7 +28,7 @@ const floatStyle = {
   width: '100%'
 }
 
-const breakoutUp = `@media only screen and (min-width: ${
+export const breakoutUp = `@media only screen and (min-width: ${
   MAX_WIDTH +
   BREAKOUT * 2 +
   PADDING * 2 + 

--- a/src/components/Dossier/Teaser.md
+++ b/src/components/Dossier/Teaser.md
@@ -14,10 +14,10 @@ Props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
     </TeaserFrontDossierLead>
   </TeaserFrontDossierIntro>
-  <TeaserFrontTileRow columns={3}>
+  <TeaserFrontTileRow>
     <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
-      <TeaserFrontLead columns={3}>
+      <TeaserFrontLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
       </TeaserFrontLead>
       <TeaserFrontCredit>
@@ -33,7 +33,7 @@ Props:
     </TeaserFrontTile>
     <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The fox</DossierTileHeadline.Editorial>
-      <TeaserFrontLead columns={3}>
+      <TeaserFrontLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
       </TeaserFrontLead>
       <TeaserFrontCredit>
@@ -54,10 +54,10 @@ Props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
     </TeaserFrontDossierLead>
   </TeaserFrontDossierIntro>
-  <TeaserFrontTileRow columns={3}>
+  <TeaserFrontTileRow>
     <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
-      <TeaserFrontLead columns={3}>
+      <TeaserFrontLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
       </TeaserFrontLead>
       <TeaserFrontCredit>
@@ -73,7 +73,7 @@ Props:
     </TeaserFrontTile>
     <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The fox</DossierTileHeadline.Editorial>
-      <TeaserFrontLead columns={3}>
+      <TeaserFrontLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
       </TeaserFrontLead>
       <TeaserFrontCredit>
@@ -95,10 +95,10 @@ Props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
     </TeaserFrontDossierLead>
   </TeaserFrontDossierIntro>
-  <TeaserFrontTileRow columns={3}>
+  <TeaserFrontTileRow>
     <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
-      <TeaserFrontLead columns={3}>
+      <TeaserFrontLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
       </TeaserFrontLead>
       <TeaserFrontCredit>
@@ -114,7 +114,7 @@ Props:
     </TeaserFrontTile>
     <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst'>
       <DossierTileHeadline.Editorial>The fox</DossierTileHeadline.Editorial>
-      <TeaserFrontLead columns={3}>
+      <TeaserFrontLead>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
       </TeaserFrontLead>
       <TeaserFrontCredit>

--- a/src/components/Dossier/docs.md
+++ b/src/components/Dossier/docs.md
@@ -10,10 +10,10 @@
 
 ### `<TeaserFrontTileRow />`
 
-For article teasers in a dossier, a `<TeaserFrontTileRow columns={3} />` should be used. It will take any number of `<TeaserFrontTile />` children and group them into three per row (desktop only).
+For article teasers in a dossier, a `<TeaserFrontTileRow />` should be used. It will take any number of `<TeaserFrontTile />` children and group them into three per row (desktop only).
 
 ```react
-<TeaserFrontTileRow columns={3}>
+<TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'>
     <DossierTileHeadline.Editorial>The quick brown fox</DossierTileHeadline.Editorial>
     <TeaserFrontLead>

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -75,12 +75,12 @@ const tileRowStyles = {
         width: '50%',
       },
       '& img': {
-        ...sizeSmall,
+        ...sizeMedium,
       },
     },
     [breakoutUp]: {
       '& img': {
-        ...sizeMedium,
+        ...sizeLarge,
       },
     },
   }),
@@ -97,18 +97,17 @@ const tileRowStyles = {
         width: '50%',
         borderTop: 'none',
         margin: '0 0 50px 0',
-        padding: '20px 0',
       },
       '& .tile:nth-child(2n+2)': {
         borderTop: 'none',
       },
       '& img': {
-        ...sizeSmall,
+        ...sizeMedium,
       },
     },
     [breakoutUp]: {
       '& img': {
-        ...sizeSmall,
+        ...sizeLarge,
       },
       '& .tile': {
         borderTop: 'none',

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -8,6 +8,7 @@ import colors from '../../theme/colors'
 
 import { FigureImage, FigureByline } from '../Figure'
 import LazyLoad from '../LazyLoad'
+import { styles } from '../Form/VirtualDropdown';
 
 // Row
 
@@ -15,27 +16,27 @@ const IMAGE_SIZE = {
   tiny: 180,
   small: 220,
   medium: 300,
-  large: 360
+  large: 360,
 }
 
 const sizeTiny = {
   maxHeight: `${IMAGE_SIZE.tiny}px`,
-  maxWidth: `${IMAGE_SIZE.tiny}px`
+  maxWidth: `${IMAGE_SIZE.tiny}px`,
 }
 
 const sizeSmall = {
   maxHeight: `${IMAGE_SIZE.small}px`,
-  maxWidth: `${IMAGE_SIZE.small}px`
+  maxWidth: `${IMAGE_SIZE.small}px`,
 }
 
 const sizeMedium = {
   maxHeight: `${IMAGE_SIZE.medium}px`,
-  maxWidth: `${IMAGE_SIZE.medium}px`
+  maxWidth: `${IMAGE_SIZE.medium}px`,
 }
 
 const sizeLarge = {
   maxHeight: `${IMAGE_SIZE.large}px`,
-  maxWidth: `${IMAGE_SIZE.large}px`
+  maxWidth: `${IMAGE_SIZE.large}px`,
 }
 
 const tileRowStyles = {
@@ -46,40 +47,48 @@ const tileRowStyles = {
     [mUp]: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      justifyContent: 'center'
-    },
-    '& .tile': {
-      boxSizing: 'border-box',
-      borderTop: `1px solid ${colors.divider}`,
-      margin: '0 0 50px 0',
-      padding: '20px 0'
+      justifyContent: 'center',
     },
   }),
   rowReverse: css({
     flexDirection: 'column-reverse',
   }),
+  colSingle: css({
+    '& .tile': {
+      width: '100%',
+      boxSizing: 'border-box',
+    },
+  }),
   colEven: css({
+    '& .tile': {
+      boxSizing: 'border-box',
+      borderTop: `1px solid ${colors.divider}`,
+    },
     '& img': {
-      ...sizeSmall
+      ...sizeSmall,
     },
     [mUp]: {
       '& .tile': {
         borderTop: 'none',
-        width: '50%'
+        width: '50%',
       },
       '& img': {
-        ...sizeSmall
-      }
+        ...sizeSmall,
+      },
     },
     [breakoutUp]: {
       '& img': {
-        ...sizeMedium
+        ...sizeMedium,
       },
     },
   }),
   colOdd: css({
+    '& .tile': {
+      boxSizing: 'border-box',
+      borderTop: `1px solid ${colors.divider}`,
+    },
     '& img': {
-      ...sizeSmall
+      ...sizeSmall,
     },
     [mUp]: {
       '& .tile': {
@@ -87,17 +96,18 @@ const tileRowStyles = {
         borderTop: 'none',
       },
       '& .tile:nth-child(2n+2)': {
-        borderLeft: `1px solid ${colors.divider}`,
+        borderTop: 'none',
       },
       '& img': {
-        ...sizeSmall
+        ...sizeSmall,
       },
     },
     [breakoutUp]: {
       '& img': {
-        ...sizeSmall
+        ...sizeSmall,
       },
       '& .tile': {
+        borderTop: 'none',
         width: '33.3%',
         borderLeft: `1px solid ${colors.divider}`,
       },
@@ -105,22 +115,31 @@ const tileRowStyles = {
         borderLeft: 'none',
       },
     },
-  })
+  }),
 }
 
 export const TeaserFrontTileRow = ({
   children,
   attributes,
-  mobileReverse
+  mobileReverse,
 }) => {
-  const kidsCountEven = React.Children.count(children) % 2 === 0
+  const kidsCount = React.Children.count(children)
+  let rowClass
+  if (kidsCount === 1) {
+    rowClass = 'colSingle'
+  } else  if (kidsCount % 2 === 0) {
+    rowClass = 'colEven'
+  } else {
+    rowClass = 'colOdd'
+  }
+
   return (
     <div
       role="group"
       {...attributes}
       {...tileRowStyles.row}
-      {...(mobileReverse && tileRowStyles.rowReverse)}
-      {...tileRowStyles[`col${kidsCountEven ? 'Even' : 'Odd'}`]}
+      {...mobileReverse && tileRowStyles.rowReverse}
+      {...tileRowStyles[rowClass]}
     >
       {children}
     </div>
@@ -133,7 +152,7 @@ TeaserFrontTileRow.propTypes = {
 }
 
 TeaserFrontTileRow.defaultProps = {
-  columns: 1
+  columns: 1,
 }
 
 // Tile
@@ -149,15 +168,15 @@ const tileStyles = {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      padding: '60px 0'
-    }
+      padding: '60px 0',
+    },
   }),
   textContainer: css({
     padding: 0,
     [mUp]: {
       padding: '0 13%',
-      width: '100%'
-    }
+      width: '100%',
+    },
   }),
   imageContainer: css({
     margin: '0 auto 30px auto',
@@ -170,11 +189,11 @@ const tileStyles = {
     minWidth: '100px',
     ...sizeTiny,
     [mUp]: {
-      ...sizeSmall
+      ...sizeSmall,
     },
     [breakoutUp]: {
-      ...sizeMedium
-    }
+      ...sizeMedium,
+    },
   }),
 }
 
@@ -192,12 +211,14 @@ const Tile = ({
 }) => {
   const background = bgColor || ''
   const justifyContent =
-    align === 'top' ? 'flex-start' : align === 'bottom' ? 'flex-end' : ''
-  const imageProps = image && FigureImage.utils.getResizedSrcs(
-    image,
-    IMAGE_SIZE.large,
-    false
-  )
+    align === 'top'
+      ? 'flex-start'
+      : align === 'bottom'
+      ? 'flex-end'
+      : ''
+  const imageProps =
+    image &&
+    FigureImage.utils.getResizedSrcs(image, IMAGE_SIZE.large, false)
   let tileContainerStyle = {
     background,
     cursor: onClick ? 'pointer' : 'default',
@@ -210,14 +231,25 @@ const Tile = ({
       {...tileStyles.container}
       onClick={onClick}
       style={tileContainerStyle}
-      className='tile'
+      className="tile"
     >
       {imageProps && (
         <div {...tileStyles.imageContainer}>
-          <LazyLoad visible={aboveTheFold} style={{position: 'relative', fontSize: 0}}>
-            <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
-              {...tileStyles.image} />
-            {byline && <FigureByline position='rightCompact' style={{color}}>{byline}</FigureByline>}
+          <LazyLoad
+            visible={aboveTheFold}
+            style={{ position: 'relative', fontSize: 0 }}
+          >
+            <img
+              src={imageProps.src}
+              srcSet={imageProps.srcSet}
+              alt={alt}
+              {...tileStyles.image}
+            />
+            {byline && (
+              <FigureByline position="rightCompact" style={{ color }}>
+                {byline}
+              </FigureByline>
+            )}
           </LazyLoad>
         </div>
       )}
@@ -238,16 +270,12 @@ Tile.propTypes = {
   alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,
-  align: PropTypes.oneOf([
-    'top',
-    'middle',
-    'bottom'
-  ]),
+  align: PropTypes.oneOf(['top', 'middle', 'bottom']),
   aboveTheFold: PropTypes.bool,
 }
 
 Tile.defaultProps = {
-  alt: ''
+  alt: '',
 }
 
 export default Tile

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -60,7 +60,7 @@ const tileRowStyles = {
   }),
   colEven: css({
     '& img': {
-      ...sizeLarge
+      ...sizeSmall
     },
     [mUp]: {
       '& .tile': {
@@ -79,7 +79,7 @@ const tileRowStyles = {
   }),
   colOdd: css({
     '& img': {
-      ...sizeLarge
+      ...sizeSmall
     },
     [mUp]: {
       '& .tile': {

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -94,6 +94,7 @@ const tileRowStyles = {
       '& .tile': {
         width: '50%',
         borderTop: 'none',
+        margin: '0 0 50px 0',
       },
       '& .tile:nth-child(2n+2)': {
         borderTop: 'none',
@@ -110,7 +111,6 @@ const tileRowStyles = {
         borderTop: 'none',
         width: '33.3%',
         borderLeft: `1px solid ${colors.divider}`,
-        margin: 0,
       },
       '& .tile:nth-child(3n+1)': {
         borderLeft: 'none',

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -41,7 +41,6 @@ const sizeLarge = {
 
 const tileRowStyles = {
   row: css({
-    margin: 0,
     display: 'flex',
     flexDirection: 'column',
     [mUp]: {
@@ -95,6 +94,7 @@ const tileRowStyles = {
         width: '50%',
         borderTop: 'none',
         margin: '0 0 50px 0',
+        padding: '20px 0',
       },
       '& .tile:nth-child(2n+2)': {
         borderTop: 'none',
@@ -110,6 +110,8 @@ const tileRowStyles = {
       '& .tile': {
         borderTop: 'none',
         width: '33.3%',
+        background: 'coral',
+        margin: '0 0 50px 0',
         borderLeft: `1px solid ${colors.divider}`,
       },
       '& .tile:nth-child(3n+1)': {
@@ -123,12 +125,13 @@ export const TeaserFrontTileRow = ({
   children,
   attributes,
   mobileReverse,
+  expand
 }) => {
   const kidsCount = React.Children.count(children)
   let rowClass
-  if (kidsCount === 1) {
+  if (kidsCount === 1 && expand) {
     rowClass = 'colSingle'
-  } else  if (kidsCount % 2 === 0) {
+  } else  if (kidsCount === 1 || kidsCount % 2 === 0) {
     rowClass = 'colEven'
   } else {
     rowClass = 'colOdd'
@@ -150,6 +153,7 @@ export const TeaserFrontTileRow = ({
 TeaserFrontTileRow.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
+  expand: PropTypes.bool,
 }
 
 TeaserFrontTileRow.defaultProps = {
@@ -160,7 +164,7 @@ TeaserFrontTileRow.defaultProps = {
 
 const tileStyles = {
   container: css({
-    margin: 0,
+    margin: '0 auto',
     textAlign: 'center',
     padding: '30px 15px 40px 15px',
     width: '100%',
@@ -225,8 +229,6 @@ const Tile = ({
     cursor: onClick ? 'pointer' : 'default',
     justifyContent,
   }
-
-  console.log("{...tileContainerStyle.image}", {...tileContainerStyle.image})
 
   return (
     <div

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -1,179 +1,42 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { mUp } from '../../theme/mediaQueries'
-import { breakoutUp } from '../Center'
+import { mUp, tUp } from './mediaQueries'
 import Text from './Text'
 import colors from '../../theme/colors'
 
 import { FigureImage, FigureByline } from '../Figure'
+import { breakoutUp } from '../Center'
 import LazyLoad from '../LazyLoad'
-import { styles } from '../Form/VirtualDropdown';
-
-// Row
 
 const IMAGE_SIZE = {
   tiny: 180,
   small: 220,
   medium: 300,
-  large: 360,
+  large: 360
 }
 
 const sizeTiny = {
   maxHeight: `${IMAGE_SIZE.tiny}px`,
-  maxWidth: `${IMAGE_SIZE.tiny}px`,
+  maxWidth: `${IMAGE_SIZE.tiny}px`
 }
 
 const sizeSmall = {
   maxHeight: `${IMAGE_SIZE.small}px`,
-  maxWidth: `${IMAGE_SIZE.small}px`,
+  maxWidth: `${IMAGE_SIZE.small}px`
 }
 
 const sizeMedium = {
   maxHeight: `${IMAGE_SIZE.medium}px`,
-  maxWidth: `${IMAGE_SIZE.medium}px`,
+  maxWidth: `${IMAGE_SIZE.medium}px`
 }
 
 const sizeLarge = {
   maxHeight: `${IMAGE_SIZE.large}px`,
-  maxWidth: `${IMAGE_SIZE.large}px`,
+  maxWidth: `${IMAGE_SIZE.large}px`
 }
 
-const tileRowStyles = {
-  row: css({
-    display: 'flex',
-    flexDirection: 'column',
-    [mUp]: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      justifyContent: 'center',
-    },
-  }),
-  rowReverse: css({
-    flexDirection: 'column-reverse',
-    [mUp]: {
-      flexDirection: 'row',
-    },
-  }),
-  colSingle: css({
-    '& .tile': {
-      width: '100%',
-      boxSizing: 'border-box',
-    },
-  }),
-  colDouble: css({
-    '& .tile': {
-      boxSizing: 'border-box',
-      borderTop: `1px solid ${colors.divider}`,
-    },
-    '& img': {
-      ...sizeSmall,
-    },
-    [mUp]: {
-      '& .tile': {
-        borderTop: 'none',
-        width: '50%',
-      },
-      '& img': {
-        ...sizeMedium,
-      },
-    },
-    [breakoutUp]: {
-      '& img': {
-        ...sizeLarge,
-      },
-    },
-  }),
-  colOther: css({
-    '& .tile': {
-      boxSizing: 'border-box',
-      borderTop: `1px solid ${colors.divider}`,
-    },
-    '& img': {
-      ...sizeSmall,
-    },
-    [mUp]: {
-      '& .tile': {
-        width: '50%',
-        borderTop: 'none',
-        margin: '0 0 50px 0',
-      },
-      '& .tile:nth-child(2n+2)': {
-        borderTop: 'none',
-      },
-      '& img': {
-        ...sizeMedium,
-      },
-    },
-    [breakoutUp]: {
-      '& img': {
-        ...sizeLarge,
-      },
-      '& .tile': {
-        borderTop: 'none',
-        width: '33.3%',
-        margin: '0 0 50px 0',
-        borderLeft: `1px solid ${colors.divider}`,
-      },
-      '& .tile:nth-child(3n+1)': {
-        borderLeft: 'none',
-      },
-    },
-  }),
-}
-
-export const TeaserFrontTileRow = ({
-  children,
-  attributes,
-  mobileReverse,
-  expand
-}) => {
-
-  const kidsCount = React.Children.count(children)
-  let rowStyle
-
-  if (expand) {
-    switch (kidsCount) {
-      case 1:
-        rowStyle = tileRowStyles.colSingle
-        break;
-      case 2:
-        rowStyle = tileRowStyles.colDouble
-        break;    
-      default:
-        rowStyle = tileRowStyles.colOther
-        break;
-    }
-  } else {
-    rowStyle = tileRowStyles.colOther
-  }
-
-  return (
-    <div
-      role="group"
-      {...attributes}
-      {...tileRowStyles.row}
-      {...mobileReverse && tileRowStyles.rowReverse}
-      {...rowStyle}
-    >
-      {children}
-    </div>
-  )
-}
-
-TeaserFrontTileRow.propTypes = {
-  children: PropTypes.node.isRequired,
-  attributes: PropTypes.object,
-  expand: PropTypes.bool,
-}
-
-TeaserFrontTileRow.defaultProps = {
-  expand: false
-}
-
-// Tile
-
-const tileStyles = {
+const styles = {
   container: css({
     margin: '0 auto',
     textAlign: 'center',
@@ -184,33 +47,142 @@ const tileStyles = {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      padding: '60px 0',
-    },
+      padding: '60px 0'
+    }
   }),
   textContainer: css({
     padding: 0,
     [mUp]: {
       padding: '0 13%',
-      width: '100%',
-    },
+      width: '100%'
+    }
   }),
   imageContainer: css({
     margin: '0 auto 30px auto',
     [mUp]: {
-      margin: '0 auto 60px auto',
-      fontSize: 0, // Removes the small flexbox space.
+      fontSize: 0 // Removes the small flexbox space.
     },
+    [breakoutUp]: {
+      margin: '0 auto 60px auto'
+    }
+  }),
+  onlyImageContainer: css({
+    margin: '0 auto',
+    fontSize: 0,
+    minHeight: '100px',  // IE11
+    width: '100%'  // IE11
   }),
   image: css({
     minWidth: '100px',
     ...sizeSmall,
     [mUp]: {
-      ...sizeMedium,
+      ...sizeMedium
     },
     [breakoutUp]: {
-      ...sizeLarge,
-    },
+      ...sizeLarge
+    }
   }),
+  onlyImage: css({
+    minWidth: '100px',
+    maxHeight: '100% !important',
+    maxWidth: '100% !important'
+  }),
+  row: css({
+    margin: 0,
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    [mUp]: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+    }
+  }),
+  rowMobileReverse: css({
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column-reverse',
+    [mUp]: {
+      flexDirection: 'row'
+    }
+  }),
+  col2: css({
+    [mUp]: {
+      '& .tile': {
+        width: '50%'
+      },
+      '& img': {
+        ...sizeSmall
+      }
+    },
+    [breakoutUp]: {
+      '& img': {
+        ...sizeMedium
+      }
+    }
+  }),
+  col3: css({
+    '& .tile': {
+      borderTop: `1px solid ${colors.divider}`
+    },
+    [mUp]: {
+      flexWrap: 'wrap',
+      '& .tile': {
+        width: '50%',
+        borderLeft: `1px solid ${colors.divider}`,
+        borderTop: 'none',
+        margin: '0 0 50px 0',
+        padding: '20px 0'
+      },
+      '& .tile:nth-child(2n+1)': {
+        borderLeft: 'none'
+      },
+      '& img': {
+        ...sizeSmall
+      }
+    },
+    [breakoutUp]: {
+      '& .tile': {
+        width: '33%',
+      },
+      '& .tile:nth-child(2n+1)': {
+        borderLeft: `1px solid ${colors.divider}`,
+      },
+      '& .tile:nth-child(3n+1)': {
+        borderLeft: 'none'
+      },
+      '& img': {
+        ...sizeSmall
+      }
+    }
+  })
+}
+
+export const TeaserFrontTileRow = ({
+  children,
+  attributes,
+  columns,
+  mobileReverse
+}) => {
+  return (
+    <div
+      role="group"
+      {...attributes}
+      {...(mobileReverse ? styles.rowMobileReverse : styles.row)}
+      {...styles[`col${columns}`]}
+    >
+      {children}
+    </div>
+  )
+}
+
+TeaserFrontTileRow.propTypes = {
+  children: PropTypes.node.isRequired,
+  attributes: PropTypes.object,
+  columns: PropTypes.oneOf([1, 2, 3]).isRequired
+}
+
+TeaserFrontTileRow.defaultProps = {
+  columns: 1
 }
 
 const Tile = ({
@@ -224,56 +196,47 @@ const Tile = ({
   bgColor,
   align,
   aboveTheFold,
+  onlyImage
 }) => {
   const background = bgColor || ''
   const justifyContent =
-    align === 'top'
-      ? 'flex-start'
-      : align === 'bottom'
-      ? 'flex-end'
-      : ''
-  const imageProps =
-    image &&
-    FigureImage.utils.getResizedSrcs(image, IMAGE_SIZE.large, false)
-  let tileContainerStyle = {
+    align === 'top' ? 'flex-start' : align === 'bottom' ? 'flex-end' : ''
+  const imageProps = image && FigureImage.utils.getResizedSrcs(
+    image,
+    IMAGE_SIZE.large,
+    false
+  )
+  let containerStyle = {
     background,
     cursor: onClick ? 'pointer' : 'default',
-    justifyContent,
+    justifyContent
+  }
+  if (onlyImage) {
+    containerStyle.padding = 0
   }
 
   return (
     <div
       {...attributes}
-      {...tileStyles.container}
+      {...styles.container}
       onClick={onClick}
-      style={tileContainerStyle}
-      className="tile"
+      style={containerStyle}
+      className='tile'
     >
       {imageProps && (
-        <div {...tileStyles.imageContainer}>
-          <LazyLoad
-            visible={aboveTheFold}
-            style={{ position: 'relative', fontSize: 0 }}
-          >
-            <img
-              src={imageProps.src}
-              srcSet={imageProps.srcSet}
-              alt={alt}
-              {...tileStyles.image}
-            />
-            {byline && (
-              <FigureByline position="rightCompact" style={{ color }}>
-                {byline}
-              </FigureByline>
-            )}
+        <div {...(onlyImage ? styles.onlyImageContainer : styles.imageContainer)}>
+          <LazyLoad visible={aboveTheFold} style={{position: 'relative', fontSize: 0}}>
+            <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
+              {...(onlyImage ? styles.onlyImage : styles.image)} />
+            {byline && <FigureByline position='rightCompact' style={{color}}>{byline}</FigureByline>}
           </LazyLoad>
         </div>
       )}
-      <div {...tileStyles.textContainer}>
+      {!onlyImage && <div {...styles.textContainer}>
         <Text color={color} maxWidth={'600px'} margin={'0 auto'}>
           {children}
         </Text>
-      </div>
+      </div>}
     </div>
   )
 }
@@ -286,12 +249,17 @@ Tile.propTypes = {
   alt: PropTypes.string,
   color: PropTypes.string,
   bgColor: PropTypes.string,
-  align: PropTypes.oneOf(['top', 'middle', 'bottom']),
+  align: PropTypes.oneOf([
+    'top',
+    'middle',
+    'bottom'
+  ]),
   aboveTheFold: PropTypes.bool,
+  onlyImage: PropTypes.bool
 }
 
 Tile.defaultProps = {
-  alt: '',
+  alt: ''
 }
 
 export default Tile

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { mUp, lUp } from '../../theme/mediaQueries'
+import { mUp } from '../../theme/mediaQueries'
 import { breakoutUp } from '../Center'
 import Text from './Text'
 import colors from '../../theme/colors'
@@ -54,38 +54,43 @@ const tileRowStyles = {
       margin: '0 0 50px 0',
       padding: '20px 0'
     },
-    '& img': {
-      ...sizeTiny
-    },
   }),
   rowReverse: css({
     flexDirection: 'column-reverse',
   }),
   colEven: css({
+    '& img': {
+      ...sizeLarge
+    },
     [mUp]: {
       '& .tile': {
+        borderTop: 'none',
         width: '50%'
       },
       '& img': {
         ...sizeSmall
       }
     },
-    [lUp]: {
+    [breakoutUp]: {
       '& img': {
         ...sizeMedium
-      }
-    }
+      },
+    },
   }),
   colOdd: css({
+    '& img': {
+      ...sizeLarge
+    },
     [mUp]: {
       '& .tile': {
         width: '50%',
+        borderTop: 'none',
       },
       '& .tile:nth-child(2n+2)': {
         borderLeft: `1px solid ${colors.divider}`,
       },
       '& img': {
-        ...sizeSmall
+        ...sizeTiny
       },
     },
     [breakoutUp]: {
@@ -108,9 +113,7 @@ export const TeaserFrontTileRow = ({
   attributes,
   mobileReverse
 }) => {
-
   const kidsCountEven = React.Children.count(children) % 2 === 0
-
   return (
     <div
       role="group"
@@ -159,20 +162,18 @@ const tileStyles = {
   imageContainer: css({
     margin: '0 auto 30px auto',
     [mUp]: {
-      fontSize: 0 // Removes the small flexbox space.
+      margin: '0 auto 60px auto',
+      fontSize: 0, // Removes the small flexbox space.
     },
-    [mUp]: {
-      margin: '0 auto 60px auto'
-    }
   }),
   image: css({
     minWidth: '100px',
-    ...sizeSmall,
+    ...sizeTiny,
     [mUp]: {
-      ...sizeMedium
+      ...sizeSmall
     },
-    [mUp]: {
-      ...sizeLarge
+    [breakoutUp]: {
+      ...sizeMedium
     }
   }),
 }

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -110,6 +110,7 @@ const tileRowStyles = {
         borderTop: 'none',
         width: '33.3%',
         borderLeft: `1px solid ${colors.divider}`,
+        margin: 0,
       },
       '& .tile:nth-child(3n+1)': {
         borderLeft: 'none',
@@ -159,7 +160,7 @@ TeaserFrontTileRow.defaultProps = {
 
 const tileStyles = {
   container: css({
-    margin: '0 auto',
+    margin: 0,
     textAlign: 'center',
     padding: '30px 15px 40px 15px',
     width: '100%',
@@ -187,12 +188,12 @@ const tileStyles = {
   }),
   image: css({
     minWidth: '100px',
-    ...sizeTiny,
+    ...sizeSmall,
     [mUp]: {
-      ...sizeSmall,
+      ...sizeMedium,
     },
     [breakoutUp]: {
-      ...sizeMedium,
+      ...sizeLarge,
     },
   }),
 }
@@ -224,6 +225,8 @@ const Tile = ({
     cursor: onClick ? 'pointer' : 'default',
     justifyContent,
   }
+
+  console.log("{...tileContainerStyle.image}", {...tileContainerStyle.image})
 
   return (
     <div

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -51,7 +51,6 @@ const tileRowStyles = {
     '& .tile': {
       boxSizing: 'border-box',
       borderTop: `1px solid ${colors.divider}`,
-      borderTop: 'none',
       margin: '0 0 50px 0',
       padding: '20px 0'
     },
@@ -110,7 +109,7 @@ export const TeaserFrontTileRow = ({
   mobileReverse
 }) => {
 
-  const kidsCountEven = React.Children.count(children) & 2 === 0
+  const kidsCountEven = React.Children.count(children) % 2 === 0
 
   return (
     <div
@@ -128,7 +127,6 @@ export const TeaserFrontTileRow = ({
 TeaserFrontTileRow.propTypes = {
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
-  columns: PropTypes.oneOf([1, 2, 3]).isRequired
 }
 
 TeaserFrontTileRow.defaultProps = {

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -51,6 +51,9 @@ const tileRowStyles = {
   }),
   rowReverse: css({
     flexDirection: 'column-reverse',
+    [mUp]: {
+      flexDirection: 'row',
+    },
   }),
   colSingle: css({
     '& .tile': {
@@ -110,7 +113,6 @@ const tileRowStyles = {
       '& .tile': {
         borderTop: 'none',
         width: '33.3%',
-        background: 'coral',
         margin: '0 0 50px 0',
         borderLeft: `1px solid ${colors.divider}`,
       },

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -90,7 +90,7 @@ const tileRowStyles = {
         borderLeft: `1px solid ${colors.divider}`,
       },
       '& img': {
-        ...sizeTiny
+        ...sizeSmall
       },
     },
     [breakoutUp]: {

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -91,7 +91,7 @@ const tileRowStyles = {
     },
     [breakoutUp]: {
       '& img': {
-        ...sizeMedium
+        ...sizeSmall
       },
       '& .tile': {
         width: '33.3%',

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -1,12 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
-import { mUp, tUp } from './mediaQueries'
+import { mUp, lUp } from '../../theme/mediaQueries'
+import { breakoutUp } from '../Center'
 import Text from './Text'
 import colors from '../../theme/colors'
 
 import { FigureImage, FigureByline } from '../Figure'
 import LazyLoad from '../LazyLoad'
+
+// Row
 
 const IMAGE_SIZE = {
   tiny: 180,
@@ -35,7 +38,106 @@ const sizeLarge = {
   maxWidth: `${IMAGE_SIZE.large}px`
 }
 
-const styles = {
+const tileRowStyles = {
+  row: css({
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    [mUp]: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'center'
+    },
+    '& .tile': {
+      boxSizing: 'border-box',
+      borderTop: `1px solid ${colors.divider}`,
+      borderTop: 'none',
+      margin: '0 0 50px 0',
+      padding: '20px 0'
+    },
+    '& img': {
+      ...sizeTiny
+    },
+  }),
+  rowReverse: css({
+    flexDirection: 'column-reverse',
+  }),
+  colEven: css({
+    [mUp]: {
+      '& .tile': {
+        width: '50%'
+      },
+      '& img': {
+        ...sizeSmall
+      }
+    },
+    [lUp]: {
+      '& img': {
+        ...sizeMedium
+      }
+    }
+  }),
+  colOdd: css({
+    [mUp]: {
+      '& .tile': {
+        width: '50%',
+      },
+      '& .tile:nth-child(2n+2)': {
+        borderLeft: `1px solid ${colors.divider}`,
+      },
+      '& img': {
+        ...sizeSmall
+      },
+    },
+    [breakoutUp]: {
+      '& img': {
+        ...sizeMedium
+      },
+      '& .tile': {
+        width: '33.3%',
+        borderLeft: `1px solid ${colors.divider}`,
+      },
+      '& .tile:nth-child(3n+1)': {
+        borderLeft: 'none',
+      },
+    },
+  })
+}
+
+export const TeaserFrontTileRow = ({
+  children,
+  attributes,
+  mobileReverse
+}) => {
+
+  const kidsCountEven = React.Children.count(children) & 2 === 0
+
+  return (
+    <div
+      role="group"
+      {...attributes}
+      {...tileRowStyles.row}
+      {...(mobileReverse && tileRowStyles.rowReverse)}
+      {...tileRowStyles[`col${kidsCountEven ? 'Even' : 'Odd'}`]}
+    >
+      {children}
+    </div>
+  )
+}
+
+TeaserFrontTileRow.propTypes = {
+  children: PropTypes.node.isRequired,
+  attributes: PropTypes.object,
+  columns: PropTypes.oneOf([1, 2, 3]).isRequired
+}
+
+TeaserFrontTileRow.defaultProps = {
+  columns: 1
+}
+
+// Tile
+
+const tileStyles = {
   container: css({
     margin: '0 auto',
     textAlign: 'center',
@@ -61,15 +163,9 @@ const styles = {
     [mUp]: {
       fontSize: 0 // Removes the small flexbox space.
     },
-    [tUp]: {
+    [mUp]: {
       margin: '0 auto 60px auto'
     }
-  }),
-  onlyImageContainer: css({
-    margin: '0 auto',
-    fontSize: 0,
-    minHeight: '100px',  // IE11
-    width: '100%'  // IE11
   }),
   image: css({
     minWidth: '100px',
@@ -77,100 +173,10 @@ const styles = {
     [mUp]: {
       ...sizeMedium
     },
-    [tUp]: {
+    [mUp]: {
       ...sizeLarge
     }
   }),
-  onlyImage: css({
-    minWidth: '100px',
-    maxHeight: '100% !important',
-    maxWidth: '100% !important'
-  }),
-  row: css({
-    margin: 0,
-    display: 'block',
-    [mUp]: {
-      display: 'flex'
-    }
-  }),
-  rowMobileReverse: css({
-    margin: 0,
-    display: 'flex',
-    flexDirection: 'column-reverse',
-    [mUp]: {
-      flexDirection: 'row'
-    }
-  }),
-  col2: css({
-    [mUp]: {
-      '& .tile': {
-        width: '50%'
-      },
-      '& img': {
-        ...sizeSmall
-      }
-    },
-    [tUp]: {
-      '& img': {
-        ...sizeMedium
-      }
-    }
-  }),
-  col3: css({
-    '& .tile': {
-      borderTop: `1px solid ${colors.divider}`
-    },
-    [mUp]: {
-      display: 'flex',
-      flexFlow: 'row wrap',
-      '& .tile': {
-        width: '33.3%',
-        borderTop: 'none',
-        borderLeft: `1px solid ${colors.divider}`,
-        margin: '0 0 50px 0',
-        padding: '20px 0'
-      },
-      '& .tile:nth-child(3n+1)': {
-        borderLeft: 'none'
-      },
-      '& img': {
-        ...sizeTiny
-      }
-    },
-    [tUp]: {
-      '& img': {
-        ...sizeSmall
-      }
-    }
-  })
-}
-
-export const TeaserFrontTileRow = ({
-  children,
-  attributes,
-  columns,
-  mobileReverse
-}) => {
-  return (
-    <div
-      role="group"
-      {...attributes}
-      {...(mobileReverse ? styles.rowMobileReverse : styles.row)}
-      {...styles[`col${columns}`]}
-    >
-      {children}
-    </div>
-  )
-}
-
-TeaserFrontTileRow.propTypes = {
-  children: PropTypes.node.isRequired,
-  attributes: PropTypes.object,
-  columns: PropTypes.oneOf([1, 2, 3]).isRequired
-}
-
-TeaserFrontTileRow.defaultProps = {
-  columns: 1
 }
 
 const Tile = ({
@@ -184,7 +190,6 @@ const Tile = ({
   bgColor,
   align,
   aboveTheFold,
-  onlyImage
 }) => {
   const background = bgColor || ''
   const justifyContent =
@@ -194,37 +199,34 @@ const Tile = ({
     IMAGE_SIZE.large,
     false
   )
-  let containerStyle = {
+  let tileContainerStyle = {
     background,
     cursor: onClick ? 'pointer' : 'default',
-    justifyContent
-  }
-  if (onlyImage) {
-    containerStyle.padding = 0
+    justifyContent,
   }
 
   return (
     <div
       {...attributes}
-      {...styles.container}
+      {...tileStyles.container}
       onClick={onClick}
-      style={containerStyle}
+      style={tileContainerStyle}
       className='tile'
     >
       {imageProps && (
-        <div {...(onlyImage ? styles.onlyImageContainer : styles.imageContainer)}>
+        <div {...tileStyles.imageContainer}>
           <LazyLoad visible={aboveTheFold} style={{position: 'relative', fontSize: 0}}>
             <img src={imageProps.src} srcSet={imageProps.srcSet} alt={alt}
-              {...(onlyImage ? styles.onlyImage : styles.image)} />
+              {...tileStyles.image} />
             {byline && <FigureByline position='rightCompact' style={{color}}>{byline}</FigureByline>}
           </LazyLoad>
         </div>
       )}
-      {!onlyImage && <div {...styles.textContainer}>
+      <div {...tileStyles.textContainer}>
         <Text color={color} maxWidth={'600px'} margin={'0 auto'}>
           {children}
         </Text>
-      </div>}
+      </div>
     </div>
   )
 }
@@ -243,7 +245,6 @@ Tile.propTypes = {
     'bottom'
   ]),
   aboveTheFold: PropTypes.bool,
-  onlyImage: PropTypes.bool
 }
 
 Tile.defaultProps = {

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -61,7 +61,7 @@ const tileRowStyles = {
       boxSizing: 'border-box',
     },
   }),
-  colEven: css({
+  colDouble: css({
     '& .tile': {
       boxSizing: 'border-box',
       borderTop: `1px solid ${colors.divider}`,
@@ -84,7 +84,7 @@ const tileRowStyles = {
       },
     },
   }),
-  colOdd: css({
+  colOther: css({
     '& .tile': {
       boxSizing: 'border-box',
       borderTop: `1px solid ${colors.divider}`,
@@ -129,14 +129,24 @@ export const TeaserFrontTileRow = ({
   mobileReverse,
   expand
 }) => {
+
   const kidsCount = React.Children.count(children)
-  let rowClass
-  if (kidsCount === 1 && expand) {
-    rowClass = 'colSingle'
-  } else  if (kidsCount === 1 || kidsCount % 2 === 0) {
-    rowClass = 'colEven'
+  let rowStyle
+
+  if (expand) {
+    switch (kidsCount) {
+      case 1:
+        rowStyle = tileRowStyles.colSingle
+        break;
+      case 2:
+        rowStyle = tileRowStyles.colDouble
+        break;    
+      default:
+        rowStyle = tileRowStyles.colOther
+        break;
+    }
   } else {
-    rowClass = 'colOdd'
+    rowStyle = tileRowStyles.colOther
   }
 
   return (
@@ -145,7 +155,7 @@ export const TeaserFrontTileRow = ({
       {...attributes}
       {...tileRowStyles.row}
       {...mobileReverse && tileRowStyles.rowReverse}
-      {...tileRowStyles[rowClass]}
+      {...rowStyle}
     >
       {children}
     </div>
@@ -159,7 +169,7 @@ TeaserFrontTileRow.propTypes = {
 }
 
 TeaserFrontTileRow.defaultProps = {
-  columns: 1,
+  expand: false
 }
 
 // Tile

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -9,14 +9,14 @@ Supported props:
 
 A `<TeaserFrontTileHeadline />` should be used.
 
-A `<TeaserFrontTileRow />` must be the parent of a `<TeaserFrontTile />`. It may contain a single tile, or 2 tiles side by side.
+A `<TeaserFrontTileRow />` must be the parent of a `<TeaserFrontTile />`. It may contain a single tile, 2 tiles side by side, or a chain of 3 tiles. The `expand` prop controls whether the row expands to the entire width (required for front tiles).
 
 Supported props:
-- `columns`: `1` (default), or `2`.
+- `expand`: `true` or `false` (default).
 
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -43,7 +43,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -66,7 +66,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow mobileReverse>
+<TeaserFrontTileRow mobileReverse expand>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -89,7 +89,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile
     color='#fff' bgColor='#000'>
     <Editorial.Format>Staatentheorie</Editorial.Format>
@@ -159,7 +159,7 @@ Supported props:
 ### Aligning items
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile align='top' image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
@@ -180,7 +180,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#000' bgColor='#fff'>
@@ -203,7 +203,7 @@ Supported props:
 ### Image only
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile onlyImage image='/static/dada.jpg' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
@@ -218,7 +218,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile onlyImage image='/static/video.jpg' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
@@ -233,7 +233,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile onlyImage image='/static/video.jpg'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -117,7 +117,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -131,7 +131,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
@@ -145,7 +145,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow>
+<TeaserFrontTileRow expand>
   <TeaserFrontTile byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <Editorial.Format>Umfrage</Editorial.Format>
     <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -16,7 +16,7 @@ Supported props:
 
 
 ```react
-<TeaserFrontTileRow columns={2}>
+<TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -43,7 +43,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow columns={2}>
+<TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -66,7 +66,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow columns={2} mobileReverse>
+<TeaserFrontTileRow mobileReverse>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -89,7 +89,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow columns={3}>
+<TeaserFrontTileRow>
   <TeaserFrontTile
     color='#fff' bgColor='#000'>
     <Editorial.Format>Staatentheorie</Editorial.Format>
@@ -159,7 +159,7 @@ Supported props:
 ### Aligning items
 
 ```react
-<TeaserFrontTileRow columns={2}>
+<TeaserFrontTileRow>
   <TeaserFrontTile align='top' image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
@@ -180,7 +180,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow columns={2}>
+<TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#000' bgColor='#fff'>
@@ -203,7 +203,7 @@ Supported props:
 ### Image only
 
 ```react
-<TeaserFrontTileRow columns={2}>
+<TeaserFrontTileRow>
   <TeaserFrontTile onlyImage image='/static/dada.jpg' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
@@ -218,7 +218,7 @@ Supported props:
 ```
 
 ```react
-<TeaserFrontTileRow columns={2}>
+<TeaserFrontTileRow>
   <TeaserFrontTile onlyImage image='/static/video.jpg' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>

--- a/src/components/TeaserFront/Tile.md
+++ b/src/components/TeaserFront/Tile.md
@@ -9,14 +9,14 @@ Supported props:
 
 A `<TeaserFrontTileHeadline />` should be used.
 
-A `<TeaserFrontTileRow />` must be the parent of a `<TeaserFrontTile />`. It may contain a single tile, 2 tiles side by side, or a chain of 3 tiles. The `expand` prop controls whether the row expands to the entire width (required for front tiles).
+A `<TeaserFrontTileRow />` must be the parent of a `<TeaserFrontTile />`. It may contain a single tile, or 2 tiles side by side.
 
 Supported props:
-- `expand`: `true` or `false` (default).
+- `columns`: `1` (default), or `2`.
 
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -25,7 +25,7 @@ Supported props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
     </TeaserFrontLead>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#fff' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
@@ -36,14 +36,14 @@ Supported props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
     </TeaserFrontLead>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#000' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -52,21 +52,21 @@ Supported props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
     </TeaserFrontLead>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#fff' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile color='#000' bgColor='#fff'>
     <Editorial.Format>Umfrage</Editorial.Format>
     <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
     <TeaserFrontCredit>
-      <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
+      <TeaserFrontCreditLink color='#000' href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow mobileReverse expand>
+<TeaserFrontTileRow columns={2} mobileReverse>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#fff' bgColor='#000'>
@@ -75,34 +75,34 @@ Supported props:
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
     </TeaserFrontLead>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#fff' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile color='#000' bgColor='#fff'>
     <Editorial.Format>Umfrage</Editorial.Format>
     <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
     <TeaserFrontCredit>
-      <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
+      <TeaserFrontCreditLink color='#000' href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={3}>
   <TeaserFrontTile
     color='#fff' bgColor='#000'>
     <Editorial.Format>Staatentheorie</Editorial.Format>
     <TeaserFrontTileHeadline.Scribble>Ist der Ameisenstaat eine Republik?</TeaserFrontTileHeadline.Scribble>
     <TeaserFrontCredit>
-      <TeaserFrontCreditLink href='#'>Daniel Binswanger</TeaserFrontCreditLink>, 30.&nbsp;August&nbsp;2018
+      <TeaserFrontCreditLink color='#fff' href='#'>Daniel Binswanger</TeaserFrontCreditLink>, 30.&nbsp;August&nbsp;2018
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile color='#000' bgColor='#fff'>
     <Editorial.Format>Die aktuelle Verkehrslage</Editorial.Format>
     <TeaserFrontTileHeadline.Scribble>An der Brücke entspringt eine Ameisenstrasse</TeaserFrontTileHeadline.Scribble>
     <TeaserFrontCredit>
-      <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink>, 31.&nbsp;August&nbsp;2018
+      <TeaserFrontCreditLink color='#000' href='#'>Constantin Seibt</TeaserFrontCreditLink>, 31.&nbsp;August&nbsp;2018
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile
@@ -110,47 +110,47 @@ Supported props:
     <Editorial.Format>Im Gleichmarsch</Editorial.Format>
     <TeaserFrontTileHeadline.Scribble>Links, zwo, drei, vier!</TeaserFrontTileHeadline.Scribble>
     <TeaserFrontCredit>
-      <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink>, 1.&nbsp;September&nbsp;2018
+      <TeaserFrontCreditLink color='#fff' href='#'>Constantin Seibt</TeaserFrontCreditLink>, 1.&nbsp;September&nbsp;2018
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_portrait.jpg' byline='Foto: Laurent Burst' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick brown fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
     </TeaserFrontLead>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#' color='#fba'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#fff' href='#' color='#fff'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>The quick fox</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontLead>
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.
     </TeaserFrontLead>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#' color='#fba'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#fff' href='#' color='#fff'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow>
   <TeaserFrontTile byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <Editorial.Format>Umfrage</Editorial.Format>
     <TeaserFrontTileHeadline.Interaction>Mehr Geld für ausländische Autorinnen oder einen Bundeshaus&shy;korrespondent?</TeaserFrontTileHeadline.Interaction>
     <TeaserFrontCredit>
-      <TeaserFrontCreditLink href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
+      <TeaserFrontCreditLink color='#000' href='#'>Constantin Seibt</TeaserFrontCreditLink> fragt nach<br />31. December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
@@ -159,11 +159,11 @@ Supported props:
 ### Aligning items
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={2}>
   <TeaserFrontTile align='top' image='/static/rothaus_landscape.jpg' byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#000' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile
@@ -173,20 +173,20 @@ Supported props:
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>An article which deserves top-alignment</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#000' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={2}>
   <TeaserFrontTile image='/static/rothaus_landscape.jpg'
     byline='Foto: Laurent Burst'
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#000' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
   <TeaserFrontTile
@@ -194,7 +194,7 @@ Supported props:
     byline='Foto: Laurent Burst' color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Short headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#000' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
@@ -203,7 +203,7 @@ Supported props:
 ### Image only
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={2}>
   <TeaserFrontTile onlyImage image='/static/dada.jpg' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
@@ -211,14 +211,14 @@ Supported props:
     color='#fff' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#fff' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow columns={2}>
   <TeaserFrontTile onlyImage image='/static/video.jpg' bgColor='#000'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>
@@ -226,14 +226,14 @@ Supported props:
     color='#000' bgColor='#fff'>
     <TeaserFrontTileHeadline.Editorial>Headline</TeaserFrontTileHeadline.Editorial>
     <TeaserFrontCredit>
-      An article by <TeaserFrontCreditLink href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
+      An article by <TeaserFrontCreditLink color='#000' href='#'>Christof Moser</TeaserFrontCreditLink>, 31 December 2017
     </TeaserFrontCredit>
   </TeaserFrontTile>
 </TeaserFrontTileRow>
 ```
 
 ```react
-<TeaserFrontTileRow expand>
+<TeaserFrontTileRow>
   <TeaserFrontTile onlyImage image='/static/video.jpg'>
     <TeaserFrontTileHeadline.Editorial>Unrendered headline</TeaserFrontTileHeadline.Editorial>
   </TeaserFrontTile>

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -226,7 +226,7 @@ const createTeasers = ({
       return matchZone('TEASERGROUP')(node)
     },
     component: ({ children, attributes, ...props }) => {
-      return <TeaserFrontTileRow columns={3} attributes={attributes} {...props}>
+      return <TeaserFrontTileRow attributes={attributes} {...props}>
         {children}
       </TeaserFrontTileRow>
     },

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -523,7 +523,7 @@ const createSchema = ({
   const articleTileRow = {
     matchMdast: matchZone('TEASERGROUP'),
     component: ({ children, attributes, ...props }) => {
-      return <TeaserFrontTileRow attributes={attributes} {...props}>
+      return <TeaserFrontTileRow expand attributes={attributes} {...props}>
         {children}
       </TeaserFrontTileRow>
     },

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -661,7 +661,7 @@ const createSchema = ({
               return matchZone('TEASERGROUP')(node)
             },
             component: ({ children, attributes, ...props }) => {
-              return <TeaserFrontTileRow attributes={attributes} {...props}>
+              return <TeaserFrontTileRow expand attributes={attributes} {...props}>
                 {children}
               </TeaserFrontTileRow>
             },

--- a/src/templates/Front/index.js
+++ b/src/templates/Front/index.js
@@ -523,7 +523,7 @@ const createSchema = ({
   const articleTileRow = {
     matchMdast: matchZone('TEASERGROUP'),
     component: ({ children, attributes, ...props }) => {
-      return <TeaserFrontTileRow columns={3} attributes={attributes} {...props}>
+      return <TeaserFrontTileRow attributes={attributes} {...props}>
         {children}
       </TeaserFrontTileRow>
     },


### PR DESCRIPTION
- Derive layout from number of children (remove `columns` prop)
- Add `expand` prop for teasers on front
- Adjust breakpoints

| Desktop | Tablet| Mobile |
| -- | -- | -- |
| <img src="https://user-images.githubusercontent.com/299766/57888722-389d2a00-7833-11e9-8baa-556df56ae189.png"> | <img src="https://user-images.githubusercontent.com/299766/57888789-65e9d800-7833-11e9-94f7-5d8b6412237b.png" > | <img src="https://user-images.githubusercontent.com/299766/57888845-86b22d80-7833-11e9-939b-d61433c5621d.png"> |
