### PR TITLE
fix(EditorialNewsletter): Replace call to action w/ prominent link to trial

### DIFF
--- a/src/templates/EditorialNewsletter/email/Center.js
+++ b/src/templates/EditorialNewsletter/email/Center.js
@@ -5,8 +5,6 @@ import HR from './HR'
 import { Mso } from 'mdast-react-render/lib/email'
 import colors from '../../../theme/colors'
 
-import Paragraph, { Link } from './Paragraph'
-
 const footerParagraphStyle = {
   color: colors.text,
   fontFamily: fontFamilies.sansSerifRegular,
@@ -24,9 +22,6 @@ const footerLinkStyle = {
 
 export default ({ children, meta }) => {
   const { slug, path, format } = meta
-
-  const isCovid19 =
-    format && format.indexOf('format-covid-19-uhr-newsletter') !== -1
 
   return (
     <tr>
@@ -55,23 +50,6 @@ export default ({ children, meta }) => {
             <tr>
               <td style={{ padding: 20 }} className='body_content'>
                 {children}
-                {isCovid19 && (
-                  <>
-                    *|INTERESTED:Customer:Member,Geteilter Zugriff|* *|ELSE:|*
-                    <Paragraph>
-                      <strong>Sie finden diesen Newsletter brauchbar …</strong>
-                      <br />… und möchten mehr davon? Schliessen Sie für CHF 22
-                      ein Monatsabo ab. Alle Newsletter, alle Beiträge, alle
-                      Podcasts, alle Debatten – auf der Website und in der App.
-                      Jederzeit kündbar.{' '}
-                      <Link href='https://www.republik.ch/angebote?package=MONTHLY_ABO&utm_source=newsletter&utm_medium=email&utm_campaign=covid-19-uhr-newsletter'>
-                        Jetzt ausprobieren
-                      </Link>
-                      .
-                    </Paragraph>
-                    *|END:INTERESTED|*
-                  </>
-                )}
               </td>
             </tr>
             <tr>

--- a/src/templates/EditorialNewsletter/email/Header.js
+++ b/src/templates/EditorialNewsletter/email/Header.js
@@ -1,5 +1,24 @@
 import React from 'react'
 import colors from '../../../theme/colors'
+import { fontFamilies } from '../../../theme/fonts'
+
+import { linkStyle } from './Paragraph'
+
+const ctaParagraphStyle = {
+  color: colors.text,
+  margin: '10px',
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontSize: '16px',
+  lineHeight: '30px'
+}
+
+const ctaLinkStyle = {
+  ...linkStyle,
+  color: colors.text,
+  fontFamily: fontFamilies.sansSerifRegular,
+  fontSize: '16px',
+  lineHeight: '30px'
+}
 
 export default ({ meta }) => {
   const { slug, path, format } = meta
@@ -8,33 +27,59 @@ export default ({ meta }) => {
     format && format.indexOf('format-covid-19-uhr-newsletter') !== -1
 
   return (
-    <tr>
-      <td
-        align='center'
-        valign='top'
-        style={{ borderBottom: `1px solid ${colors.divider}` }}
-      >
-        <a
-          href={`https://www.republik.ch${path ? path : `/${slug}`}`}
-          title='Im Web lesen'
+    <>
+      <tr>
+        <td
+          align='center'
+          valign='top'
+          style={{ borderBottom: !isCovid19 && `1px solid ${colors.divider}` }}
         >
-          <img
-            height='79'
-            width={isCovid19 ? 217 : 178}
-            src={`https://www.republik.ch/static/logo_republik_newsletter${
-              isCovid19 ? '_covid19' : ''
-            }.png`}
-            style={{
-              border: 0,
-              width: `${isCovid19 ? 217 : 178}px !important`,
-              height: '79px !important',
-              margin: 0,
-              maxWidth: '100% !important'
-            }}
-            alt='REPUBLIK'
-          />
-        </a>
-      </td>
-    </tr>
+          <a
+            href={`https://www.republik.ch${path ? path : `/${slug}`}`}
+            title='Im Web lesen'
+          >
+            <img
+              height='79'
+              width={isCovid19 ? 217 : 178}
+              src={`https://www.republik.ch/static/logo_republik_newsletter${
+                isCovid19 ? '_covid19' : ''
+              }.png`}
+              style={{
+                border: 0,
+                width: `${isCovid19 ? 217 : 178}px !important`,
+                height: '79px !important',
+                margin: 0,
+                maxWidth: '100% !important'
+              }}
+              alt='REPUBLIK'
+            />
+          </a>
+        </td>
+      </tr>
+      {isCovid19 && (
+        <>
+          *|INTERESTED:Customer:Member,Geteilter Zugriff|* *|ELSE:|*
+          *|IFNOT:COVID19_AG|*
+          <tr>
+            <td
+              align='center'
+              valign='top'
+              style={{ backgroundColor: colors.primaryBg }}
+            >
+              <p style={ctaParagraphStyle}>
+                Neugierig auf die ganze Republik?{' '}
+                <a
+                  href='https://www.republik.ch/probelesen?campaign=covid-19-uhr-newsletter&email=*|EMAILB64U|*&token=*|AS_ATOKEN|*'
+                  style={ctaLinkStyle}
+                >
+                  Jetzt ausprobieren
+                </a>
+              </p>
+            </td>
+          </tr>
+          *|END:IF|* *|END:INTERESTED|*
+        </>
+      )}
+    </>
   )
 }

--- a/src/templates/EditorialNewsletter/email/Header.js
+++ b/src/templates/EditorialNewsletter/email/Header.js
@@ -32,7 +32,9 @@ export default ({ meta }) => {
         <td
           align='center'
           valign='top'
-          style={{ borderBottom: !isCovid19 && `1px solid ${colors.divider}` }}
+          style={{
+            borderBottom: !isCovid19 ? `1px solid ${colors.divider}` : undefined
+          }}
         >
           <a
             href={`https://www.republik.ch${path ? path : `/${slug}`}`}


### PR DESCRIPTION
<img width="930" alt="Bildschirmfoto 2020-05-14 um 15 42 27" src="https://user-images.githubusercontent.com/331800/81942708-c3f1fc80-95fa-11ea-970b-7f429d1cb03e.png">
