### PR TITLE
fix(Typography): Provide color context to Editorial.Note

### DIFF
--- a/src/components/Typography/Editorial.js
+++ b/src/components/Typography/Editorial.js
@@ -269,8 +269,20 @@ const note = css({
   }
 })
 
-export const Note = ({ children, attributes, ...props }) => (
-  <p {...attributes} {...props} {...note} {...interactionFontRule}>
-    {children}
-  </p>
-)
+export const Note = ({ children, attributes, ...props }) => {
+  const [colorScheme] = useColorContext()
+  const colors = css({
+    color: colorScheme.text
+  })
+  return (
+    <p
+      {...attributes}
+      {...props}
+      {...note}
+      {...colors}
+      {...interactionFontRule}
+    >
+      {children}
+    </p>
+  )
+}


### PR DESCRIPTION
_It's black, it's white
It's tough for you to get by
It's black, it's white, woo_

This Pull Request uses color context in `Typography/Editorial/Note` to render notes in dark mode as well.

<img width="649" alt="Bildschirmfoto 2020-05-29 um 09 09 22" src="https://user-images.githubusercontent.com/331800/83231736-48608580-a18c-11ea-9b2a-534a73bc3fce.png">
<img width="654" alt="Bildschirmfoto 2020-05-29 um 09 09 12" src="https://user-images.githubusercontent.com/331800/83231738-48f91c00-a18c-11ea-9f34-3a75151a570a.png">
