### PR TITLE
Paynote v2

### DIFF
--- a/src/components/Button/docs.md
+++ b/src/components/Button/docs.md
@@ -140,6 +140,17 @@ To fit, e.g. in a header, it's permissible to set an explicit height.
 </Button>
 ```
 
+```react|span-3
+<Button black primary>
+  Schwarz
+</Button>
+```
+
+```react|span-3
+<Button black primary simulate='hover'>
+  Schwarz
+</Button>
+```
 
 ```react|span-3,dark
 <Button white>

--- a/src/components/Button/docs.md
+++ b/src/components/Button/docs.md
@@ -140,18 +140,6 @@ To fit, e.g. in a header, it's permissible to set an explicit height.
 </Button>
 ```
 
-```react|span-3
-<Button black primary>
-  Schwarz
-</Button>
-```
-
-```react|span-3
-<Button black primary simulate='hover'>
-  Schwarz
-</Button>
-```
-
 ```react|span-3,dark
 <Button white>
   Weiss

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -108,17 +108,6 @@ const whiteStyle = css({
     color: '#000'
   }
 })
-const blackPrimaryStyle = css({
-  backgroundColor: '#000',
-  borderColor: '#000',
-  color: '#fff',
-  '@media (hover)': {
-    ':hover': {
-      backgroundColor: colors.secondary,
-      borderColor: colors.secondary
-    }
-  }
-})
 const blockStyle = css({
   display: 'block',
   width: '100%'
@@ -151,7 +140,6 @@ const Button = ({
     dimmed && dimmedStyle,
     black && blackStyle,
     white && whiteStyle,
-    black && primary && blackPrimaryStyle,
     block && blockStyle,
     big && bigStyle,
     spacedOut && marginBottomStyle,

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -108,6 +108,17 @@ const whiteStyle = css({
     color: '#000'
   }
 })
+const blackPrimaryStyle = css({
+  backgroundColor: '#000',
+  borderColor: '#000',
+  color: '#fff',
+  '@media (hover)': {
+    ':hover': {
+      backgroundColor: colors.secondary,
+      borderColor: colors.secondary
+    }
+  }
+})
 const blockStyle = css({
   display: 'block',
   width: '100%'
@@ -140,6 +151,7 @@ const Button = ({
     dimmed && dimmedStyle,
     black && blackStyle,
     white && whiteStyle,
+    black && primary && blackPrimaryStyle,
     block && blockStyle,
     big && bigStyle,
     spacedOut && marginBottomStyle,

--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -28,6 +28,9 @@ const styles = {
   disabled: css({
     border: `1px solid ${colors.disabled}`
   }),
+  uncheckedBlack: css({
+    borderColor: '#000000'
+  }),
   box: css({
     display: 'inline-block',
     padding: '3px 3px 3px 0',
@@ -53,11 +56,7 @@ export default ({ children, name, checked, disabled, onChange, black }) =>
     <span {...styles.box}>
       {checked
         ? <Checked disabled={disabled} black={black} />
-        : <span
-            {...(disabled
-              ? merge(styles.unchecked, styles.disabled)
-              : styles.unchecked)}
-          />}
+        : <span {...merge(styles.unchecked, black && styles.uncheckedBlack, disabled && styles.disabled)} />}
     </span>
     <input
       {...styles.input}

--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -65,8 +65,8 @@ export default ({ children, name, checked, disabled, onChange, black, error }) =
         : <span {...merge(
           styles.unchecked,
           disabled && styles.disabled,
-          error && styles.uncheckedError,
-          black && styles.uncheckedBlack
+          black && styles.uncheckedBlack,
+          error && styles.uncheckedError
         )} />}
     </span>
     <input

--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -15,6 +15,9 @@ const styles = {
   labelDisabled: css({
     color: colors.disabled
   }),
+  labelError: css({
+    color: colors.error
+  }),
   input: css({
     display: 'none'
   }),
@@ -31,6 +34,9 @@ const styles = {
   uncheckedBlack: css({
     borderColor: '#000000'
   }),
+  uncheckedError: css({
+    borderColor: colors.error
+  }),
   box: css({
     display: 'inline-block',
     padding: '3px 3px 3px 0',
@@ -40,23 +46,28 @@ const styles = {
   })
 }
 
-const Checked = ({ disabled, black }) =>
+const Checked = ({ disabled, black, error }) =>
   <svg width="18" height="18" viewBox="0 0 18 18">
     <path
       d="M0 0h18v18H0V0zm7 14L2 9.192l1.4-1.346L7 11.308 14.6 4 16 5.346 7 14z"
-      fill={(disabled && colors.disabled) || (black && '#000000') || colors.primary}
+      fill={(disabled && colors.disabled) || (error && colors.error) || (black && '#000000') || colors.primary}
       fillRule="evenodd"
     />
   </svg>
 
-export default ({ children, name, checked, disabled, onChange, black }) =>
+export default ({ children, name, checked, disabled, onChange, black, error }) =>
   <label
-    {...(disabled ? merge(styles.label, styles.labelDisabled) : styles.label)}
+    {...merge(styles.label, disabled && styles.labelDisabled, error && styles.labelError)}
   >
     <span {...styles.box}>
       {checked
-        ? <Checked disabled={disabled} black={black} />
-        : <span {...merge(styles.unchecked, black && styles.uncheckedBlack, disabled && styles.disabled)} />}
+        ? <Checked disabled={disabled} black={black} error={error} />
+        : <span {...merge(
+          styles.unchecked,
+          disabled && styles.disabled,
+          error && styles.uncheckedError,
+          black && styles.uncheckedBlack
+        )} />}
     </span>
     <input
       {...styles.input}

--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -37,22 +37,22 @@ const styles = {
   })
 }
 
-const Checked = ({ disabled }) =>
+const Checked = ({ disabled, black }) =>
   <svg width="18" height="18" viewBox="0 0 18 18">
     <path
       d="M0 0h18v18H0V0zm7 14L2 9.192l1.4-1.346L7 11.308 14.6 4 16 5.346 7 14z"
-      fill={disabled ? colors.disabled : colors.primary}
+      fill={(disabled && colors.disabled) || (black && '#000000') || colors.primary}
       fillRule="evenodd"
     />
   </svg>
 
-export default ({ children, name, checked, disabled, onChange }) =>
+export default ({ children, name, checked, disabled, onChange, black }) =>
   <label
     {...(disabled ? merge(styles.label, styles.labelDisabled) : styles.label)}
   >
     <span {...styles.box}>
       {checked
-        ? <Checked disabled={disabled} />
+        ? <Checked disabled={disabled} black={black} />
         : <span
             {...(disabled
               ? merge(styles.unchecked, styles.disabled)

--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -194,8 +194,8 @@ class Field extends Component {
     const valueIsPresent = value !== undefined && value !== null && String(value).length !== 0
     const labelStyle = (isFocused || valueIsPresent || hasError)
       ? merge(
-          labelTextStyle, labelTextTopStyle, colorStyle,
-          isFocused && labelTextFocusedStyle,
+          labelTextStyle, labelTextTopStyle,
+          isFocused && labelTextFocusedStyle, colorStyle,
           hasError && labelTextErrorStyle
         )
       : merge(labelTextStyle, colorStyle)

--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -64,7 +64,8 @@ const containerStyle = css({
   fontFamily: fontFamilies.sansSerifRegular,
   fontSize: 22,
   lineHeight: `${lineHeight}px`,
-  marginBottom: 15
+  marginBottom: 15,
+  cursor: 'text'
 })
 const labelTextStyle = css({
   position: 'absolute',

--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -101,6 +101,15 @@ const whiteStyle = css({
     color: 'rgba(255,255,255,0.8)'
   }
 })
+const fieldErrorWhiteStyle = css({
+  borderColor: colors.negative.error,
+  ':focus': {
+    borderColor: colors.negative.error
+  }
+})
+const labelTextErrorWhiteStyle = css({
+  color: colors.negative.error
+})
 const blackStyle = css({
   backgroundColor: 'transparent',
   color: '#000',
@@ -128,6 +137,9 @@ const iconWrapperStyle = css({
   position: 'absolute',
   right: 3,
   top: lineHeight + 5
+})
+const iconWrapperStyleWhite = css({
+  color: '#ffffff'
 })
 
 const ArrowUp = ({size, fill, ...props}) => (
@@ -196,13 +208,14 @@ class Field extends Component {
       ? merge(
           labelTextStyle, labelTextTopStyle,
           isFocused && labelTextFocusedStyle, colorStyle,
-          hasError && labelTextErrorStyle
+          hasError && labelTextErrorStyle,
+          hasError && this.props.white && labelTextErrorWhiteStyle
         )
       : merge(labelTextStyle, colorStyle)
     const incStyle = hasIncrease ? fieldIncStyle : undefined
     const iconStyle = icon ? fieldIconStyle : undefined
     const fStyle = hasError
-      ? merge(fieldStyle, colorStyle, fieldErrorStyle, incStyle, iconStyle)
+      ? merge(fieldStyle, colorStyle, fieldErrorStyle, this.props.white && fieldErrorWhiteStyle, incStyle, iconStyle)
       : merge(fieldStyle, incStyle, colorStyle, iconStyle)
 
     return (
@@ -267,7 +280,7 @@ class Field extends Component {
             }} />
         )}
         {icon && (
-          <span {...iconWrapperStyle}>{icon}</span>
+          <span {...merge(iconWrapperStyle, this.props.white && iconWrapperStyleWhite)}>{icon}</span>
         )}
       </label>
     )

--- a/src/components/Form/Field.js
+++ b/src/components/Form/Field.js
@@ -194,16 +194,15 @@ class Field extends Component {
     const valueIsPresent = value !== undefined && value !== null && String(value).length !== 0
     const labelStyle = (isFocused || valueIsPresent || hasError)
       ? merge(
-          labelTextStyle, labelTextTopStyle,
+          labelTextStyle, labelTextTopStyle, colorStyle,
           isFocused && labelTextFocusedStyle,
-          hasError && labelTextErrorStyle,
-          colorStyle
+          hasError && labelTextErrorStyle
         )
       : merge(labelTextStyle, colorStyle)
     const incStyle = hasIncrease ? fieldIncStyle : undefined
     const iconStyle = icon ? fieldIconStyle : undefined
     const fStyle = hasError
-      ? merge(fieldStyle, fieldErrorStyle, incStyle, colorStyle, iconStyle)
+      ? merge(fieldStyle, colorStyle, fieldErrorStyle, incStyle, iconStyle)
       : merge(fieldStyle, incStyle, colorStyle, iconStyle)
 
     return (

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -163,6 +163,12 @@ state: {checked: false}
 </Checkbox>
 ```
 
+```react
+<Checkbox black checked onChange={() => {}}>
+  Ich akzeptiere
+</Checkbox>
+```
+
 ## Radio
 
 ```react

--- a/src/components/Form/docs.md
+++ b/src/components/Form/docs.md
@@ -69,6 +69,15 @@ state: {
 <Field white label='Label' />
 ```
 
+Also works with error display
+```react|span-3
+<Field 
+  black 
+  label='Label' 
+  error='You clearly did something wrong' />
+```
+
+
 ### Change and Validation
 
 `onChange` gets called with the following arguments:
@@ -165,6 +174,12 @@ state: {checked: false}
 
 ```react
 <Checkbox black checked onChange={() => {}}>
+  Ich akzeptiere
+</Checkbox>
+```
+
+```react
+<Checkbox error onChange={() => {}}>
   Ich akzeptiere
 </Checkbox>
 ```

--- a/src/components/RawHtml/docs.md
+++ b/src/components/RawHtml/docs.md
@@ -37,3 +37,13 @@ By default the HTML is rendered inside a `<span>` element. The `type` property c
   }}
 />
 ```
+
+```react|span-6
+<RawHtml
+  error
+  type={Interaction.H1}
+  dangerouslySetInnerHTML={{
+    __html: 'Error and <a href="#">Link</a>'
+  }}
+/>
+```

--- a/src/components/RawHtml/docs.md
+++ b/src/components/RawHtml/docs.md
@@ -27,3 +27,13 @@ By default the HTML is rendered inside a `<span>` element. The `type` property c
   }}
 />
 ```
+
+```react|span-6
+<RawHtml
+  black
+  type={Interaction.H1}
+  dangerouslySetInnerHTML={{
+    __html: '<b>Bold</b> und <a href="#">Link</a>'
+  }}
+/>
+```

--- a/src/components/RawHtml/docs.md
+++ b/src/components/RawHtml/docs.md
@@ -40,6 +40,16 @@ By default the HTML is rendered inside a `<span>` element. The `type` property c
 
 ```react|span-6
 <RawHtml
+  white
+  type={Interaction.H1}
+  dangerouslySetInnerHTML={{
+    __html: '<b>Bold</b> und <a href="#">Link</a>'
+  }}
+/>
+```
+
+```react|span-6
+<RawHtml
   error
   type={Interaction.H1}
   dangerouslySetInnerHTML={{

--- a/src/components/RawHtml/index.js
+++ b/src/components/RawHtml/index.js
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
-import { css } from 'glamor'
-import { linkStyle } from '../Typography'
+import { css, merge } from 'glamor'
+import { linkBlackStyle, linkStyle } from '../Typography'
 import PropTypes from 'prop-types'
 
 const styles = {
@@ -9,11 +9,14 @@ const styles = {
     '& ul, & ol': {
       overflow: 'hidden'
     }
+  }),
+  black: css({
+    '& a': linkBlackStyle
   })
 }
 
-const RawHtml = ({type, dangerouslySetInnerHTML}) => createElement(type, {
-  ...styles.default,
+const RawHtml = ({type, dangerouslySetInnerHTML, black}) => createElement(type, {
+  ...merge(styles.default, black && styles.black),
   dangerouslySetInnerHTML
 })
 

--- a/src/components/RawHtml/index.js
+++ b/src/components/RawHtml/index.js
@@ -1,7 +1,8 @@
 import { createElement } from 'react'
 import { css, merge } from 'glamor'
-import { linkBlackStyle, linkStyle } from '../Typography'
+import { linkBlackStyle, linkErrorStyle, linkStyle } from '../Typography'
 import PropTypes from 'prop-types'
+import colors from '../../theme/colors'
 
 const styles = {
   default: css({
@@ -13,11 +14,15 @@ const styles = {
   black: css({
     color: '#000000',
     '& a': linkBlackStyle
+  }),
+  error: css({
+    color: colors.error,
+    '& a': linkErrorStyle
   })
 }
 
-const RawHtml = ({type, dangerouslySetInnerHTML, black}) => createElement(type, {
-  ...merge(styles.default, black && styles.black),
+const RawHtml = ({type, dangerouslySetInnerHTML, black, error}) => createElement(type, {
+  ...merge(styles.default, error && styles.error, black && styles.black),
   dangerouslySetInnerHTML
 })
 

--- a/src/components/RawHtml/index.js
+++ b/src/components/RawHtml/index.js
@@ -22,7 +22,7 @@ const styles = {
 }
 
 const RawHtml = ({type, dangerouslySetInnerHTML, black, error}) => createElement(type, {
-  ...merge(styles.default, error && styles.error, black && styles.black),
+  ...merge(styles.default, black && styles.black, error && styles.error),
   dangerouslySetInnerHTML
 })
 

--- a/src/components/RawHtml/index.js
+++ b/src/components/RawHtml/index.js
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import { css, merge } from 'glamor'
-import { linkBlackStyle, linkErrorStyle, linkStyle } from '../Typography'
+import { linkBlackStyle, linkErrorStyle, linkErrorStyleNegative, linkStyle } from '../Typography'
 import PropTypes from 'prop-types'
 import colors from '../../theme/colors'
 
@@ -15,14 +15,26 @@ const styles = {
     color: '#000000',
     '& a': linkBlackStyle
   }),
+  white: css({
+    color: colors.negative.text,
+  }),
   error: css({
     color: colors.error,
     '& a': linkErrorStyle
+  }),
+  errorWhite: css({
+    color: colors.negative.error,
+    '& a': linkErrorStyleNegative
   })
 }
 
-const RawHtml = ({type, dangerouslySetInnerHTML, black, error}) => createElement(type, {
-  ...merge(styles.default, black && styles.black, error && styles.error),
+const RawHtml = ({type, dangerouslySetInnerHTML, black, white, error}) => createElement(type, {
+  ...merge(
+    styles.default,
+    black && styles.black,
+    white && styles.white,
+    error && styles.error,
+    error && white && styles.errorWhite),
   dangerouslySetInnerHTML
 })
 

--- a/src/components/RawHtml/index.js
+++ b/src/components/RawHtml/index.js
@@ -11,6 +11,7 @@ const styles = {
     }
   }),
   black: css({
+    color: '#000000',
     '& a': linkBlackStyle
   })
 }

--- a/src/components/TitleBlock/docs.md
+++ b/src/components/TitleBlock/docs.md
@@ -2,7 +2,7 @@ A `<TitleBlock />` is a container for an article's title elements like headline,
 
 Supported props:
 - `center`: bool, large centered title block
-
+ 
 
 ```react
 <TitleBlock>

--- a/src/components/TitleBlock/index.js
+++ b/src/components/TitleBlock/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { MAX_WIDTH, PADDING, BREAKOUT } from '../Center'
 import { css, merge } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
-import { container } from 'glamor/ous'
 
 const styles = {
   container: css({

--- a/src/components/TitleBlock/index.js
+++ b/src/components/TitleBlock/index.js
@@ -1,19 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { MAX_WIDTH, PADDING, BREAKOUT } from '../Center'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
+import { container } from 'glamor/ous'
 
 const styles = {
   container: css({
     maxWidth: MAX_WIDTH + PADDING * 2,
-    margin: '0 auto 40px auto',
+    margin: '0 auto',
     paddingTop: 30,
     paddingLeft: PADDING,
     paddingRight: PADDING,
     [mUp]: {
       paddingTop: 40,
-      margin: '0 auto 70px auto'
+      margin: '0 auto'
+    }
+  }),
+  containerMargin: css({
+    marginBottom: 40,
+    [mUp]: {
+      marginBottom: 70
     }
   })
 }
@@ -21,10 +28,11 @@ const styles = {
 const TitleBlock = ({
   children,
   attributes,
-  center
+  center,
+  margin
 }) => {
   return (
-    <section {...attributes} {...styles.container} style={{
+    <section {...attributes} {...merge(styles.container, margin && styles.containerMargin)} style={{
       textAlign: center ? 'center' : undefined,
       maxWidth: center ? MAX_WIDTH + BREAKOUT + PADDING : undefined
     }}>

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -34,6 +34,8 @@ export const linkStyle = {
 }
 export const linkRule = css(linkStyle)
 
+export const linkBlackStyle = _Editorial.link
+
 const styles = {
   h1: css({
     ...fontStyles.serifBold36,

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -8,6 +8,7 @@ import * as _Interaction from './Interaction'
 import * as _Scribble from './Scribble'
 import { css } from 'glamor'
 import { convertStyleToRem } from './utils'
+import { underline } from '../../lib/styleMixins'
 
 // Namespaced exports.
 export const Editorial = {..._Editorial}
@@ -34,7 +35,16 @@ export const linkStyle = {
 }
 export const linkRule = css(linkStyle)
 
-export const linkBlackStyle = _Editorial.link
+export const linkBlackStyle = css({
+  ...underline,
+  cursor: 'pointer',
+  color: '#000000',
+  '@media (hover)': {
+    ':hover': {
+      color: colors.text
+    }
+  }
+})
 
 const styles = {
   h1: css({

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -55,6 +55,16 @@ export const linkErrorStyle = css({
   }
 })
 
+export const linkErrorStyleNegative = css({
+  ...underline,
+  color: colors.negative.error,
+  '@media (hover)': {
+    ':hover': {
+      color: colors.negative.error
+    }
+  }
+})
+
 const styles = {
   h1: css({
     ...fontStyles.serifBold36,

--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -37,11 +37,20 @@ export const linkRule = css(linkStyle)
 
 export const linkBlackStyle = css({
   ...underline,
-  cursor: 'pointer',
   color: '#000000',
   '@media (hover)': {
     ':hover': {
       color: colors.text
+    }
+  }
+})
+
+export const linkErrorStyle = css({
+  ...underline,
+  color: colors.error,
+  '@media (hover)': {
+    ':hover': {
+      color: colors.error
     }
   }
 })

--- a/src/lib.js
+++ b/src/lib.js
@@ -122,6 +122,7 @@ export {
 export {Container, NarrowContainer} from './components/Grid'
 export {
   fontStyles,
+  linkBlackStyle,
   linkRule, A,
   H1, H2,
   Lead,

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -2,7 +2,7 @@
 import createArticleSchema from '@project-r/styleguide/lib/templates/Article'
 
 const schema = createArticleSchema({
-  titleBlockAppend: <div>Share Actions</div>
+  titleBlockPrepend: <div>Share Actions</div>
 })
 ```
 
@@ -13,7 +13,6 @@ const schema = createArticleSchema({
 - `customMetaFields`, passed to `customFields` of the `meta` module. Default to repo refs for discussion, format and dossier.
 - `series`, allow to form series via meta data
 - `titleBlockPrepend`, prepend React elements—e.g. a dossier tag—to the title block
-- `titleBlockAppend`, append React elements—e.g. share icons—to the title block
 - `titleBlockRule`, overwrite the whole title block, prepend and append are no longer applied
 - `getPath`, the function to transform meta data to a path, default `/YYYY/MM/DD/:slug`
 - `t`, optional translation function, used for e.g. DNT notes

--- a/src/templates/Article/docs.md
+++ b/src/templates/Article/docs.md
@@ -2,7 +2,7 @@
 import createArticleSchema from '@project-r/styleguide/lib/templates/Article'
 
 const schema = createArticleSchema({
-  titleBlockPrepend: <div>Share Actions</div>
+  titleMargin: false
 })
 ```
 
@@ -14,6 +14,7 @@ const schema = createArticleSchema({
 - `series`, allow to form series via meta data
 - `titleBlockPrepend`, prepend React elements—e.g. a dossier tag—to the title block
 - `titleBlockRule`, overwrite the whole title block, prepend and append are no longer applied
+- `titleMargin`, automatically adds some margin below the title, default `true`
 - `getPath`, the function to transform meta data to a path, default `/YYYY/MM/DD/:slug`
 - `t`, optional translation function, used for e.g. DNT notes
 - `dynamicComponentRequire`, optional custom require function for dynamic components

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -786,7 +786,7 @@ const createSchema = ({
   titleBlockRule,
   titleBlockPrepend = null,
   titleBlockAppend = null,
-  titleBlockAfter = null,
+  titleMargin = true,
   repoPrefix = 'article-',
   series = true,
   Link = DefaultLink,
@@ -846,7 +846,7 @@ const createSchema = ({
           titleBlockRule || {
             matchMdast: matchZone('TITLE'),
             component: ({children, format, ...props}) => <>
-              <TitleBlock {...props} format={format} Link={Link}>
+              <TitleBlock {...props} format={format} Link={Link} margin={titleMargin}>
                 {titleBlockPrepend}
                 {format && format.meta && (
                   <Editorial.Format color={format.meta.color || colors[format.meta.kind]} contentEditable={false}>

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -785,7 +785,6 @@ const createSchema = ({
   ],
   titleBlockRule,
   titleBlockPrepend = null,
-  titleBlockAppend = null,
   titleMargin = true,
   repoPrefix = 'article-',
   series = true,
@@ -858,7 +857,6 @@ const createSchema = ({
                   </Editorial.Format>
                 )}
                 {children}
-                {titleBlockAppend}
               </TitleBlock>
             </>,
             props: (node, index, parent, { ancestors }) => ({

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -786,6 +786,7 @@ const createSchema = ({
   titleBlockRule,
   titleBlockPrepend = null,
   titleBlockAppend = null,
+  titleBlockAfter = null,
   repoPrefix = 'article-',
   series = true,
   Link = DefaultLink,
@@ -844,7 +845,7 @@ const createSchema = ({
           addProgressProps(dynamicComponent),
           titleBlockRule || {
             matchMdast: matchZone('TITLE'),
-            component: ({children, format, ...props}) => (
+            component: ({children, format, ...props}) => <>
               <TitleBlock {...props} format={format} Link={Link}>
                 {titleBlockPrepend}
                 {format && format.meta && (
@@ -859,7 +860,8 @@ const createSchema = ({
                 {children}
                 {titleBlockAppend}
               </TitleBlock>
-            ),
+              {titleBlockAfter}
+            </>,
             props: (node, index, parent, { ancestors }) => ({
               center: node.data.center,
               format: ancestors[ancestors.length - 1].format

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -860,7 +860,6 @@ const createSchema = ({
                 {children}
                 {titleBlockAppend}
               </TitleBlock>
-              {titleBlockAfter}
             </>,
             props: (node, index, parent, { ancestors }) => ({
               center: node.data.center,

--- a/src/templates/Format/index.js
+++ b/src/templates/Format/index.js
@@ -21,7 +21,7 @@ const createSchema = ({
   series = false,
   titleBlockPrepend = null,
   titleBlockAppend = null,
-  titleBlockAfter = null,
+  titleMargin = true,
   titleBlockRule,
   getPath = ({ slug }) => `/format/${(slug || '').split('/').pop()}`,
   ...args
@@ -60,12 +60,11 @@ const createSchema = ({
     titleBlockRule: titleBlockRule || {
       matchMdast: matchZone('TITLE'),
       component: ({children, ...props}) => <>
-        <TitleBlock {...props} center Link={Link}>
+        <TitleBlock {...props} center Link={Link} margin={titleMargin}>
           {titleBlockPrepend}
           {children}
           {titleBlockAppend}
         </TitleBlock>
-        {titleBlockAfter}
       </>,
       editorModule: 'title',
       editorOptions: {

--- a/src/templates/Format/index.js
+++ b/src/templates/Format/index.js
@@ -20,7 +20,6 @@ const createSchema = ({
   customMetaFields = [],
   series = false,
   titleBlockPrepend = null,
-  titleBlockAppend = null,
   titleMargin = true,
   titleBlockRule,
   getPath = ({ slug }) => `/format/${(slug || '').split('/').pop()}`,
@@ -63,7 +62,6 @@ const createSchema = ({
         <TitleBlock {...props} center Link={Link} margin={titleMargin}>
           {titleBlockPrepend}
           {children}
-          {titleBlockAppend}
         </TitleBlock>
       </>,
       editorModule: 'title',

--- a/src/templates/Format/index.js
+++ b/src/templates/Format/index.js
@@ -21,6 +21,7 @@ const createSchema = ({
   series = false,
   titleBlockPrepend = null,
   titleBlockAppend = null,
+  titleBlockAfter = null,
   titleBlockRule,
   getPath = ({ slug }) => `/format/${(slug || '').split('/').pop()}`,
   ...args
@@ -58,13 +59,14 @@ const createSchema = ({
     series,
     titleBlockRule: titleBlockRule || {
       matchMdast: matchZone('TITLE'),
-      component: ({children, ...props}) => (
+      component: ({children, ...props}) => <>
         <TitleBlock {...props} center Link={Link}>
           {titleBlockPrepend}
           {children}
           {titleBlockAppend}
         </TitleBlock>
-      ),
+        {titleBlockAfter}
+      </>,
       editorModule: 'title',
       editorOptions: {
         coverType: COVER_TYPE

--- a/src/theme/colors.docs.js
+++ b/src/theme/colors.docs.js
@@ -26,8 +26,8 @@ ${<Fragment>
 ### Negative colors
 
 ${<Fragment>
-  <ColorSpecimen span={3} name='negative.containerBg' value={colors.negative.containerBg} />
-  <ColorSpecimen span={2} name='negative.primaryBg' value={colors.negative.primaryBg} />
+  <ColorSpecimen span={1} name='negative.containerBg' value={colors.negative.containerBg} />
+  <ColorSpecimen span={1} name='negative.primaryBg' value={colors.negative.primaryBg} />
   <ColorSpecimen span={1} name='negative.divider' value={colors.negative.divider} />
   <ColorSpecimen span={1} name='negative.text' value={colors.negative.text} />
   <ColorSpecimen span={1} name='negative.lightText' value={colors.negative.lightText} />

--- a/src/theme/colors.docs.js
+++ b/src/theme/colors.docs.js
@@ -23,6 +23,17 @@ ${<Fragment>
   <ColorSpecimen span={1} name='social' value={colors.social} />
 </Fragment>}
 
+### Negative colors
+
+${<Fragment>
+  <ColorSpecimen span={3} name='negative.containerBg' value={colors.negative.containerBg} />
+  <ColorSpecimen span={2} name='negative.primaryBg' value={colors.negative.primaryBg} />
+  <ColorSpecimen span={1} name='negative.divider' value={colors.negative.divider} />
+  <ColorSpecimen span={1} name='negative.text' value={colors.negative.text} />
+  <ColorSpecimen span={1} name='negative.lightText' value={colors.negative.lightText} />
+  <ColorSpecimen span={1} name='negative.error' value={colors.negative.error} />
+</Fragment>}
+
 ## Formats
 
 ${<Fragment>

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -64,6 +64,14 @@ const colors = {
     '#bcbd22',
     '#17becf'
   ],
+  negative: {
+    containerBg: '#111',
+    primaryBg: '#191919',
+    text: '#f0f0f0',
+    lightText: '#828282',
+    divider: '#5b5b5b',
+    error: '#ff5724'
+  },
   ...getJson('COLORS')
 }
 

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -70,7 +70,7 @@ const colors = {
     text: '#f0f0f0',
     lightText: '#828282',
     divider: '#5b5b5b',
-    error: '#ff5724'
+    error: 'rgb(239,69,51)'
   },
   ...getJson('COLORS')
 }


### PR DESCRIPTION
- include optional titleMargin option in the schema creator for both Article and Format schemas.
- remove unused TitleBlockAppend option from Article and Format schemas
- migrate negative colors to the styleguide

 - add black option for checkbox
<img width="657" alt="Screenshot 2019-10-28 at 11 24 34" src="https://user-images.githubusercontent.com/3907984/67671170-b2eee000-f975-11e9-8246-6c345b299837.png">
- add black option for raw html (for links)
<img width="713" alt="Screenshot 2019-10-28 at 11 56 20" src="https://user-images.githubusercontent.com/3907984/67673307-0fec9500-f97a-11e9-8b15-5880c12d96bb.png">
- implement error styles for various elements in black mode
<img width="564" alt="Screenshot 2019-10-29 at 11 48 11" src="https://user-images.githubusercontent.com/3907984/67760692-0dee0900-fa42-11e9-8b50-1903902ec64a.png">
<img width="1051" alt="Screenshot 2019-10-29 at 11 48 19" src="https://user-images.githubusercontent.com/3907984/67760693-0dee0900-fa42-11e9-85bc-6be3e95c3829.png">
<img width="1041" alt="Screenshot 2019-10-29 at 11 48 28" src="https://user-images.githubusercontent.com/3907984/67760695-0dee0900-fa42-11e9-9693-1c4918cce5b2.png">
<img width="1102" alt="Screenshot 2019-10-31 at 12 36 53" src="https://user-images.githubusercontent.com/3907984/67943796-25142e80-fbdb-11e9-94f2-799625b984a8.png">
