### PR TITLE
feat(Infobox): collapsable

### DIFF
--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -14,17 +14,41 @@ const COLLAPSED_HEIGHT = {
   desktop: 240
 }
 
-const collapsedBodyStyle = (mobile, desktop) => {
-  return css({
-    overflow: 'hidden',
-    maxHeight: `${mobile}px`,
+const collapsedBodyStyle = (mobile, desktop) => css({
+  overflow: 'hidden',
+  maxHeight: mobile,
+  [mUp]: {
+    maxHeight: desktop
+  }
+})
+
+const collapsedEditorPreviewStyle = (mobile, desktop) => css({
+  position: 'relative',
+  minHeight: mobile,
+  [mUp]: {
+    minHeight: desktop
+  },
+  '&:before': {
+    content: ' ',
+    display: 'block',
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    right: 0,
+    backgroundColor: colors.secondaryBg,
+    borderTop: `1px solid ${colors.primary}`,
+    borderBottom: `1px solid ${colors.primary}`,
+    top: mobile,
     [mUp]: {
-      maxHeight: `${desktop}px`
+      top: desktop
     }
-  })
-}
+  }
+})
 
 const styles = {
+  body: css({
+    position: 'relative'
+  }),
   buttonContainer: css({
     position: 'relative',
     borderTop: `1px solid ${colors.divider}`,
@@ -59,7 +83,7 @@ const styles = {
   })
 }
 
-const Collapsable = ({ t, children, height, threshold, initialVisibility, style }) => {
+const Collapsable = ({ t, children, height, threshold, initialVisibility, style, editorPreview }) => {
   /**
    * Measuring the body size (height), so we can determine whether to collapse
    * the body.
@@ -96,19 +120,22 @@ const Collapsable = ({ t, children, height, threshold, initialVisibility, style 
   ])
 
   return (
-    <>
-      <div ref={bodyRef} {...(collapsed ? collapsedBodyStyle(mobile, desktop) : undefined)} style={style}>
+    <div {...editorPreview && collapsedEditorPreviewStyle(mobile, desktop)}>
+      <div ref={bodyRef}
+        {...styles.body}
+        {...collapsed && !editorPreview && collapsedBodyStyle(mobile, desktop)}
+        style={style}>
         {children}
       </div>
 
-      {bodyVisibility !== 'auto' && (
+      {bodyVisibility !== 'auto' && !editorPreview && (
         <div {...(collapsed ? styles.buttonContainer : {})}>
           <button {...styles.button} onClick={onToggleCollapsed} title={collapseLabel}>
             {collapseLabel}
           </button>
         </div>
       )}
-    </>
+    </div>
   )
 }
 
@@ -122,7 +149,8 @@ Collapsable.propTypes = {
   }),
   initialVisibility: PropTypes.oneOf(['auto', 'full', 'preview']),
   threshold: PropTypes.number,
-  style: PropTypes.object
+  style: PropTypes.object,
+  editorPreview: PropTypes.bool
 }
 
 Collapsable.defaultProps = {

--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -14,17 +14,6 @@ const COLLAPSED_HEIGHT = {
   desktop: 240
 }
 
-const buttonStyle = {
-  outline: 'none',
-  WebkitAppearance: 'none',
-  background: 'transparent',
-  border: 'none',
-  padding: '0',
-  display: 'block',
-  cursor: 'pointer',
-  height: '100%'
-}
-
 const collapsedBodyStyle = (mobile, desktop) => {
   return css({
     overflow: 'hidden',
@@ -64,8 +53,14 @@ const styles = {
     }
   }),
   collapseToggleButton: css({
-    ...buttonStyle,
     ...sansSerifRegular14,
+    outline: 'none',
+    WebkitAppearance: 'none',
+    background: 'transparent',
+    border: 'none',
+    padding: '0',
+    display: 'block',
+    cursor: 'pointer',
     color: colors.primary,
     height: '32px',
     lineHeight: '32px',

--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -14,8 +14,6 @@ const COLLAPSED_HEIGHT = {
   desktop: 240
 }
 
-const highlightPadding = 7
-
 const buttonStyle = {
   outline: 'none',
   WebkitAppearance: 'none',
@@ -40,15 +38,6 @@ const collapsedBodyStyle = (mobile, desktop) => {
 const styles = {
   container: css({
     position: 'relative'
-  }),
-  highlight: css({
-    top: -highlightPadding,
-    left: -highlightPadding,
-    right: -highlightPadding,
-    bottom: -highlightPadding,
-    padding: highlightPadding,
-    width: `calc(100% + ${highlightPadding * 2}px)`,
-    backgroundColor: colors.primaryBg
   }),
   margin: css({
     display: 'block',

--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -25,20 +25,7 @@ const collapsedBodyStyle = (mobile, desktop) => {
 }
 
 const styles = {
-  container: css({
-    position: 'relative'
-  }),
-  margin: css({
-    display: 'block',
-    marginTop: 8
-  }),
-  unpublished: css({
-    marginBottom: 8
-  }),
-  context: css({
-    marginBottom: 10
-  }),
-  collapeToggleContainer: css({
+  buttonContainer: css({
     position: 'relative',
     borderTop: `1px solid ${colors.divider}`,
     '&::before': {
@@ -52,7 +39,7 @@ const styles = {
       background: 'linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 100%)'
     }
   }),
-  collapseToggleButton: css({
+  button: css({
     ...sansSerifRegular14,
     outline: 'none',
     WebkitAppearance: 'none',
@@ -74,8 +61,8 @@ const styles = {
 
 const Collapsable = ({ t, children, collapsable, height, threshold, style }) => {
   /**
-   * Measuring the comment body size (height), so we can determine whether to collapse
-   * the comment body.
+   * Measuring the body size (height), so we can determine whether to collapse
+   * the body.
    *
    * bodyVisibility:
    *   - 'indeterminate': We don't know yet whether to collapse the body or not.
@@ -101,7 +88,7 @@ const Collapsable = ({ t, children, collapsable, height, threshold, style }) => 
   }, [isDesktop, collapsable, bodyVisibility, bodySize, desktop, mobile, threshold])
 
   const collapsed = !collapsable || bodyVisibility === 'indeterminate' ? undefined : bodyVisibility === 'preview'
-  const collapseLabel = t && t(`styleguide/CommentActions/${collapsed ? 'expand' : 'collapse'}`)
+  const collapseLabel = t && t(`styleguide/Collapsable/${collapsed ? 'expand' : 'collapse'}`)
   const onToggleCollapsed = React.useCallback(() => setBodyVisibility(v => (v === 'preview' ? 'full' : 'preview')), [
     setBodyVisibility
   ])
@@ -117,8 +104,8 @@ const Collapsable = ({ t, children, collapsable, height, threshold, style }) => 
       </div>
 
       {bodyVisibility !== 'indeterminate' && (
-        <div {...(collapsed ? styles.collapeToggleContainer : {})}>
-          <button {...styles.collapseToggleButton} onClick={onToggleCollapsed} title={collapseLabel}>
+        <div {...(collapsed ? styles.buttonContainer : {})}>
+          <button {...styles.button} onClick={onToggleCollapsed} title={collapseLabel}>
             {collapseLabel}
           </button>
         </div>

--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -1,0 +1,165 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+
+import { sansSerifRegular14 } from '../Typography/styles'
+
+import colors from '../../theme/colors'
+import { mUp } from '../../theme/mediaQueries'
+import { useMediaQuery } from '../../lib/useMediaQuery'
+import { useBoundingClientRect } from '../../lib/useBoundingClientRect'
+
+const COLLAPSED_HEIGHT = {
+  mobile: 180,
+  desktop: 240
+}
+
+const highlightPadding = 7
+
+const buttonStyle = {
+  outline: 'none',
+  WebkitAppearance: 'none',
+  background: 'transparent',
+  border: 'none',
+  padding: '0',
+  display: 'block',
+  cursor: 'pointer',
+  height: '100%'
+}
+
+const collapsedBodyStyle = (mobile, desktop) => {
+  return css({
+    overflow: 'hidden',
+    maxHeight: `${mobile}px`,
+    [mUp]: {
+      maxHeight: `${desktop}px`
+    }
+  })
+}
+
+const styles = {
+  container: css({
+    position: 'relative'
+  }),
+  highlight: css({
+    top: -highlightPadding,
+    left: -highlightPadding,
+    right: -highlightPadding,
+    bottom: -highlightPadding,
+    padding: highlightPadding,
+    width: `calc(100% + ${highlightPadding * 2}px)`,
+    backgroundColor: colors.primaryBg
+  }),
+  margin: css({
+    display: 'block',
+    marginTop: 8
+  }),
+  unpublished: css({
+    marginBottom: 8
+  }),
+  context: css({
+    marginBottom: 10
+  }),
+  collapeToggleContainer: css({
+    position: 'relative',
+    borderTop: `1px solid ${colors.divider}`,
+    '&::before': {
+      position: 'absolute',
+      display: 'block',
+      content: '""',
+      left: 0,
+      right: 0,
+      top: -61,
+      height: 60,
+      background: 'linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 100%)'
+    }
+  }),
+  collapseToggleButton: css({
+    ...buttonStyle,
+    ...sansSerifRegular14,
+    color: colors.primary,
+    height: '32px',
+    lineHeight: '32px',
+    '@media (hover)': {
+      ':hover': {
+        color: colors.secondary
+      }
+    }
+  })
+}
+
+const Collapsable = ({ t, children, collapsable, height, threshold, style }) => {
+  /**
+   * Measuring the comment body size (height), so we can determine whether to collapse
+   * the comment body.
+   *
+   * bodyVisibility:
+   *   - 'indeterminate': We don't know yet whether to collapse the body or not.
+   *   - 'full': The body is collapsable but we're showing the full body.
+   *   - 'preview': The body is collapsed.
+   */
+
+  const [bodyVisibility, setBodyVisibility] = React.useState('indeterminate')
+  const [bodyRef, bodySize] = useBoundingClientRect([children])
+  const isDesktop = useMediaQuery(mUp)
+  const { desktop, mobile } = height
+  React.useEffect(() => {
+    /*
+     * Collapse the body (switch to 'preview' visibility) when allowed and the size
+     * exceeds the threshold.
+     */
+    if (bodyVisibility === 'indeterminate' && collapsable && bodySize.height !== undefined) {
+      const maxBodyHeight = isDesktop ? desktop : mobile
+      if (bodySize.height > maxBodyHeight + threshold) {
+        setBodyVisibility('preview')
+      }
+    }
+  }, [isDesktop, collapsable, bodyVisibility, bodySize, desktop, mobile, threshold])
+
+  const collapsed = !collapsable || bodyVisibility === 'indeterminate' ? undefined : bodyVisibility === 'preview'
+  const collapseLabel = t && t(`styleguide/CommentActions/${collapsed ? 'expand' : 'collapse'}`)
+  const onToggleCollapsed = React.useCallback(() => setBodyVisibility(v => (v === 'preview' ? 'full' : 'preview')), [
+    setBodyVisibility
+  ])
+
+  if (!collapsable) {
+    return children
+  }
+
+  return (
+    <>
+      <div ref={bodyRef} {...(collapsed ? collapsedBodyStyle(mobile, desktop) : undefined)} style={style}>
+        {children}
+      </div>
+
+      {bodyVisibility !== 'indeterminate' && (
+        <div {...(collapsed ? styles.collapeToggleContainer : {})}>
+          <button {...styles.collapseToggleButton} onClick={onToggleCollapsed} title={collapseLabel}>
+            {collapseLabel}
+          </button>
+        </div>
+      )}
+    </>
+  )
+}
+
+
+Collapsable.propTypes = {
+  t: PropTypes.func,
+  children: PropTypes.node.isRequired,
+  collapsable: PropTypes.bool,
+  height: PropTypes.shape({
+    mobile: PropTypes.number,
+    desktop: PropTypes.number
+  }),
+  threshold: PropTypes.number,
+  style: PropTypes.object
+}
+
+Collapsable.defaultProps = {
+  collapsable: true,
+  height: COLLAPSED_HEIGHT,
+  threshold: 50
+}
+
+export default Collapsable

--- a/src/components/Collapsable/docs.md
+++ b/src/components/Collapsable/docs.md
@@ -6,6 +6,8 @@ Supported props:
 - `threshold`: We won't collapse a comment if it just slightly exceeds the heights above. This threshold can be adjusted here in pixels (defaults to 50).
 - `style`: An optional style object.
 
+Used in [Comment Body](/components/discussion/internal#body) and [Infobox](/infobox#collapsable).
+
 ```react
 <Collapsable t={t}>
   <Editorial.P>

--- a/src/components/Collapsable/docs.md
+++ b/src/components/Collapsable/docs.md
@@ -1,8 +1,8 @@
 A `<Collapsable />` wraps content that should be collapsed by default and can be expanded on click.
 
 Supported props:
-- `collapsable`: Whether the content should be collapsable.
 - `height`: Object defining `mobile` and `desktop` pixel height in collapsed state (defaults to `{mobile: 180, desktop: 240}`).
+- `initialVisibility`: `preview`, `full` or `auto` (default, collapses if height + threshold is exceeded)
 - `threshold`: We won't collapse a comment if it just slightly exceeds the heights above. This threshold can be adjusted in pixels (defaults to 50).
 - `style`: An optional style object.
 
@@ -16,13 +16,22 @@ Used in [Comment Body](/components/discussion/internal#body) and [Infobox](/info
 </Collapsable>
 ```
 
+Does not collapse because the height is not exceed by more than the default threshold of 50px:
 
 ```react
-<Collapsable t={t} height={{ mobile: 80, desktop: 95 }}>
+<Collapsable t={t} height={{ mobile: 65, desktop: 65 }}>
   <Editorial.P>
-    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought.
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.
   </Editorial.P>
 </Collapsable>
 ```
 
+Always collapse with an `initialVisibility` of `preview`:
 
+```react
+<Collapsable t={t} height={{ mobile: 65, desktop: 65 }} initialVisibility='preview'>
+  <Editorial.P>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.
+  </Editorial.P>
+</Collapsable>
+```

--- a/src/components/Collapsable/docs.md
+++ b/src/components/Collapsable/docs.md
@@ -5,6 +5,7 @@ Supported props:
 - `initialVisibility`: `preview`, `full` or `auto` (default, collapses if height + threshold is exceeded)
 - `threshold`: We won't collapse a comment if it just slightly exceeds the heights above. This threshold can be adjusted in pixels (defaults to 50).
 - `style`: An optional style object.
+- `editorPreview`: only mark the cut off area visually, for editors.
 
 Used in [Comment Body](/components/discussion/internal#body) and [Infobox](/infobox#collapsable).
 
@@ -26,12 +27,14 @@ Does not collapse because the height is not exceed by more than the default thre
 </Collapsable>
 ```
 
-Always collapse with an `initialVisibility` of `preview`:
+## Editor Preview
+
+Content only visible after expanding is marked with an soft background color between two primary lines.
 
 ```react
-<Collapsable t={t} height={{ mobile: 65, desktop: 65 }} initialVisibility='preview'>
+<Collapsable t={t} editorPreview>
   <Editorial.P>
-    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought.
   </Editorial.P>
 </Collapsable>
 ```

--- a/src/components/Collapsable/docs.md
+++ b/src/components/Collapsable/docs.md
@@ -3,7 +3,7 @@ A `<Collapsable />` wraps content that should be collapsed by default and can be
 Supported props:
 - `collapsable`: Whether the content should be collapsable.
 - `height`: Object defining `mobile` and `desktop` pixel height in collapsed state (defaults to `{mobile: 180, desktop: 240}`).
-- `threshold`: We won't collapse a comment if it just slightly exceeds the heights above. This threshold can be adjusted here in pixels (defaults to 50).
+- `threshold`: We won't collapse a comment if it just slightly exceeds the heights above. This threshold can be adjusted in pixels (defaults to 50).
 - `style`: An optional style object.
 
 Used in [Comment Body](/components/discussion/internal#body) and [Infobox](/infobox#collapsable).

--- a/src/components/Collapsable/docs.md
+++ b/src/components/Collapsable/docs.md
@@ -1,0 +1,26 @@
+A `<Collapsable />` wraps content that should be collapsed by default and can be expanded on click.
+
+Supported props:
+- `collapsable`: Whether the content should be collapsable.
+- `height`: Object defining `mobile` and `desktop` pixel height in collapsed state (defaults to `{mobile: 180, desktop: 240}`).
+- `threshold`: We won't collapse a comment if it just slightly exceeds the heights above. This threshold can be adjusted here in pixels (defaults to 50).
+- `style`: An optional style object.
+
+```react
+<Collapsable t={t}>
+  <Editorial.P>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought.
+  </Editorial.P>
+</Collapsable>
+```
+
+
+```react
+<Collapsable t={t} height={{ mobile: 80, desktop: 95 }}>
+  <Editorial.P>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought.
+  </Editorial.P>
+</Collapsable>
+```
+
+

--- a/src/components/Collapsable/index.js
+++ b/src/components/Collapsable/index.js
@@ -1,0 +1,3 @@
+export {
+  default as Collapsable
+} from './Collapsable'

--- a/src/components/Discussion/Internal/Comment/Body.js
+++ b/src/components/Discussion/Internal/Comment/Body.js
@@ -3,43 +3,14 @@ import { css } from 'glamor'
 
 import { Collapsable } from '../../../Collapsable'
 import { DiscussionContext } from '../../DiscussionContext'
-
 import { Label } from '../../../Typography'
-import { sansSerifRegular14 } from '../../../Typography/styles'
-
-import colors from '../../../../theme/colors'
-import { mUp } from '../../../../theme/mediaQueries'
 
 import { Context } from './Context'
 import { renderCommentMdast } from './render'
 
-import { COLLAPSED_HEIGHT } from '../../config'
-
-const highlightPadding = 7
-
-const buttonStyle = {
-  outline: 'none',
-  WebkitAppearance: 'none',
-  background: 'transparent',
-  border: 'none',
-  padding: '0',
-  display: 'block',
-  cursor: 'pointer',
-  height: '100%'
-}
-
 const styles = {
   container: css({
     position: 'relative'
-  }),
-  highlight: css({
-    top: -highlightPadding,
-    left: -highlightPadding,
-    right: -highlightPadding,
-    bottom: -highlightPadding,
-    padding: highlightPadding,
-    width: `calc(100% + ${highlightPadding * 2}px)`,
-    backgroundColor: colors.primaryBg
   }),
   margin: css({
     display: 'block',
@@ -48,41 +19,8 @@ const styles = {
   unpublished: css({
     marginBottom: 8
   }),
-  collapsedBody: css({
-    height: `${COLLAPSED_HEIGHT.mobile}px`,
-    overflow: 'hidden',
-    [mUp]: {
-      maxHeight: `${COLLAPSED_HEIGHT.desktop}px`
-    }
-  }),
   context: css({
     marginBottom: 10
-  }),
-  collapeToggleContainer: css({
-    position: 'relative',
-    borderTop: `1px solid ${colors.divider}`,
-    '&::before': {
-      position: 'absolute',
-      display: 'block',
-      content: '""',
-      left: 0,
-      right: 0,
-      top: -61,
-      height: 60,
-      background: 'linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 100%)'
-    }
-  }),
-  collapseToggleButton: css({
-    ...buttonStyle,
-    ...sansSerifRegular14,
-    color: colors.primary,
-    height: '32px',
-    lineHeight: '32px',
-    '@media (hover)': {
-      ':hover': {
-        color: colors.secondary
-      }
-    }
   })
 }
 
@@ -104,7 +42,10 @@ export const Body = ({ t, comment, context }) => {
     </>
    )
   const bodyNode = collapsable && !isHighlighted
-    ? <Collapsable t={t} collapsable={collapsable && !isHighlighted} style={{ opacity: published ? 1 : 0.5 }}>
+    ? <Collapsable
+        t={t}
+        collapsable={collapsable && !isHighlighted}
+        style={{ opacity: published ? 1 : 0.5 }}>
         {body}
       </Collapsable>
     : body

--- a/src/components/Discussion/config.js
+++ b/src/components/Discussion/config.js
@@ -15,14 +15,3 @@ export const verticalLineWidth = 2
  * Comments nested deeper than that are displayed differently.
  */
 export const nestLimit = 4
-
-/**
- * If the comment body is taller than this, it will be collapsed. Subject to
- * the 'collapsable' option taht can be set per-Discussion.
- */
-export const COLLAPSED_HEIGHT = {
-  mobile: 180,
-  desktop: 240,
-  // We won't collapse a comment if it just slightly exceeds the heights above.
-  threshold: 50
-}

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -101,7 +101,7 @@ const getBreakoutSize = (size, hasFigure) => {
   return size
 }
 
-const InfoBox = ({ t, children, attributes, size, figureSize, figureFloat, collapsable }) => {
+const InfoBox = ({ t, children, attributes, size, figureSize, figureFloat, collapsable, collapsableEditorPreview }) => {
   let styles = {}
   const float = figureFloat || size === 'float'
   if (figureSize) {
@@ -124,7 +124,7 @@ const InfoBox = ({ t, children, attributes, size, figureSize, figureFloat, colla
   }
 
   const content = collapsable
-    ? <Collapsable t={t} height={{ mobile: 230, desktop: 230 }}>
+    ? <Collapsable t={t} height={{ mobile: 230, desktop: 230 }} editorPreview={collapsableEditorPreview}>
       {children}
     </Collapsable>
     : children

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -123,18 +123,16 @@ const InfoBox = ({ t, children, attributes, size, figureSize, figureFloat, colla
     ...(size === 'float' ? floatStyle : defaultStyle)
   }
 
-  const childrenNode = collapsable
-    ? (
-        <Collapsable collapsable={true} t={t} height={{ mobile: 180, desktop: 230 }}>
-          {children}
-        </Collapsable>
-      )
+  const content = collapsable
+    ? <Collapsable t={t} height={{ mobile: 230, desktop: 230 }}>
+      {children}
+    </Collapsable>
     : children
 
   return (
     <Breakout attributes={attributes} size={getBreakoutSize(size, figureSize)}>
       <section {...styles}>
-        {childrenNode}
+        {content}
       </section>
     </Breakout>
   )

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -121,7 +121,7 @@ const InfoBox = ({ t, children, attributes, size, figureSize, figureFloat, colla
 
   const childrenNode = collapsable
     ? (
-        <Collapsable collapsable={true} t={t}>
+        <Collapsable collapsable={true} t={t} height={{ mobile: 180, desktop: 230 }}>
           {children}
         </Collapsable>
       )

--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { Breakout, MAX_WIDTH_MOBILE } from '../Center'
+import { Collapsable } from '../Collapsable'
 import { mUp, onlyS } from '../../theme/mediaQueries'
 
 export const IMAGE_SIZES = {
@@ -96,7 +97,7 @@ const getBreakoutSize = (size, hasFigure) => {
   return size
 }
 
-const InfoBox = ({ children, attributes, size, figureSize, figureFloat }) => {
+const InfoBox = ({ t, children, attributes, size, figureSize, figureFloat, collapsable }) => {
   let styles = {}
   const float = figureFloat || size === 'float'
   if (figureSize) {
@@ -118,25 +119,36 @@ const InfoBox = ({ children, attributes, size, figureSize, figureFloat }) => {
     ...(size === 'float' ? floatStyle : defaultStyle)
   }
 
+  const childrenNode = collapsable
+    ? (
+        <Collapsable collapsable={true} t={t}>
+          {children}
+        </Collapsable>
+      )
+    : children
+
   return (
     <Breakout attributes={attributes} size={getBreakoutSize(size, figureSize)}>
       <section {...styles}>
-        {children}
+        {childrenNode}
       </section>
     </Breakout>
   )
 }
 
 InfoBox.propTypes = {
+  t: PropTypes.func,
   children: PropTypes.node.isRequired,
   attributes: PropTypes.object,
   size: PropTypes.oneOf(['float', 'breakout']),
   figureSize: PropTypes.oneOf(Object.keys(IMAGE_SIZES)),
-  figureFloat: PropTypes.bool.isRequired
+  figureFloat: PropTypes.bool.isRequired,
+  collapsable: PropTypes.bool
 }
 
 InfoBox.defaultProps = {
-  figureFloat: false
+  figureFloat: false,
+  collapsable: false
 }
 
 export default InfoBox

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -151,7 +151,7 @@ Supported props:
 ```
 
 ```react|responsive
-<Center>
+<Center>wq
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size='float' figureSize='XS'>
     <InfoBoxTitle>This is a float info box</InfoBoxTitle>
@@ -191,40 +191,4 @@ The `collapsable` attribute collapses the infobox, unless the content height is 
   </InfoBoxText>
 </InfoBox>
 </div>
-```
-
-### `<InfoBoxSubhead />` and `<InfoBoxListItem />`
-
-```react
-<InfoBox>
-  <InfoBoxTitle>This is a box title</InfoBoxTitle>
-  <InfoBoxSubhead>
-    This is a subhead
-  </InfoBoxSubhead>
-  <Editorial.UL>
-    <InfoBoxListItem>
-      <p>He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.</p>
-    </InfoBoxListItem>
-    <InfoBoxListItem>
-      <p>The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked.</p>
-    </InfoBoxListItem>
-    <InfoBoxListItem>
-      <p>One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin.</p>
-    </InfoBoxListItem>
-  </Editorial.UL>
-    <InfoBoxSubhead>
-    This is a subhead
-  </InfoBoxSubhead>
-  <Editorial.OL>
-    <InfoBoxListItem>
-      <p>He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.</p>
-    </InfoBoxListItem>
-    <InfoBoxListItem>
-      <p>The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked.</p>
-    </InfoBoxListItem>
-    <InfoBoxListItem>
-      <p>One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin.</p>
-    </InfoBoxListItem>
-  </Editorial.OL>
-</InfoBox>
 ```

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -151,7 +151,7 @@ Supported props:
 ```
 
 ```react|responsive
-<Center>wq
+<Center>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
   <InfoBox size='float' figureSize='XS'>
     <InfoBoxTitle>This is a float info box</InfoBoxTitle>

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -7,6 +7,7 @@ Supported props:
   - `float`: Break out to the left and let other elements flow around.
 - `figureSize`: The image size, `XS`, `S`, `M` or `L`. Should always be `XS` when `size` is `float`.
 - `figureFloat`: Enforce floating image on desktop.
+- `collapsable`: Whether the infobox should be collapsed by default.
 
 ```react
 <InfoBox>
@@ -166,4 +167,64 @@ Supported props:
   </InfoBox>
   <Editorial.P>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores.</Editorial.P>
 </Center>
+```
+
+### collapsable
+
+The `collapsable` attribute collapses the infobox, unless the content height is too small.
+
+```react
+<div>
+<InfoBox collapsable t={t}>
+  <InfoBoxTitle>This is a box title</InfoBoxTitle>
+  <InfoBoxText>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls.
+  </InfoBoxText>
+  <InfoBoxText>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment.
+  </InfoBoxText>
+</InfoBox>
+<InfoBox collapsable t={t}>
+  <InfoBoxTitle>This is a box title</InfoBoxTitle>
+  <InfoBoxText>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin.
+  </InfoBoxText>
+</InfoBox>
+</div>
+```
+
+### `<InfoBoxSubhead />` and `<InfoBoxListItem />`
+
+```react
+<InfoBox>
+  <InfoBoxTitle>This is a box title</InfoBoxTitle>
+  <InfoBoxSubhead>
+    This is a subhead
+  </InfoBoxSubhead>
+  <Editorial.UL>
+    <InfoBoxListItem>
+      <p>He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.</p>
+    </InfoBoxListItem>
+    <InfoBoxListItem>
+      <p>The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked.</p>
+    </InfoBoxListItem>
+    <InfoBoxListItem>
+      <p>One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin.</p>
+    </InfoBoxListItem>
+  </Editorial.UL>
+    <InfoBoxSubhead>
+    This is a subhead
+  </InfoBoxSubhead>
+  <Editorial.OL>
+    <InfoBoxListItem>
+      <p>He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.</p>
+    </InfoBoxListItem>
+    <InfoBoxListItem>
+      <p>The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked.</p>
+    </InfoBoxListItem>
+    <InfoBoxListItem>
+      <p>One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin.</p>
+    </InfoBoxListItem>
+  </Editorial.OL>
+</InfoBox>
 ```

--- a/src/components/InfoBox/docs.md
+++ b/src/components/InfoBox/docs.md
@@ -8,6 +8,7 @@ Supported props:
 - `figureSize`: The image size, `XS`, `S`, `M` or `L`. Should always be `XS` when `size` is `float`.
 - `figureFloat`: Enforce floating image on desktop.
 - `collapsable`: Whether the infobox should be collapsed by default.
+- `collapsableEditorPreview`: forward `editorPreview` to collapsable component.
 
 ```react
 <InfoBox>

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,17 @@ ReactDOM.render(
                 colors: require('./theme/colors')
               },
               src: require('./components/Progress/docs.md')
-            }
+            },
+            {
+              path: '/collapsable',
+              title: 'Collapsable',
+              imports: {
+                t,
+                ...require('./components/Typography'),
+                ...require('./components/Collapsable')
+              },
+              src: require('./components/Collapsable/docs.md')
+            },
           ]
         },
         {
@@ -325,6 +335,7 @@ ReactDOM.render(
               path: '/infobox',
               title: 'InfoBox',
               imports: {
+                t,
                 css,
                 ...require('./components/Typography'),
                 ...require('./components/InfoBox'),

--- a/src/index.js
+++ b/src/index.js
@@ -503,7 +503,9 @@ ReactDOM.render(
               path: '/templates/article',
               title: 'Article',
               imports: {
-                schema: require('./templates/Article').default(),
+                schema: require('./templates/Article').default({
+                  t
+                }),
                 ...require('./templates/docs'),
                 renderMdast: require('mdast-react-render').renderMdast
               },

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,7 +1,15 @@
 {
-  "updated": "2019-05-30T19:01:47.103Z",
+  "updated": "2019-07-08T13:09:41.326Z",
   "title": "live",
   "data": [
+    {
+      "key": "styleguide/Collapsable/expand",
+      "value": "Alles lesen"
+    },
+    {
+      "key": "styleguide/Collapsable/collapse",
+      "value": "Weniger"
+    },
     {
       "key": "styleguide/CommentComposer/placeholder",
       "value": "Einen Kommentar verfassen…"
@@ -61,14 +69,6 @@
     {
       "key": "styleguide/CommentActions/downvote/count/other",
       "value": "{count} Gegenstimmen"
-    },
-    {
-      "key": "styleguide/CommentActions/expand",
-      "value": "Alles lesen"
-    },
-    {
-      "key": "styleguide/CommentActions/collapse",
-      "value": "Weniger"
     },
     {
       "key": "styleguide/CommentTeaser/comment/link",

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -615,11 +615,18 @@ Zweitens: ich habe erklärt mit diese zwei Spieler: nach Dortmund brauchen viell
 
 ### Infobox with List
 
+And `collapsable`.
+
 ```react|noSource
 <Markdown schema={schema}>{`
 <section><h6>CENTER</h6>
 
 <section><h6>INFOBOX</h6>
+
+\`\`\`
+{"collapsable": true}
+\`\`\`
+
 
 ### Boxentitel
 

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -303,11 +303,13 @@ const centerFigure = {
   ]
 }
 
-const infoBox = {
+const createInfoBox = ({ t }) => ({
   matchMdast: matchInfoBox,
   component: InfoBox,
   props: (node, index, parent, { ancestors }) => ({
+    t,
     size: node.data.size,
+    collapsable: node.data.collapsable,
     figureSize: node.children.find(
       matchFigure
     )
@@ -416,7 +418,7 @@ const infoBox = {
       rules: paragraphRules
     }
   ]
-}
+})
 
 const blockQuote = {
   matchMdast: matchZone('BLOCKQUOTE'),
@@ -1017,7 +1019,7 @@ const createSchema = ({
                 },
                 isVoid: true
               },
-              infoBox,
+              createInfoBox({ t }),
               pullQuote,
               paragraph,
               {


### PR DESCRIPTION
Implements collapsable infoboxes https://github.com/orbiting/styleguide/issues/228 and factors the collapsable logic out of `Comment/Body.js` into a shared `Collapsable` component.

Docs:
https://r-styleguide-pr-244.herokuapp.com/collapsable (new)
https://r-styleguide-pr-244.herokuapp.com/infobox#collapsable (new)
https://r-styleguide-pr-244.herokuapp.com/components/discussion/internal#body (unchanged)

TODO:
- [x] Pipe `t` down to InfoBox component in templates/Article once https://github.com/orbiting/styleguide/pull/242 is merged.