### PR TITLE
Dark mode for related articles

### DIFF
--- a/src/components/Dossier/Subheader.js
+++ b/src/components/Dossier/Subheader.js
@@ -3,6 +3,7 @@ import { css } from 'glamor'
 import { mUp } from '../TeaserFront/mediaQueries'
 import { sansSerifMedium16, sansSerifMedium20 } from '../Typography/styles'
 import { convertStyleToRem } from '../Typography/utils'
+import { useColorContext } from '../Colors/useColorContext'
 
 const styles = {
   subheader: css({
@@ -18,7 +19,16 @@ const styles = {
 }
 
 const Subheader = ({ children }) => {
-  return <h2 {...styles.subheader}>{children}</h2>
+  const [colorScheme] = useColorContext()
+  const colors = css({
+    color: colorScheme.text
+  })
+
+  return (
+    <h2 {...styles.subheader} {...colors}>
+      {children}
+    </h2>
+  )
 }
 
 export default Subheader

--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -59,6 +59,7 @@ const CreditLink = ({
 
 CreditLink.propTypes = {
   children: PropTypes.node.isRequired,
+  color: PropTypes.string,
   collapsedColor: PropTypes.string
 }
 

--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -2,9 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { lab } from 'd3-color'
 import { css } from 'glamor'
-import colors from '../../theme/colors'
 import { underline } from '../../lib/styleMixins'
 import { tUp } from './mediaQueries'
+import { useColorContext } from '../Colors/useColorContext'
+
+const getHoverColor = labColor =>
+  labColor.l > 50 ? labColor.darker(0.6) : labColor.brighter(3)
 
 const CreditLink = ({
   attributes,
@@ -13,36 +16,27 @@ const CreditLink = ({
   collapsedColor,
   ...props
 }) => {
-  const labColor = lab(color)
+  const [colorScheme] = useColorContext()
+  const textColor = color || colorScheme.text
+  const labColor = lab(textColor)
   const labCollapsedColor = collapsedColor && lab(collapsedColor)
+  const hoverColor = color ? getHoverColor(labColor) : colorScheme.lightText
 
-  const baseColorStyle = color
-    ? {
-        color,
-        '@media (hover)': {
-          ':hover': {
-            color: labColor.l > 50 ? labColor.darker(0.6) : labColor.brighter(3)
-          }
-        }
+  const baseColorStyle = {
+    color: textColor,
+    '@media (hover)': {
+      ':hover': {
+        color: hoverColor
       }
-    : {
-        color: colors.text,
-        '@media (hover)': {
-          ':hover': {
-            color: colors.lightText
-          }
-        }
-      }
+    }
+  }
 
   const colorStyle = labCollapsedColor
     ? {
         color: collapsedColor,
         '@media (hover)': {
           ':hover': {
-            color:
-              labCollapsedColor.l > 50
-                ? labCollapsedColor.darker(0.6)
-                : labCollapsedColor.brighter(3)
+            color: getHoverColor(labCollapsedColor)
           }
         },
         [tUp]: {
@@ -67,10 +61,6 @@ CreditLink.propTypes = {
   children: PropTypes.node.isRequired,
   color: PropTypes.string,
   collapsedColor: PropTypes.string
-}
-
-CreditLink.defaultProps = {
-  color: colors.primary
 }
 
 export default CreditLink

--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -17,7 +17,7 @@ const CreditLink = ({
   ...props
 }) => {
   const [colorScheme] = useColorContext()
-  const textColor = color || colorScheme.text
+  const textColor = color ? color : colorScheme.text
   const labColor = lab(textColor)
   const labCollapsedColor = collapsedColor && lab(collapsedColor)
   const hoverColor = color ? getHoverColor(labColor) : colorScheme.lightText
@@ -59,7 +59,6 @@ const CreditLink = ({
 
 CreditLink.propTypes = {
   children: PropTypes.node.isRequired,
-  color: PropTypes.string,
   collapsedColor: PropTypes.string
 }
 

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -6,6 +6,7 @@ import { FigureByline, FigureImage } from '../Figure'
 import LazyLoad from '../LazyLoad'
 import { mUp } from './mediaQueries'
 import Text from './Text'
+import { useColorContext } from '../Colors/useColorContext'
 
 const IMAGE_SIZE = {
   small: 220,
@@ -81,7 +82,9 @@ const Tile = ({
   aboveTheFold,
   onlyImage
 }) => {
-  const background = bgColor || ''
+  const [colorScheme] = useColorContext()
+  const background = bgColor || colorScheme.containerBg
+  const textColor = color || colorScheme.text
   const justifyContent =
     align === 'top' ? 'flex-start' : align === 'bottom' ? 'flex-end' : ''
   const imageProps =
@@ -122,7 +125,10 @@ const Tile = ({
               {...(onlyImage ? styles.onlyImage : styles.image)}
             />
             {byline && (
-              <FigureByline position='rightCompact' style={{ color }}>
+              <FigureByline
+                position='rightCompact'
+                style={{ color: textColor }}
+              >
                 {byline}
               </FigureByline>
             )}
@@ -131,7 +137,7 @@ const Tile = ({
       )}
       {!onlyImage && (
         <div {...styles.textContainer}>
-          <Text color={color} maxWidth={'600px'} margin={'0 auto'}>
+          <Text color={textColor} maxWidth={'600px'} margin={'0 auto'}>
             {children}
           </Text>
         </div>

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -153,6 +153,8 @@ Tile.propTypes = {
   byline: PropTypes.string,
   alt: PropTypes.string,
   onClick: PropTypes.func,
+  color: PropTypes.string,
+  bgColor: PropTypes.string,
   align: PropTypes.oneOf(['top', 'middle', 'bottom']),
   aboveTheFold: PropTypes.bool,
   onlyImage: PropTypes.bool

--- a/src/components/TeaserFront/Tile.js
+++ b/src/components/TeaserFront/Tile.js
@@ -153,8 +153,6 @@ Tile.propTypes = {
   byline: PropTypes.string,
   alt: PropTypes.string,
   onClick: PropTypes.func,
-  color: PropTypes.string,
-  bgColor: PropTypes.string,
   align: PropTypes.oneOf(['top', 'middle', 'bottom']),
   aboveTheFold: PropTypes.bool,
   onlyImage: PropTypes.bool

--- a/src/components/TeaserFront/TileRow.js
+++ b/src/components/TeaserFront/TileRow.js
@@ -5,6 +5,7 @@ import colors from '../../theme/colors'
 import { breakoutUp } from '../Center'
 import { mUp } from './mediaQueries'
 import { sizeSmall, sizeMedium } from './Tile'
+import { useColorContext } from '../Colors/useColorContext'
 
 const styles = {
   base: css({
@@ -107,14 +108,10 @@ const styles = {
     }
   }),
   autoColumns: css({
-    '& .tile': {
-      borderTop: `1px solid ${colors.divider}`
-    },
     [mUp]: {
       flexWrap: 'wrap',
       '& .tile': {
         width: '50%',
-        borderLeft: `1px solid ${colors.divider}`,
         borderTop: 'none',
         margin: '0 0 50px 0',
         padding: '20px 0'
@@ -129,9 +126,6 @@ const styles = {
     [breakoutUp]: {
       '& .tile': {
         width: '33.33%'
-      },
-      '& .tile:nth-child(2n+1)': {
-        borderLeft: `1px solid ${colors.divider}`
       },
       '& .tile:nth-child(3n+1)': {
         borderLeft: 'none'
@@ -151,11 +145,30 @@ export const TeaserFrontTileRow = ({
   mobileReverse,
   mobileColumns
 }) => {
+  const [colorScheme] = useColorContext()
+  const autoBorders = css({
+    '& .tile': {
+      borderTop: `1px solid ${colorScheme.divider}`
+    },
+    [mUp]: {
+      '& .tile': {
+        borderLeft: `1px solid ${colorScheme.divider}`
+      }
+    },
+    [breakoutUp]: {
+      '& .tile:nth-child(2n+1)': {
+        borderLeft: `1px solid ${colorScheme.divider}`
+      }
+    }
+  })
+
   const rowStyles = merge(
     styles.base,
     !autoColumns && styles[`col${columns}`],
     mobileReverse && styles.mobileReverse,
-    autoColumns ? styles.autoColumns : styles[`mobileCol${mobileColumns}`]
+    autoColumns
+      ? merge(autoBorders, styles.autoColumns)
+      : styles[`mobileCol${mobileColumns}`]
   )
   return (
     <div role='group' {...attributes} {...rowStyles}>

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -160,8 +160,7 @@ const createTeasers = ({ t, Link }) => {
         props: node => {
           return {
             title: node.title,
-            href: node.url,
-            color: colors.text
+            href: node.url
           }
         },
         component: ({ children, data, ...props }) => (


### PR DESCRIPTION
- handle default color scheme for teaser/tiles (based on color context)

**Needs to be tested for teasers with user set colors**

![Screenshot 2020-01-20 at 17 53 33](https://user-images.githubusercontent.com/3907984/72744755-76b2d080-3bae-11ea-9aa6-ed426c9126d3.png)
