### PR TITLE
Scroll the <CommentComposer> into view upon mount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16566,6 +16566,12 @@
         "invariant": "^2.2.2"
       }
     },
+    "scroll-into-view": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/scroll-into-view/-/scroll-into-view-1.9.7.tgz",
+      "integrity": "sha512-zhUw4nEe9H2C4yFMdWU5V1wFyRmB0OoJQ93BtSMH1Rj1a6kS0EmG7I4WoY2S3OwW3YKyU851q03rpxtIcDwzhw==",
+      "dev": true
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "d3-time-format": "2.x",
     "downshift": "^2.2.2",
     "glamor": "^2.20.40",
+    "isomorphic-unfetch": "3.x",
     "lodash": "4.x",
     "mdast-react-render": ">=1.1",
+    "prop-types": ">=15.5",
     "react": ">=16.5",
     "react-maskedinput": ">=4.0.1",
-    "prop-types": ">=15.5",
     "react-textarea-autosize": ">=5.1.0",
-    "topojson": "3.x",
-    "isomorphic-unfetch": "3.x"
+    "scroll-into-view": "^1.9.7",
+    "topojson": "3.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
@@ -70,6 +71,7 @@
     "react-scripts": "1.1.4",
     "react-textarea-autosize": "^5.1.0",
     "rimraf": "^2.6.1",
+    "scroll-into-view": "^1.9.7",
     "semantic-release": "^6.3.6",
     "slate": "^0.41",
     "slate-mdast-serializer": "^3",

--- a/src/components/CommentComposer/CommentComposer.js
+++ b/src/components/CommentComposer/CommentComposer.js
@@ -93,16 +93,13 @@ class CommentComposer extends PureComponent {
 
     this.state = {
       text: props.initialText || '',
-      count: 0,
-      progress: 0,
       tagValue: props.tagValue
     }
 
-    this.root = React.createRef();
+    this.root = React.createRef()
 
     this.onChange = ev => {
       this.setState({text: ev.target.value})
-      this.updateMaxLength()
     }
 
     this.onSubmit = () => {
@@ -112,14 +109,12 @@ class CommentComposer extends PureComponent {
       )
     }
 
+    // MUST be a function because <Textarea> doesn't support
+    // React.createRef()-style refs.
     this.textarea = null
     this.textareaRef = (ref) => {
       this.textarea = ref
     }
-
-    this.getCount = () => (
-      (this.textarea && this.textarea.value.length) || 0
-    )
 
     this.onTagChange = (tagValue) => {
       this.setState({tagValue})
@@ -127,47 +122,15 @@ class CommentComposer extends PureComponent {
     }
   }
 
-  updateMaxLength () {
-    if (this.props.maxLength) {
-      this.setState({
-        count: this.getCount(),
-        progress: this.getCount() / this.props.maxLength * 100
-      })
-    }
-  }
-
   componentDidMount () {
     if (this.textarea) {
       this.textarea.focus()
-      this.updateMaxLength()
     }
 
     // Scroll the viewport such that the composer is aligned to the top.
     scrollIntoView(this.root.current, {
       align: {top: 0, topOffset: 60}
     })
-  }
-
-  renderProgress () {
-    const {maxLength} = this.props
-    if (!maxLength) return null
-
-    const {count, progress} = this.state
-    const remaining = maxLength - count
-    const progressColor = progress > 100 ? colors.error : colors.text
-    return (
-      <div {...styles.maxLength}>
-        {remaining < 21 && <span {...styles.remaining} style={{color: progressColor}}>
-          {remaining}
-        </span>}
-        <ProgressCircle
-          stroke={progressColor}
-          radius={9}
-          strokeWidth={2}
-          progress={Math.min(progress, 100)}
-        />
-      </div>
-    )
   }
 
   render () {
@@ -184,8 +147,8 @@ class CommentComposer extends PureComponent {
       tagRequired,
       tags
     } = this.props
-    const {text, count, tagValue} = this.state
-    const maxLengthExceeded = maxLength && count > maxLength
+    const {text, tagValue} = this.state
+    const maxLengthExceeded = maxLength && text.length > maxLength
 
     return (
       <div ref={this.root}>
@@ -215,7 +178,12 @@ class CommentComposer extends PureComponent {
             rows='1'
             onChange={this.onChange}
           />
-          {this.renderProgress()}
+          {maxLength && (
+            <MaxLengthIndicator
+              maxLength={maxLength}
+              length={text.length}
+            />
+          )}
           <div {...styles.actions}>
             {secondaryActions && (
               <div {...styles.secondaryActions}>
@@ -256,3 +224,23 @@ CommentComposer.propTypes = {
 }
 
 export default CommentComposer
+
+const MaxLengthIndicator = ({maxLength, length}) => {
+  const progress = length / maxLength * 100
+  const remaining = maxLength - length
+  const progressColor = progress > 100 ? colors.error : colors.text
+
+  return (
+    <div {...styles.maxLength}>
+      {remaining < 21 && <span {...styles.remaining} style={{color: progressColor}}>
+        {remaining}
+      </span>}
+      <ProgressCircle
+        stroke={progressColor}
+        radius={9}
+        strokeWidth={2}
+        progress={Math.min(progress, 100)}
+      />
+    </div>
+  )
+}

--- a/src/components/CommentComposer/CommentComposer.js
+++ b/src/components/CommentComposer/CommentComposer.js
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react'
 import PropTypes from 'prop-types'
 import {css} from 'glamor'
 import Textarea from 'react-textarea-autosize';
+import scrollIntoView from 'scroll-into-view'
 import colors from '../../theme/colors'
 import {serifRegular16, sansSerifRegular14, sansSerifRegular16} from '../Typography/styles'
 
@@ -97,6 +98,8 @@ class CommentComposer extends PureComponent {
       tagValue: props.tagValue
     }
 
+    this.root = React.createRef();
+
     this.onChange = ev => {
       this.setState({text: ev.target.value})
       this.updateMaxLength()
@@ -138,6 +141,11 @@ class CommentComposer extends PureComponent {
       this.textarea.focus()
       this.updateMaxLength()
     }
+
+    // Scroll the viewport such that the composer is aligned to the top.
+    scrollIntoView(this.root.current, {
+      align: {top: 0, topOffset: 60}
+    })
   }
 
   renderProgress () {
@@ -180,7 +188,7 @@ class CommentComposer extends PureComponent {
     const maxLengthExceeded = maxLength && count > maxLength
 
     return (
-      <div>
+      <div ref={this.root}>
         <CommentComposerHeader
           {...displayAuthor}
           onClick={onEditPreferences}


### PR DESCRIPTION
Using [scroll-into-view](https://github.com/KoryNunn/scroll-into-view). The native `Element.scrollIntoView()` didn't work well because it does not support setting an offset, so the comment composer would scroll to the very top and be hidden behind the header.

Fixes https://github.com/orbiting/republik-frontend/issues/301