### PR TITLE
Featured Comments

### DIFF
--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -510,7 +510,10 @@ const BarChart = props => {
                           )}
                           {isLollipop && (
                             <circle
-                              cx={segment.x + segment.width - 1}
+                              cx={
+                                segment.x +
+                                (segment.value >= 0 ? segment.width - 1 : 0)
+                              }
                               cy={bar.height / 2}
                               r={
                                 Math.floor(
@@ -533,7 +536,8 @@ const BarChart = props => {
                                     (isLollipop ? 8 : 0)
                                   : segment.x +
                                     (segment.value >= 0 ? segment.width : 0) -
-                                    4
+                                    4 -
+                                    (isLollipop ? 8 : 0)
                               }
                               textAnchor={
                                 valueTextStartAnchor ? 'start' : 'end'

--- a/src/components/Chart/Lollipops.docs.md
+++ b/src/components/Chart/Lollipops.docs.md
@@ -45,3 +45,35 @@ Januar 2020,0.75
     `.trim()} />
 </div>
 ```
+
+## Negative Values
+
+```react
+<div>
+  <ChartTitle>Branchen, die zum Stillstand kamen</ChartTitle>
+  <CsvChart
+    config={{
+      "type": "Lollipop",
+      "y": "branche",
+      "sort": "none",
+      "numberFormat": "+.0%",
+      "domain": [
+        -1.1,
+        0
+      ],
+      "colorRange": [
+        "#6A3D9A"
+      ],
+      "showBarValues": true,
+      "band": "band"
+    }}
+    values={`
+branche,value,band_lower,band_upper
+Persönliche Dienstleistungen,-0.875,-0.950,-0.800
+Gastgewerbe und Beherbergung,-0.875,-0.950,-0.800
+Luftfahrt,-0.950,-1.000,-0.900
+"Kunst, Unterhaltung und Erholung",-0.950,-1.000,-0.900
+Reisebüros,-0.975,-1.000,-0.950
+    `.trim()} />
+</div>
+```

--- a/src/components/Discussion/DiscussionContext.docs.js
+++ b/src/components/Discussion/DiscussionContext.docs.js
@@ -5,12 +5,16 @@ import React from 'react'
  * shape of the context value. This value is provided to all components in
  * the documentation pages.
  */
-export const createSampleDiscussionContextValue = ({ t }) => ({
+export const createSampleDiscussionContextValue = ({
+  t,
+  isAdmin = false,
+  actions = {}
+}) => ({
   /**
    * Admin users have elevated priviledges, they can for example unpublish
    * any comment.
    */
-  isAdmin: false,
+  isAdmin,
 
   /**
    * The Discussion object, straight from the GraphQL server.
@@ -83,7 +87,9 @@ export const createSampleDiscussionContextValue = ({ t }) => ({
       Promise.resolve({ ok: true }),
 
     shareComment: commentId => Promise.resolve({ ok: true }),
-    openDiscussionPreferences: () => Promise.resolve({ ok: true })
+    openDiscussionPreferences: () => Promise.resolve({ ok: true }),
+
+    ...actions
   },
 
   /**

--- a/src/components/Discussion/Internal/Comment/Actions.js
+++ b/src/components/Discussion/Internal/Comment/Actions.js
@@ -9,9 +9,14 @@ import ReportIcon from 'react-icons/lib/md/flag'
 import EditIcon from 'react-icons/lib/md/edit'
 import ReplyIcon from 'react-icons/lib/md/reply'
 import ShareIcon from 'react-icons/lib/md/share'
+import FeaturedIcon from 'react-icons/lib/md/star-outline'
 import colors from '../../../../theme/colors'
 import { sansSerifMedium14 } from '../../../Typography/styles'
 import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
+import { timeFormat } from '../../../../lib/timeFormat'
+
+const dateFormat = timeFormat('%d.%m.%Y')
+const hmFormat = timeFormat('%H:%M')
 
 const styles = {
   root: css({
@@ -110,7 +115,9 @@ export const Actions = ({
     userVote,
     numReports,
     userReportedAt,
-    userCanReport
+    userCanReport,
+    featuredAt,
+    featuredText
   } = comment
   const { isAdmin, discussion, actions, clock } = React.useContext(
     DiscussionContext
@@ -209,6 +216,13 @@ export const Actions = ({
           <UnpublishIcon />
         </IconButton>
       )}
+      <IconButton
+        type='left'
+        onClick={onShare}
+        title={t('styleguide/CommentActions/share')}
+      >
+        <ShareIcon />
+      </IconButton>
       {userCanReport && onReport && (
         <IconButton
           type='left'
@@ -222,14 +236,26 @@ export const Actions = ({
           </span>
         </IconButton>
       )}
-      <IconButton
-        type='left'
-        onClick={onShare}
-        title={t('styleguide/CommentActions/share')}
-      >
-        <ShareIcon />
-      </IconButton>
       <div {...styles.votes}>
+        {!!(featuredText || actions.featureComment) && (
+          <IconButton
+            type='left'
+            title={
+              featuredAt
+                ? t('styleguide/CommentActions/featured', {
+                    date: dateFormat(new Date(featuredAt)),
+                    time: hmFormat(new Date(featuredAt)),
+                    text: featuredText
+                  })
+                : t('styleguide/CommentActions/feature')
+            }
+            onClick={
+              actions.featureComment && (() => actions.featureComment(comment))
+            }
+          >
+            <FeaturedIcon fill={featuredText ? colors.primary : undefined} />
+          </IconButton>
+        )}
         <div {...styles.vote}>
           <IconButton
             type={userVote === 'UP' ? 'selectedVote' : 'vote'}

--- a/src/components/Discussion/Internal/docs.imports.js
+++ b/src/components/Discussion/Internal/docs.imports.js
@@ -73,6 +73,19 @@ export const comments = {
     ...allComments.comment2,
     embed: allComments.linkPreview1,
     mentioningDocument: allComments.mentioningDocument
+  },
+
+  withAdminActions: {
+    ...allComments.comment2,
+    content: exampleShortMdast,
+    userCanReport: true,
+    userVote: undefined
+  },
+  featured: {
+    ...allComments.comment2,
+    content: exampleShortMdast,
+    featuredText: '[…] entweder am Anfang […] oder nie.',
+    featuredAt: '2020-05-10T20:02:20.000Z'
   }
 }
 

--- a/src/components/Discussion/Internal/docs.md
+++ b/src/components/Discussion/Internal/docs.md
@@ -211,6 +211,39 @@ The buttons / icons below the comment. The reply button is disabled if the discu
   onEdit={() => {}}
 />
 ```
+
+```react|noSource,span-2
+<DiscussionContext.Provider
+  value={createSampleDiscussionContextValue({ 
+    t,
+    isAdmin: true,
+    actions: {
+      featureComment: () => Promise.resolve({ ok: true })
+    }
+  })}
+>
+  <Comment.Actions
+    t={t}
+    comment={comments.withAdminActions}
+    onUnpublish={() => {}}
+    onReport={() => {}}
+    onReply={() => {}}
+    onEdit={() => {}}
+  />
+</DiscussionContext.Provider>
+```
+
+```react|noSource,span-2
+<Comment.Actions
+  t={t}
+  comment={comments.featured}
+  onUnpublish={() => {}}
+  onReport={() => {}}
+  onReply={() => {}}
+  onEdit={() => {}}
+/>
+```
+
 ```react|noSource,span-2
 <Comment.IconLink
   href={""}

--- a/src/index.js
+++ b/src/index.js
@@ -343,6 +343,7 @@ ReactDOM.render(
               title: 'Internal',
               imports: {
                 t,
+                createSampleDiscussionContextValue,
                 ...require('./components/Discussion/Internal/docs.imports')
               },
               src: require('./components/Discussion/Internal/docs.md')

--- a/src/lib.js
+++ b/src/lib.js
@@ -151,3 +151,7 @@ export { usePrevious } from './lib/usePrevious'
 export { useDebounce } from './lib/useDebounce'
 export { useBodyScrollLock, isBodyScrollLocked } from './lib/useBodyScrollLock'
 export { HeaderHeightProvider, useHeaderHeight } from './lib/useHeaderHeight'
+
+export {
+  default as ActiveDebateTeaser
+} from './components/TeaserActiveDebates/DebateTeaser'

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-02-06T12:45:18.393Z",
+  "updated": "2020-05-10T19:56:53.981Z",
   "title": "live",
   "data": [
     {
@@ -28,7 +28,11 @@
     },
     {
       "key": "styleguide/CommentActions/expand",
-      "value": "Kommentaren"
+      "value": "Kommentare anschauen"
+    },
+    {
+      "key": "styleguide/CommentActions/share",
+      "value": "Beitrag teilen"
     },
     {
       "key": "styleguide/CommentActions/answer",
@@ -81,6 +85,14 @@
     {
       "key": "styleguide/CommentActions/downvote/count/other",
       "value": "{count} Gegenstimmen"
+    },
+    {
+      "key": "styleguide/CommentActions/feature",
+      "value": "Beitrag hervorheben"
+    },
+    {
+      "key": "styleguide/CommentActions/featured",
+      "value": "Am {date} um {time} Uhr redaktionell hervorgehobenes Zitat: {text}"
     },
     {
       "key": "styleguide/CommentTeaser/comment/link",
@@ -194,10 +206,6 @@
     {
       "key": "styleguide/charts/error",
       "value": "Diese Visualisierung ist kaputt."
-    },
-    {
-      "key": "styleguide/templates/unauthorizedZone",
-      "value": "Inhalt nur für Mitglieder."
     },
     {
       "key": "styleguide/DynamicComponent/error",

--- a/src/templates/Front/liveTeasers.js
+++ b/src/templates/Front/liveTeasers.js
@@ -184,12 +184,8 @@ const createLiveTeasers = ({
             note: 'Anzahl Debatten, default 4'
           },
           {
-            key: 'highlightId',
-            note: 'Kommentar-ID (focus-Wert im URL)'
-          },
-          {
-            key: 'highlightQuote',
-            note: 'Zitat aus dem Kommentar'
+            key: 'featured',
+            note: 'Anzahl Beiträge, 0 für keine, default 1'
           }
         ]
       }


### PR DESCRIPTION
<img width="967" alt="Screenshot 2020-05-11 at 00 18 16" src="https://user-images.githubusercontent.com/410211/81511901-ed6e0800-931c-11ea-9a96-08416001258a.png">

left: regular, middle: admin actions (black star), right: featured (green star)

Under the hood changes:
- new `TeaserActiveDebates` query with featured via API, depends on https://github.com/orbiting/backends/pull/418
- move flag icon after share icon (less accidental reply clicks)