### PR TITLE
fix(EditorialNewsletter): Add delivery reason note to email/Center (footer)

### DIFF
--- a/src/templates/EditorialNewsletter/email/Center.js
+++ b/src/templates/EditorialNewsletter/email/Center.js
@@ -5,6 +5,13 @@ import HR from './HR'
 import { Mso } from 'mdast-react-render/lib/email'
 import colors from '../../../theme/colors'
 
+const footerParagraphStyle = {
+  color: colors.text,
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontSize: '15px',
+  lineHeight: '30px'
+}
+
 const footerLinkStyle = {
   ...linkStyle,
   color: colors.text,
@@ -58,7 +65,7 @@ export default ({ children, meta }) => {
                       margin: 0,
                       maxWidth: '100% !important'
                     }}
-                    alt=''
+                    alt='REPUBLIK'
                   />
                 </a>
                 <p style={{ ...paragraphStyle, marginTop: 0 }}>
@@ -68,23 +75,25 @@ export default ({ children, meta }) => {
                   8004 Zürich
                 </p>
                 <HR />
-                <p>
+                <p style={footerParagraphStyle}>
                   <a
                     href={`https://www.republik.ch${path ? path : `/${slug}`}`}
                     style={footerLinkStyle}
                   >
                     Im Web lesen
                   </a>
-                  <br />
+                </p>
+                <p style={footerParagraphStyle}>
+                  Um{' '}
                   <a
                     href='https://www.republik.ch/konto#newsletter'
                     style={footerLinkStyle}
                   >
-                    Newsletter-Einstellungen anpassen
+                    Ihre Newsletter-Einstellungen einzusehen und anzupassen
                   </a>
-                  <br />
+                  , öffnen Sie «Konto» in der Republik-App oder auf republik.ch.{' '}
                   <a href='*|UNSUB|*' style={footerLinkStyle}>
-                    Von allen Newslettern abmelden
+                    Alle Newsletter sofort pausieren
                   </a>
                 </p>
               </td>


### PR DESCRIPTION
This Pull Request changes `EditorNewsletter` footer part. It adds a delivery reason note and offers some advice on how to change newsletter settings.

Wording is ought to hinder misconstrued notions that unsubscribing from newsletters cancels (paid) subscription, and a newsletter is the actual product.

Wording ok'd with Community Plus gents, tested with internal and external NL recipients.

**After**

<img width="692" alt="Bildschirmfoto 2020-04-07 um 14 35 09" src="https://user-images.githubusercontent.com/331800/78671785-09c2f300-78e0-11ea-968a-b83431d1380f.png">

**Before**

<img width="683" alt="Bildschirmfoto 2020-04-07 um 13 57 20" src="https://user-images.githubusercontent.com/331800/78666498-b5b41080-78d7-11ea-8c17-31478349cba8.png">
