### PR TITLE
Increase margin on IconButton

### DIFF
--- a/src/components/IconButton/index.js
+++ b/src/components/IconButton/index.js
@@ -77,7 +77,7 @@ const styles = {
     position: 'relative',
     alignItems: 'center',
     textDecoration: 'none',
-    marginRight: 18,
+    marginRight: 20,
     border: 0,
     padding: 0,
     color: 'inherit',


### PR DESCRIPTION
Right before the release of the action bar, I changed the IconButton default margin from 20px to 18px. I think it's a bit too narrow and on small mobile phones users could benefit from a bit more space, so I reverted it back to 20px. See narrowest scenario below iPhone 5S (it's subtle): 

after:
![Screenshot 2020-09-03 at 08 16 11](https://user-images.githubusercontent.com/20746301/92078070-f8621200-edbd-11ea-8d4a-e36bd95dbb28.jpg)

before
![Screenshot 2020-09-03 at 08 16 29](https://user-images.githubusercontent.com/20746301/92078075-f9933f00-edbd-11ea-99ae-a8f5524d8a60.jpg)
