### PR TITLE
Slider fixes

### DIFF
--- a/src/components/Collapsable/Collapsable.js
+++ b/src/components/Collapsable/Collapsable.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
 
 import { sansSerifRegular14 } from '../Typography/styles'
 
@@ -52,16 +52,21 @@ const styles = {
   }),
   buttonContainer: css({
     position: 'relative',
-    borderTop: `1px solid ${colors.divider}`,
     '&::before': {
       position: 'absolute',
       display: 'block',
       content: '""',
       left: 0,
       right: 0,
-      top: -61,
+      top: -60,
       height: 60,
       background: 'linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 100%)'
+    }
+  }),
+  buttonContainerDivider: css({
+    borderTop: `1px solid ${colors.divider}`,
+    '&::before': {
+      top: -61,
     }
   }),
   button: css({
@@ -84,7 +89,7 @@ const styles = {
   })
 }
 
-const Collapsable = ({ t, children, height, threshold, initialVisibility, style, editorPreview }) => {
+const Collapsable = ({ t, children, height, threshold, initialVisibility, style, alwaysCollapsed, editorPreview }) => {
   /**
    * Measuring the body size (height), so we can determine whether to collapse
    * the body.
@@ -130,10 +135,10 @@ const Collapsable = ({ t, children, height, threshold, initialVisibility, style,
       </div>
 
       {bodyVisibility !== 'auto' && !editorPreview && (
-        <div {...(collapsed ? styles.buttonContainer : {})}>
-          <button {...styles.button} onClick={onToggleCollapsed} title={collapseLabel}>
+        <div {...merge(collapsed ? styles.buttonContainer : {}, !alwaysCollapsed && styles.buttonContainerDivider)}>
+          {!alwaysCollapsed && (<button {...styles.button} onClick={onToggleCollapsed} title={collapseLabel}>
             {collapseLabel}
-          </button>
+          </button>)}
         </div>
       )}
     </div>
@@ -151,13 +156,15 @@ Collapsable.propTypes = {
   initialVisibility: PropTypes.oneOf(['auto', 'full', 'preview']),
   threshold: PropTypes.number,
   style: PropTypes.object,
-  editorPreview: PropTypes.bool
+  editorPreview: PropTypes.bool,
+  alwaysCollapsed: PropTypes.bool
 }
 
 Collapsable.defaultProps = {
   height: COLLAPSED_HEIGHT,
   initialVisibility: 'auto',
-  threshold: 50
+  threshold: 50,
+  alwaysCollapsed: false
 }
 
 export default Collapsable

--- a/src/components/Collapsable/docs.md
+++ b/src/components/Collapsable/docs.md
@@ -38,3 +38,15 @@ Content only visible after expanding is marked with an soft background color bet
   </Editorial.P>
 </Collapsable>
 ```
+
+## Always Collapsed
+
+Read more button no accessible
+
+```react
+<Collapsable t={t} alwaysCollapsed>
+  <Editorial.P>
+    One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought.
+  </Editorial.P>
+</Collapsable>
+```

--- a/src/components/Form/Slider.js
+++ b/src/components/Form/Slider.js
@@ -35,7 +35,7 @@ const styles = {
     background: 'transparent',
     outline: 'none',
     width: 260,
-    padding: 0,
+    padding: '4px 0',
     marginTop: 0,
     marginRight: 10,
     marginBottom: 0,

--- a/src/components/Form/Slider.js
+++ b/src/components/Form/Slider.js
@@ -4,7 +4,7 @@ import colors from '../../theme/colors'
 import { fontStyles } from '../../theme/fonts'
 import { Label } from '../Typography'
 
-const thumbSize = 18
+const thumbSize = 20
 const trackHeight = 4
 
 const thumbStyle = {

--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -6,7 +6,7 @@ import { fontStyles } from '../../theme/fonts'
 import { underline } from '../../lib/styleMixins'
 import colors from '../../theme/colors'
 import { fontRule as interactionFontRule } from './Interaction'
-import {convertStyleToRem} from "./utils";
+import { convertStyleToRem, pxToRem } from './utils'
 
 export { List, UnorderedList as UL, OrderedList as OL, ListItem as LI } from '../List'
 
@@ -144,7 +144,7 @@ const paragraph = css({
   ...convertStyleToRem(styles.serifRegular17),
   [mUp]: {
     ...convertStyleToRem(styles.serifRegular19),
-    margin: '30px 0 30px 0'
+    margin: `${pxToRem(30)} 0 ${pxToRem(30)} 0`
   },
   ':first-child': {
     marginTop: 0

--- a/src/lib.js
+++ b/src/lib.js
@@ -32,6 +32,7 @@ export { AudioPlayer } from './components/AudioPlayer'
 export { VideoPlayer } from './components/VideoPlayer'
 export { default as LazyLoad } from './components/LazyLoad'
 export { default as LazyImage } from './components/LazyLoad/Image'
+export { Collapsable } from './components/Collapsable'
 export {
   InfoBox,
   InfoBoxText,


### PR DESCRIPTION
– Increase slider thumb clickable surface

<img width="1047" alt="Screenshot 2019-10-14 at 16 52 54" src="https://user-images.githubusercontent.com/3907984/66760821-21766d00-eea3-11e9-9ef4-53acbd9ca5e4.png">

– Set editorial paragraph margins in rem
– Add alwaysCollapsed option to Collapsable component

<img width="1115" alt="Screenshot 2019-10-14 at 16 52 39" src="https://user-images.githubusercontent.com/3907984/66760838-29361180-eea3-11e9-9865-e695424d32f7.png">


