### PR TITLE
Log lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "build": "npm run build:lib && react-scripts build",
     "start": "react-scripts start",
     "dev": "babel -w src --out-dir lib & PORT=3003 react-scripts start",
+    "tape": "babel-tape-runner",
     "test": "babel-tape-runner src/**/*.test.js | faucet && babel-tape-runner src/**/**/*.test.js | faucet",
     "cloc": "find . -name '*.js' -not -path \"./node_modules*\" -not -path \"./lib*\" | xargs wc -l",
     "eject": "react-scripts eject",

--- a/src/catalogTheme.css
+++ b/src/catalogTheme.css
@@ -7,3 +7,8 @@ svg g[fill="#FFFFFF"] {
   margin-top: 0 !important;
   font-size: 18px;
 }
+
+pre[class*="HighlightedCode"] {
+  max-height: 800px;
+  overflow: auto;
+}

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -364,6 +364,8 @@ const BarChart = (props) => {
                       {subsup.svg(bar.first.label)}
                     </text>
                     if (href) {
+                      // disable a11y rule because it does not understand that this a tag is an svg tag
+                      // eslint-disable-next-line jsx-a11y/anchor-is-valid
                       barLabel = <a xlinkHref={href}>{barLabel}</a>
                     }
                     return (
@@ -517,7 +519,7 @@ const BarChart = (props) => {
   )
 }
 
-BarChart.propTypes = {
+export const propTypes = {
   children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
@@ -560,6 +562,8 @@ BarChart.propTypes = {
   description: PropTypes.string,
   showBarValues: PropTypes.bool
 }
+
+BarChart.propTypes = propTypes
 
 BarChart.defaultProps = {
   columns: 1,

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -298,7 +298,9 @@ const BarChart = (props) => {
     x.nice(3)
   }
 
-  const xAxis = calculateAxis(props.numberFormat, tLabel, x.domain())
+  const xAxis = calculateAxis(props.numberFormat, tLabel, x.domain(), undefined, {
+    ticks: props.xTicks
+  })
 
   // stack bars
   groupedData.forEach(group => {

--- a/src/components/Chart/Lines.docs.md
+++ b/src/components/Chart/Lines.docs.md
@@ -5602,3 +5602,283 @@ year,value
     />
 </div>
 ```
+
+## Log Scale
+
+```react
+<div>
+  <ChartTitle>Preise, Mieten und Löhne</ChartTitle>
+  <CsvChart
+    config={{
+      "type": "Line",
+      "color": "category",
+      "numberFormat": ".0f",
+      "yScale": "log",
+      "yTicks": [
+        500,
+        1000,
+        2000,
+        3000
+      ],
+      "yNice": 0,
+      "yAnnotations": [{
+        "value": 100,
+        "x": "1939"
+      }],
+      "xTicks": [
+        1939,
+        1970,
+        2000,
+        2018
+      ],
+      "paddingLeft": 5,
+      "colorSort": "none"
+    }}
+    values={`
+year,category,value
+1939,Löhne,100.0
+1942,Löhne,125.0
+1943,Löhne,134.0
+1944,Löhne,143.0
+1945,Löhne,153.0
+1946,Löhne,169.0
+1947,Löhne,183.0
+1948,Löhne,193.0
+1949,Löhne,195.0
+1950,Löhne,197.0
+1951,Löhne,206.0
+1952,Löhne,212.0
+1953,Löhne,215.0
+1954,Löhne,218.0
+1955,Löhne,224.0
+1956,Löhne,233.0
+1957,Löhne,244.0
+1958,Löhne,252.0
+1959,Löhne,260.0
+1960,Löhne,272.0
+1961,Löhne,289.0
+1962,Löhne,310.0
+1963,Löhne,332.0
+1964,Löhne,358.0
+1965,Löhne,384.0
+1966,Löhne,412.0
+1967,Löhne,439.0
+1968,Löhne,460.0
+1969,Löhne,488.0
+1970,Löhne,534.0
+1971,Löhne,601.0
+1972,Löhne,667.0
+1973,Löhne,747.0
+1974,Löhne,838.0
+1975,Löhne,901.0
+1976,Löhne,920.0
+1977,Löhne,942.0
+1978,Löhne,972.0
+1979,Löhne,1004.0
+1980,Löhne,1058.0
+1981,Löhne,1124.0
+1982,Löhne,1203.0
+1983,Löhne,1248.0
+1984,Löhne,1283.0
+1985,Löhne,1323.0
+1986,Löhne,1370.0
+1987,Löhne,1403.0
+1988,Löhne,1452.0
+1989,Löhne,1507.0
+1990,Löhne,1595.0
+1991,Löhne,1706.0
+1992,Löhne,1788.0
+1993,Löhne,1836.0
+1994,Löhne,1862.0
+1995,Löhne,1887.0
+1996,Löhne,1910.0
+1997,Löhne,1919.0
+1998,Löhne,1932.0
+1999,Löhne,1938.0
+2000,Löhne,1963.0
+2001,Löhne,2011.0
+2002,Löhne,2047.0
+2003,Löhne,2076.0
+2004,Löhne,2095.0
+2005,Löhne,2115.0
+2006,Löhne,2140.0
+2007,Löhne,2175.0
+2008,Löhne,2219.0
+2009,Löhne,2266.0
+2010,Löhne,2285.0
+2011,Löhne,2306.0
+2012,Löhne,2326.0
+2013,Löhne,2343.0
+2014,Löhne,2361.0
+2015,Löhne,2370.0
+2016,Löhne,2386.0
+2017,Löhne,2395.0
+2018,Löhne,2407.0
+1939,Mietpreise,100.0
+1940,Mietpreise,99.8
+1941,Mietpreise,99.8
+1942,Mietpreise,100.1
+1943,Mietpreise,100.3
+1944,Mietpreise,101.2
+1945,Mietpreise,101.6
+1946,Mietpreise,102.3
+1947,Mietpreise,103.3
+1948,Mietpreise,104.8
+1949,Mietpreise,106.9
+1950,Mietpreise,108.8
+1951,Mietpreise,116.8
+1952,Mietpreise,118.7
+1953,Mietpreise,120.8
+1954,Mietpreise,124.8
+1955,Mietpreise,127.8
+1956,Mietpreise,131.0
+1957,Mietpreise,134.1
+1958,Mietpreise,141.1
+1959,Mietpreise,145.5
+1960,Mietpreise,148.8
+1961,Mietpreise,157.4
+1962,Mietpreise,161.4
+1963,Mietpreise,173.1
+1964,Mietpreise,179.3
+1965,Mietpreise,190.8
+1966,Mietpreise,213.5
+1967,Mietpreise,230.8
+1968,Mietpreise,246.3
+1969,Mietpreise,261.3
+1970,Mietpreise,281.3
+1971,Mietpreise,307.9
+1972,Mietpreise,328.9
+1973,Mietpreise,351.4
+1974,Mietpreise,385.6
+1975,Mietpreise,413.0
+1976,Mietpreise,420.9
+1977,Mietpreise,422.3
+1978,Mietpreise,422.3
+1979,Mietpreise,424.3
+1980,Mietpreise,434.5
+1981,Mietpreise,467.7
+1982,Mietpreise,509.2
+1983,Mietpreise,522.1
+1984,Mietpreise,536.2
+1985,Mietpreise,556.3
+1986,Mietpreise,575.5
+1987,Mietpreise,591.1
+1988,Mietpreise,608.0
+1989,Mietpreise,650.7
+1990,Mietpreise,713.0
+1991,Mietpreise,773.3
+1992,Mietpreise,818.5
+1993,Mietpreise,837.0
+1994,Mietpreise,838.2
+1995,Mietpreise,854.8
+1996,Mietpreise,862.4
+1997,Mietpreise,862.4
+1998,Mietpreise,863.4
+1999,Mietpreise,871.7
+2000,Mietpreise,897.7
+2001,Mietpreise,913.4
+2002,Mietpreise,918.3
+2003,Mietpreise,921.3
+2004,Mietpreise,940.5
+2005,Mietpreise,949.7
+2006,Mietpreise,970.4
+2007,Mietpreise,990.7
+2008,Mietpreise,1021.2
+2009,Mietpreise,1036.4
+2010,Mietpreise,1050.7
+2011,Mietpreise,1062.1
+2012,Mietpreise,1062.2
+2013,Mietpreise,1076.7
+2014,Mietpreise,1088.5
+2015,Mietpreise,1089.3
+2016,Mietpreise,1100.7
+2017,Mietpreise,1111.0
+2018,Mietpreise,1116.7
+1939,Konsumentenpeise,100.0
+1940,Konsumentenpeise,112.6
+1941,Konsumentenpeise,129.8
+1942,Konsumentenpeise,140.6
+1943,Konsumentenpeise,144.5
+1944,Konsumentenpeise,146.6
+1945,Konsumentenpeise,145.6
+1946,Konsumentenpeise,149.3
+1947,Konsumentenpeise,157.3
+1948,Konsumentenpeise,158.2
+1949,Konsumentenpeise,155.2
+1950,Konsumentenpeise,155.4
+1951,Konsumentenpeise,165.2
+1952,Konsumentenpeise,165.2
+1953,Konsumentenpeise,164.3
+1954,Konsumentenpeise,167.1
+1955,Konsumentenpeise,167.7
+1956,Konsumentenpeise,171.4
+1957,Konsumentenpeise,174.9
+1958,Konsumentenpeise,176.4
+1959,Konsumentenpeise,175.4
+1960,Konsumentenpeise,178.5
+1961,Konsumentenpeise,184.7
+1962,Konsumentenpeise,190.7
+1963,Konsumentenpeise,198.1
+1964,Konsumentenpeise,202.7
+1965,Konsumentenpeise,212.7
+1966,Konsumentenpeise,222.4
+1967,Konsumentenpeise,230.2
+1968,Konsumentenpeise,235.3
+1969,Konsumentenpeise,240.8
+1970,Konsumentenpeise,253.8
+1971,Konsumentenpeise,270.6
+1972,Konsumentenpeise,289.2
+1973,Konsumentenpeise,323.7
+1974,Konsumentenpeise,348.1
+1975,Konsumentenpeise,360.1
+1976,Konsumentenpeise,364.7
+1977,Konsumentenpeise,369.0
+1978,Konsumentenpeise,371.6
+1979,Konsumentenpeise,390.9
+1980,Konsumentenpeise,408.1
+1981,Konsumentenpeise,435.1
+1982,Konsumentenpeise,458.8
+1983,Konsumentenpeise,468.7
+1984,Konsumentenpeise,482.2
+1985,Konsumentenpeise,497.9
+1986,Konsumentenpeise,498.1
+1987,Konsumentenpeise,507.4
+1988,Konsumentenpeise,517.4
+1989,Konsumentenpeise,543.4
+1990,Konsumentenpeise,572.0
+1991,Konsumentenpeise,601.9
+1992,Konsumentenpeise,622.5
+1993,Konsumentenpeise,638.0
+1994,Konsumentenpeise,640.6
+1995,Konsumentenpeise,653.1
+1996,Konsumentenpeise,658.2
+1997,Konsumentenpeise,660.8
+1998,Konsumentenpeise,659.6
+1999,Konsumentenpeise,670.6
+2000,Konsumentenpeise,680.7
+2001,Konsumentenpeise,682.9
+2002,Konsumentenpeise,689.0
+2003,Konsumentenpeise,693.0
+2004,Konsumentenpeise,702.3
+2005,Konsumentenpeise,709.4
+2006,Konsumentenpeise,713.7
+2007,Konsumentenpeise,728.0
+2008,Konsumentenpeise,733.1
+2009,Konsumentenpeise,735.3
+2010,Konsumentenpeise,739.0
+2011,Konsumentenpeise,733.7
+2012,Konsumentenpeise,730.5
+2013,Konsumentenpeise,731.1
+2014,Konsumentenpeise,728.7
+2015,Konsumentenpeise,719.1
+2016,Konsumentenpeise,719.0
+2017,Konsumentenpeise,725.1
+2018,Konsumentenpeise,730.1
+    `.trim()}
+    />
+  <Editorial.Note>
+    Quelle: BFS
+  </Editorial.Note>
+</div>
+```
+

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -284,8 +284,8 @@ LineGroup.propTypes = {
   yAxisFormat: PropTypes.func.isRequired,
   yAnnotations: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.number.isRequired,
-    label: PropTypes.string.isRequired,
-    x: PropTypes.string,
+    label: PropTypes.string,
+    x: PropTypes.date,
     dy: PropTypes.string
   })),
   x: PropTypes.func.isRequired,
@@ -451,7 +451,7 @@ const LineChart = (props) => {
   )
 }
 
-LineChart.propTypes = {
+export const propTypes = {
   children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
@@ -500,13 +500,15 @@ LineChart.propTypes = {
   yTicks: PropTypes.arrayOf(PropTypes.number),
   yAnnotations: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.number.isRequired,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.string,
     x: PropTypes.string,
     dy: PropTypes.string
   })),
   tLabel: PropTypes.func.isRequired,
   description: PropTypes.string
 }
+
+LineChart.propTypes = propTypes
 
 export const Line = props => <LineChart {...props} />
 
@@ -551,7 +553,5 @@ Slope.defaultProps = {
 }
 
 // Additional Info for Docs
-// - Line is the master chart and «owns» the prop types
-Line.propTypes = LineChart.propTypes
 // - Slope just has different default props
 Slope.base = 'Line'

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -15,7 +15,8 @@ import { timeFormat } from '../../lib/timeFormat'
 
 import layout, {
   LABEL_FONT, VALUE_FONT,
-  Y_CONNECTOR, Y_CONNECTOR_PADDING
+  Y_CONNECTOR, Y_CONNECTOR_PADDING,
+  yScales
 } from './Lines.layout'
 
 import {
@@ -283,7 +284,9 @@ LineGroup.propTypes = {
   yAxisFormat: PropTypes.func.isRequired,
   yAnnotations: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.number.isRequired,
-    label: PropTypes.string.isRequired
+    label: PropTypes.string.isRequired,
+    x: PropTypes.string,
+    dy: PropTypes.string
   })),
   x: PropTypes.func.isRequired,
   xTicks: PropTypes.array.isRequired,
@@ -457,6 +460,7 @@ LineChart.propTypes = {
   xScale: PropTypes.oneOf(['time', 'ordinal']),
   xSort: sortPropType,
   xTicks: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  yScale: PropTypes.oneOf(Object.keys(yScales)),
   timeParse: PropTypes.string.isRequired,
   timeFormat: PropTypes.string.isRequired,
   column: PropTypes.string,
@@ -509,6 +513,7 @@ export const Line = props => <LineChart {...props} />
 Line.defaultProps = {
   x: 'year',
   xScale: 'time',
+  yScale: 'linear',
   timeParse: '%Y',
   timeFormat: '%Y',
   numberFormat: '.0%',
@@ -529,6 +534,7 @@ export const Slope = props => <LineChart {...props} />
 Slope.defaultProps = {
   x: 'year',
   xScale: 'ordinal',
+  yScale: 'linear',
   timeParse: '%Y',
   timeFormat: '%Y',
   numberFormat: '.0%',

--- a/src/components/Chart/Maps.js
+++ b/src/components/Chart/Maps.js
@@ -376,7 +376,7 @@ const featuresShape = PropTypes.shape({
   url: PropTypes.string.isRequired
 })
 
-GenericMap.propTypes = {
+export const propTypes = {
   children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
@@ -431,6 +431,8 @@ GenericMap.propTypes = {
   color: PropTypes.string
 }
 
+GenericMap.propTypes = propTypes
+
 GenericMap.defaultProps = {
   numberFormat: 's',
   columns: 1,
@@ -448,6 +450,8 @@ GenericMap.defaultProps = {
   sizes: [10],
   getProjection: () => geoEqualEarth()
 }
+
+
 
 export const ProjectedMap = props => <GenericMap {...props} />
 

--- a/src/components/Chart/ScatterPlots.docs.md
+++ b/src/components/Chart/ScatterPlots.docs.md
@@ -14,10 +14,10 @@ Go forth and make correlations visible, and tell everyone it proofs nothing!
       "y": "co2 pp 2014",
       "yUnit": "Tonnen CO<sub>2</sub>",
       "xUnit": "PPP-US-Dollar",
-      "yNumberFormat": ".1f",
+      "yNumberFormat": ".2f",
       "yScale": "log",
       "xScale": "log",
-      "yTicks": [0.01, 0.5, 1, 10, 100],
+      "yTicks": [0.1, 0.5, 1, 10, 100],
       "yNice": 0,
       "xTicks": [500, 10000, 250000],
       "xNice": 0

--- a/src/components/Chart/ScatterPlots.js
+++ b/src/components/Chart/ScatterPlots.js
@@ -459,7 +459,7 @@ class ScatterPlot extends Component {
   }
 }
 
-ScatterPlot.propTypes = {
+export const propTypes = {
   children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
@@ -515,6 +515,8 @@ ScatterPlot.propTypes = {
   tLabel: PropTypes.func.isRequired,
   description: PropTypes.string
 }
+
+ScatterPlot.propTypes = propTypes
 
 ScatterPlot.defaultProps = {
   x: 'value',

--- a/src/components/Chart/ScatterPlots.js
+++ b/src/components/Chart/ScatterPlots.js
@@ -236,7 +236,11 @@ class ScatterPlot extends Component {
     if (xNice) {
       x.nice(xNice)
     }
-    const xAxis = calculateAxis(props.xNumberFormat || props.numberFormat, tLabel, x.domain()) // xUnit is rendered separately
+    const xAxis = calculateAxis(props.xNumberFormat || props.numberFormat, tLabel, x.domain(), undefined, {
+      ticks: props.xLines
+        ? props.xLines.map(line => line.tick)
+        : props.xTicks
+    }) // xUnit is rendered separately
     const xLines = props.xLines || (
       props.xTicks || (props.xScale === 'log' ? get3EqualDistTicks(x) : xAxis.ticks)
     ).map(tick => ({ tick }))
@@ -260,7 +264,11 @@ class ScatterPlot extends Component {
     if (yNice) {
       y.nice(yNice)
     }
-    const yAxis = calculateAxis(props.yNumberFormat || props.numberFormat, tLabel, y.domain(), tLabel(props.yUnit))
+    const yAxis = calculateAxis(props.yNumberFormat || props.numberFormat, tLabel, y.domain(), tLabel(props.yUnit), {
+      ticks: props.yLines
+        ? props.yLines.map(line => line.tick)
+        : props.yTicks
+    })
     const yLines = props.yLines || (
       props.yTicks || (props.yScale === 'log' ? get3EqualDistTicks(y) : yAxis.ticks)
     ).map(tick => ({ tick }))

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -421,7 +421,7 @@ const TimeBarChart = (props) => {
   )
 }
 
-TimeBarChart.propTypes = {
+export const propTypes = {
   children: PropTypes.node,
   values: PropTypes.array.isRequired,
   padding: PropTypes.number.isRequired,
@@ -461,6 +461,8 @@ TimeBarChart.propTypes = {
   tLabel: PropTypes.func.isRequired,
   description: PropTypes.string
 }
+
+TimeBarChart.propTypes = propTypes
 
 TimeBarChart.defaultProps = {
   x: 'year',

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -171,7 +171,9 @@ const TimeBarChart = (props) => {
     })
   })
 
-  const yAxis = calculateAxis(props.numberFormat, tLabel, y.domain(), tLabel(props.unit))
+  const yAxis = calculateAxis(props.numberFormat, tLabel, y.domain(), tLabel(props.unit), {
+    ticks: props.yTicks
+  })
   const yTicks = props.yTicks || yAxis.ticks
   // ensure highest value is last
   // - the last value is labled with the unit

--- a/src/components/Chart/docs.js
+++ b/src/components/Chart/docs.js
@@ -10,6 +10,12 @@ import {
   deduplicate
 } from './utils'
 
+import { propTypes as barPropTypes } from './Bars'
+import { propTypes as timeBarPropTypes } from './TimeBars'
+import { propTypes as linePropTypes } from './Lines'
+import { propTypes as scatterPlotPropTypes } from './ScatterPlots'
+import { propTypes as genericMapPropTypes } from './Maps'
+
 const propTypeNames = new Map()
 Object.keys(PropTypes).forEach(key => {
   propTypeNames.set(PropTypes[key], key)
@@ -17,16 +23,19 @@ Object.keys(PropTypes).forEach(key => {
 })
 propTypeNames.set(sortPropType, 'string')
 
-const isSubType = Component => Component.base || Component.extends
+const baseChartPropTypes = {
+  Bar: barPropTypes,
+  TimeBar: timeBarPropTypes,
+  Line: linePropTypes,
+  ScatterPlot: scatterPlotPropTypes,
+  GenericMap: genericMapPropTypes
+}
 
 const charts = Object.keys(ReactCharts)
-const baseCharts = charts
-  .filter(key => !isSubType(ReactCharts[key]))
-  .filter(key => ReactCharts[key].propTypes)
 
-const props = baseCharts.reduce(
+const props = Object.keys(baseChartPropTypes).reduce(
   (all, chart) => {
-    const propTypes = ReactCharts[chart].propTypes
+    const propTypes = baseChartPropTypes[chart]
     const props = Object.keys(propTypes).map(key => ({
       key,
       type: propTypeNames.get(propTypes[key]),

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -7,7 +7,7 @@ import Bar, { Lollipop } from './Bars'
 import TimeBar from './TimeBars'
 import { Line, Slope } from './Lines'
 import ScatterPlot from './ScatterPlots'
-import { GenericMap, ProjectedMap, SwissMap } from './Maps';
+import { GenericMap, ProjectedMap, SwissMap } from './Maps'
 
 import colors from '../../theme/colors'
 

--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -132,10 +132,12 @@ export const getFormat = (numberFormat, tLabel) => {
 
 export const last = (array, index) => array.length - 1 === index
 
-export const calculateAxis = (numberFormat, tLabel, domain, unit = '') => {
+export const calculateAxis = (numberFormat, tLabel, domain, unit = '', {
+  ticks: predefinedTicks
+} = {}) => {
   const [min, max] = domain
   const step = (max - min) / 2
-  const ticks = [
+  const ticks = predefinedTicks || [
     min,
     min < 0 && max > 0
       ? 0
@@ -161,12 +163,22 @@ export const calculateAxis = (numberFormat, tLabel, domain, unit = '') => {
     let pow = formatPow(tLabel, Math.max(0, min) + magnitude / 2)
     let scaledStep = pow.scale(step)
     let scaledMax = pow.scale(max)
-    specifier.precision = precisionFixed((scaledStep - Math.floor(scaledStep)) || (scaledMax - Math.floor(scaledMax)))
+    specifier.precision = precisionFixed(
+      ticks.reduce(
+        (precision, value) => precision || pow.scale(value) - Math.floor(pow.scale(value)),
+        0
+      )
+    )
 
     lastFormat = sFormat(tLabel, specifier.precision, pow, 'f')
     regularFormat = sFormat(tLabel, specifier.precision, {scale: pow.scale, suffix: ''}, 'f')
   } else {
-    specifier.precision = precisionFixed((step - Math.floor(step)) || (max - Math.floor(max)))
+    specifier.precision = precisionFixed(
+      ticks.reduce(
+        (precision, value) => precision || value - Math.floor(value),
+        0
+      )
+    )
     lastFormat = regularFormat = format(specifier.toString())
   }
   const axisFormat = (value, isLast) => isLast ? `${lastFormat(value)} ${unit}` : regularFormat(value)

--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -161,8 +161,6 @@ export const calculateAxis = (numberFormat, tLabel, domain, unit = '', {
   } else if (specifier.type === 's') {
     const magnitude = d3Max([max - (min > 0 ? min : 0), min].map(Math.abs))
     let pow = formatPow(tLabel, Math.max(0, min) + magnitude / 2)
-    let scaledStep = pow.scale(step)
-    let scaledMax = pow.scale(max)
     specifier.precision = precisionFixed(
       ticks.reduce(
         (precision, value) => precision || pow.scale(value) - Math.floor(pow.scale(value)),

--- a/src/components/Chart/utils.test.js
+++ b/src/components/Chart/utils.test.js
@@ -1,0 +1,53 @@
+import test from 'tape'
+import { calculateAxis } from './utils'
+
+const tLabel = identity => identity
+
+test('calculateAxis with round ticks', assert => {
+  const yAxis = calculateAxis('.2f', tLabel, [99.34, 2507.3], 'Meter', {
+    ticks: [100, 500, 1000, 2000]
+  })
+
+  assert.equal(
+    yAxis.format(99.34),
+    '99,34',
+    'format with two decimal digits'
+  )
+  assert.equal(
+    yAxis.axisFormat(100),
+    '100',
+    'no unnecessary acis decimal digits'
+  )
+  assert.equal(
+    yAxis.axisFormat(2000, true),
+    '2000 Meter',
+    'include unit for last tick'
+  )
+  assert.end()
+})
+
+test('calculateAxis with uneven ticks', assert => {
+  const yAxis = calculateAxis('.1f', tLabel, [70, 85], 'Jahre')
+
+  assert.equal(
+    yAxis.format(80.57),
+    '80,6',
+    'format with one decimal digit'
+  )
+  assert.deepEqual(
+    yAxis.ticks,
+    [70,77.5,85],
+    'auto ticks'
+  )
+  assert.deepEqual(
+    yAxis.axisFormat(77.5),
+    '77,5',
+    'axis fromat with one decimal digit'
+  )
+  assert.equal(
+    yAxis.axisFormat(85, true),
+    '85,0 Jahre',
+    'include unit for last tick'
+  )
+  assert.end()
+})

--- a/src/components/CommentBody/email/Container.js
+++ b/src/components/CommentBody/email/Container.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { cssFor } from 'glamor'
 
 import { serifRegular16 } from '../../Typography/styles'
 

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { renderMdast } from 'mdast-react-render'
 import { parse } from '@orbiting/remark-preset'
 

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -3,14 +3,5 @@ import { renderMdast } from 'mdast-react-render'
 import { parse } from '@orbiting/remark-preset'
 
 export const Markdown = ({children, schema}) => {
-  return (
-    <div>
-      {renderMdast(parse(children), schema)}
-      <pre style={{backgroundColor: '#fff', padding: 20, margin: '20px -20px -20px -20px', overflow: 'auto'}}>
-        <code style={{fontFamily: '"Roboto Mono", monospace'}}>
-          {children.trim()}
-        </code>
-      </pre>
-    </div>
-  )
+  return renderMdast(parse(children), schema)
 }


### PR DESCRIPTION
Changes
- `yScale` `log` for lines
- fix #218
- fix chart prop types for props hopefully, clear all `eslint` warnings

<img width="1019" alt="Screenshot 2019-07-12 at 14 45 46" src="https://user-images.githubusercontent.com/410211/61129002-c011bd00-a4b3-11e9-84c4-0b39ad98bc0c.png">
