### PR TITLE
fix(Callout): place callout above footer

### DIFF
--- a/src/components/Callout/index.js
+++ b/src/components/Callout/index.js
@@ -54,14 +54,16 @@ const styles = {
     left: 0,
     bottom: -400,
     right: 0,
-    padding: 15,
+    padding: '15px 15px 55px',
     animation: `0.3s ${slideUp} 0.2s forwards`,
     textAlign: 'left',
+    boxShadow: 'inset 0px -30px 30px -20px rgba(156, 156, 156, 0.6)',
     [mUp]: {
       bottom: 'auto',
       top: 20,
       padding: 10,
-      animation: 'none'
+      animation: 'none',
+      boxShadow: 'none'
     }
   }),
   right: {

--- a/src/components/Callout/index.js
+++ b/src/components/Callout/index.js
@@ -61,6 +61,7 @@ const styles = {
     [mUp]: {
       bottom: 'auto',
       top: 20,
+      left: 'auto',
       padding: 10,
       animation: 'none',
       boxShadow: 'none'

--- a/src/components/Callout/index.js
+++ b/src/components/Callout/index.js
@@ -54,10 +54,10 @@ const styles = {
     left: 0,
     bottom: -400,
     right: 0,
-    padding: '15px 15px 55px',
+    padding: '15px 15px 80px',
     animation: `0.3s ${slideUp} 0.2s forwards`,
     textAlign: 'left',
-    boxShadow: 'inset 0px -30px 30px -20px rgba(156, 156, 156, 0.6)',
+    boxShadow: 'inset 0px -50px 50px -30px rgba(0, 0, 0, 0.3)',
     [mUp]: {
       bottom: 'auto',
       top: 20,

--- a/src/theme/zIndex.js
+++ b/src/theme/zIndex.js
@@ -1,7 +1,7 @@
 export default {
   dropdown: 5,
   frontImage: 1,
-  callout: 10,
+  callout: 20,
   overlay: 50,
   foreground: 100
 }


### PR DESCRIPTION
Like the refactoring but the footer has a z-index of 11, which means the callout menu can potentially get hidden below it, which I believe should never happen.