### PR TITLE
feat(EditorialNewsletter): trial campaign for covid-19

### DIFF
--- a/src/templates/EditorialNewsletter/docs.md
+++ b/src/templates/EditorialNewsletter/docs.md
@@ -108,9 +108,15 @@ format: 'https://github.com/republik/format-covid-19-uhr-newsletter'
 
 <section><h6>CENTER</h6>
 
-Ladies and Gentlemen,
+Liebe Leserinnen, liebe Leser
 
 At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. **Lorem ipsum** dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua ...
+
+Bleiben Sie umsichtig, bleiben Sie freundlich, bleiben Sie gesund.
+
+Philipp Albrecht, Elia Blülle, Dennis Bühler, Oliver Fuchs und Cinzia Venafro
+
+**PS:** Haben Sie Fragen und Feedback, schreiben Sie an: covid19@republik.ch.
 
 <hr /></section>
 

--- a/src/templates/EditorialNewsletter/email/Center.js
+++ b/src/templates/EditorialNewsletter/email/Center.js
@@ -5,6 +5,9 @@ import HR from './HR'
 import { Mso } from 'mdast-react-render/lib/email'
 import colors from '../../../theme/colors'
 
+import { Button } from './Button'
+import Paragraph, { Link } from './Paragraph'
+
 const footerParagraphStyle = {
   color: colors.text,
   fontFamily: fontFamilies.sansSerifRegular,
@@ -21,7 +24,11 @@ const footerLinkStyle = {
 }
 
 export default ({ children, meta }) => {
-  const { slug, path } = meta
+  const { slug, path, format } = meta
+
+  const isCovid19 =
+    format && format.indexOf('format-covid-19-uhr-newsletter') !== -1
+
   return (
     <tr>
       <td align='center' valign='top'>
@@ -49,6 +56,24 @@ export default ({ children, meta }) => {
             <tr>
               <td style={{ padding: 20 }} className='body_content'>
                 {children}
+                {isCovid19 && (
+                  <>
+                    *|INTERESTED:Customer:Member,Geteilter Zugriff|* *|ELSE:|*
+                    <Paragraph>
+                      <strong>Neugierig auf die ganze Republik?</strong>
+                      <br />
+                      Jetzt kostenlos 14 Tage lang testen. Alle Newsletter, alle
+                      Beiträge, alle Podcasts, alle Debatten entdecken – auf der
+                      Website und in der App. Gratis, unverbindlich und ohne
+                      Werbung, finanziert von unseren Leserinnen:{' '}
+                      <Link href='https://www.republik.ch/probelesen?campaign=covid-19-uhr-newsletter&email=*|EMAILB64U|*&token=*|AS_ATOKEN|*'>
+                        Jetzt ausprobieren
+                      </Link>
+                      .
+                    </Paragraph>
+                    *|END:INTERESTED|*
+                  </>
+                )}
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
<img width="406" alt="Screenshot 2020-04-22 at 11 30 40" src="https://user-images.githubusercontent.com/410211/79965753-b8446780-848c-11ea-9e7f-07660c1399da.png">

When not member or active trial:
```
*|INTERESTED:Customer:Member,Geteilter Zugriff|* *|ELSE:|*
```
We display a teaser to start a trial. With special tokens (if not available it still works gracefully with an extra email verification step)