### PR TITLE
fix(Infobox): smaller size when collapsed

### DIFF
--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -138,7 +138,7 @@ const InfoBox = ({
   const content = collapsable ? (
     <Collapsable
       t={t}
-      height={{ mobile: 230, desktop: 230 }}
+      height={{ mobile: 121, desktop: 151 }}
       editorPreview={collapsableEditorPreview}
     >
       {children}


### PR DESCRIPTION
Reduces the Infobox size when collapsed. Approved by CR and Produktion.

new desktop:
![Screenshot from 2020-04-14 16-01-35](https://user-images.githubusercontent.com/3500621/79233773-92eea280-7e69-11ea-9c2e-b111884992a2.png)

new mobile:
![Screenshot from 2020-04-14 16-01-18](https://user-images.githubusercontent.com/3500621/79233774-92eea280-7e69-11ea-99c8-e36a492a358b.png)


previous desktop:
![Screenshot from 2020-04-14 16-03-05](https://user-images.githubusercontent.com/3500621/79233768-92560c00-7e69-11ea-8d15-e54ce668db8e.png)

previous mobile:
![Screenshot from 2020-04-14 16-03-24](https://user-images.githubusercontent.com/3500621/79233764-91bd7580-7e69-11ea-8679-6cd3cd32ed5f.png)

