### PR TITLE
Fine Tune TeaserMyMagazine

### DIFF
--- a/src/components/InfoBox/InfoBox.js
+++ b/src/components/InfoBox/InfoBox.js
@@ -112,7 +112,7 @@ const InfoBox = ({
   figureSize,
   figureFloat,
   collapsable,
-  collapsableEditorPreview
+  editorPreview
 }) => {
   let styles = {}
   const float = figureFloat || size === 'float'
@@ -139,7 +139,7 @@ const InfoBox = ({
     <Collapsable
       t={t}
       height={{ mobile: 121, desktop: 151 }}
-      editorPreview={collapsableEditorPreview}
+      editorPreview={editorPreview}
     >
       {children}
     </Collapsable>

--- a/src/components/LazyLoad/Image.js
+++ b/src/components/LazyLoad/Image.js
@@ -31,6 +31,8 @@ export default ({
     attributes={{ ...styles.container, ...attributes }}
     offset={offset}
     visible={visible}
+    consistentPlaceholder
+    type='span'
     style={{
       // We always subtract 1px to prevent against rounding issues that can lead
       // to the background color shining through at the bottom of the image.

--- a/src/components/LazyLoad/docs.md
+++ b/src/components/LazyLoad/docs.md
@@ -1,18 +1,20 @@
 ### `<LazyLoad />`
 
-Awaits the viewport approaching to render its children. It works by rendering a span wrapper which should act as an placeholder—reserving the right amount of space. When `!process.browser` the children will be rendered in a `<noscript>` tag before being visible.
+Awaits the viewport approaching to render its children. It works by rendering a wrapper which should act as an placeholder—reserving the right amount of space. When `!process.browser` the children will be rendered in a `<noscript>` tag before being visible.
 
 #### Properties
 
 - `visible` bool, overwrite laziness—e.g. server rendered first items
 - `offset` number, default 0.5, distance in viewport height to start rendering
+- `type` React element, default div
 - `style` object, applied to wrapper
 - `attributes` object, spread onto the wrapper
+- `consistentPlaceholder` bool, render noscript and always keep placeholder around, use this if you need consistent SSR page size and noscript support
 - `children` node, the lazy loaded content
 
 ### `<LazyImage />`
 
-A convenience wrapper for width filling images with an known aspect ratio. It takes care of the placeholder.
+A convenience wrapper for width filling images with an known aspect ratio. It takes care of the placeholder—consistent with SSR and noscript support.
 
 #### Properties
 
@@ -28,7 +30,6 @@ A convenience wrapper for width filling images with an known aspect ratio. It ta
     By default a LazyLoad wrapped component will only load once it's half the screen height away. There is an image below, in 1.5 screen heights:
   </P>
   <LazyLoad style={{
-    display: 'block',
     position: 'relative',
     paddingBottom: `${100 / (2000 / 1411)}%`,
     backgroundColor: 'rgba(0,0,0,0.1)'

--- a/src/components/LazyLoad/index.js
+++ b/src/components/LazyLoad/index.js
@@ -67,11 +67,24 @@ class LazyLoad extends Component {
     instances.rm(this)
   }
   render() {
-    const { children, attributes, style, type: Element, noscript } = this.props
+    const {
+      children,
+      attributes,
+      style,
+      type: Element,
+      consistentPlaceholder
+    } = this.props
     const visible = this.props.visible || this.state.visible
+    if (visible && !consistentPlaceholder) {
+      return <>{children}</>
+    }
     return (
       <Element ref={this.setRef} {...attributes} style={style}>
-        {visible ? children : noscript ? <noscript>{children}</noscript> : null}
+        {visible ? (
+          children
+        ) : consistentPlaceholder ? (
+          <noscript>{children}</noscript>
+        ) : null}
       </Element>
     )
   }
@@ -79,8 +92,8 @@ class LazyLoad extends Component {
 
 LazyLoad.defaultProps = {
   offset: 0.5,
-  type: 'span',
-  noscript: true
+  type: 'div',
+  consistentPlaceholder: false
 }
 
 export default LazyLoad

--- a/src/components/TeaserCarousel/Carousel.js
+++ b/src/components/TeaserCarousel/Carousel.js
@@ -49,6 +49,7 @@ export const Carousel = ({
         {...styles.carousel}
         style={{
           backgroundColor: bgColor,
+          // for color inherit below, e.g. TeaserSectionTitle
           color: color ? color : 'inherit',
           margin: article ? '20px 0' : undefined
         }}

--- a/src/components/TeaserMyMagazine/TeaserMyMagazine.js
+++ b/src/components/TeaserMyMagazine/TeaserMyMagazine.js
@@ -38,7 +38,13 @@ const TeaserMyMagazine = ({
   }
 
   return (
-    <div {...css({ backgroundColor: colorScheme.primaryBg })}>
+    <div
+      style={{
+        backgroundColor: colorScheme.primaryBg,
+        // for color inherit below, e.g. TeaserSectionTitle
+        color: colorScheme.text
+      }}
+    >
       <section {...css(styles.section)}>
         <div role='group' {...css(styles.row, styles.withHighlight)}>
           {latestProgressOrBookmarkedArticles?.length ? (

--- a/src/components/TeaserMyMagazine/TeaserMyMagazine.js
+++ b/src/components/TeaserMyMagazine/TeaserMyMagazine.js
@@ -25,7 +25,8 @@ const TeaserMyMagazine = ({
   bookmarkLabel,
   notificationsUrl,
   notificationsLabel,
-  Link = DefaultLink
+  Link = DefaultLink,
+  placeholder = null
 }) => {
   const [colorScheme] = useColorContext()
 
@@ -33,7 +34,7 @@ const TeaserMyMagazine = ({
     !latestSubscribedArticles?.length &&
     !latestProgressOrBookmarkedArticles?.length
   ) {
-    return null
+    return placeholder
   }
 
   return (

--- a/src/components/TeaserShared/SectionTitle.js
+++ b/src/components/TeaserShared/SectionTitle.js
@@ -14,6 +14,7 @@ const styles = {
     display: 'block',
     marginBottom: 15,
     ...sansSerifMedium22,
+    textDecoration: 'none',
     '& svg': {
       width: 22,
       height: 22,
@@ -32,38 +33,26 @@ const styles = {
   small: css({
     color: 'inherit',
     ...sansSerifMedium16,
+    textDecoration: 'none',
     '& svg': {
       marginTop: -1,
       width: 16,
       height: 16,
       marginLeft: 4
     }
-  }),
-  link: css({
-    textDecoration: 'none'
   })
 }
 
 const SectionTitle = React.forwardRef(
   ({ children, small, onClick, href }, ref) => {
-    const [colorScheme] = useColorContext()
     const style = small ? styles.small : styles.container
     return href ? (
-      <a
-        href={href}
-        onClick={onClick}
-        {...css(style, styles.link, { color: colorScheme.text })}
-        ref={ref}
-      >
+      <a href={href} onClick={onClick} {...style} ref={ref}>
         {children}
         {<ChevronRight />}
       </a>
     ) : (
-      <span
-        onClick={onClick}
-        {...css(style, { color: colorScheme.text })}
-        ref={ref}
-      >
+      <span onClick={onClick} {...style} ref={ref}>
         {children}
       </span>
     )

--- a/src/templates/Front/liveTeasers.js
+++ b/src/templates/Front/liveTeasers.js
@@ -232,11 +232,7 @@ const createLiveTeasers = ({
       props: node => node.data,
       component: props => {
         return (
-          <LazyLoad
-            type='div'
-            noscript={false}
-            style={{ minHeight: LAZYLOADER_DIALOG_HEIGHT }}
-          >
+          <LazyLoad style={{ minHeight: LAZYLOADER_DIALOG_HEIGHT }}>
             <DiscussionWithData {...props} />
           </LazyLoad>
         )
@@ -279,8 +275,6 @@ const createLiveTeasers = ({
         }
         return (
           <LazyLoad
-            type='div'
-            noscript={false}
             style={{
               minHeight: LAZYLOADER_MYMAGAZINE_HEIGHT,
               backgroundColor: colors.negative.primaryBg

--- a/src/templates/Front/liveTeasers.js
+++ b/src/templates/Front/liveTeasers.js
@@ -14,6 +14,7 @@ import Center from '../../components/Center'
 import Loader from '../../components/Loader'
 import LazyLoad from '../../components/LazyLoad'
 import { mUp } from '../../theme/mediaQueries'
+import colors from '../../theme/colors'
 
 const styles = {
   feedContainer: css({
@@ -31,6 +32,23 @@ const LAZYLOADER_MYMAGAZINE_HEIGHT = 210
 
 const DefaultLink = ({ children }) => children
 const withData = Component => props => <Component {...props} data={{}} />
+const Placeholder = ({ attributes, children, minHeight }) => (
+  <div
+    attributes={attributes}
+    style={{
+      padding: '20px 0',
+      backgroundColor: '#111',
+      color: '#f0f0f0',
+      textAlign: 'center',
+      minHeight,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    }}
+  >
+    {children}
+  </div>
+)
 
 const createLiveTeasers = ({
   Link = DefaultLink,
@@ -49,7 +67,8 @@ const createLiveTeasers = ({
       bookmarksUrl,
       bookmarkLabel,
       notificationsUrl,
-      notificationsLabel
+      notificationsLabel,
+      placeholder
     }) => {
       return (
         <Loader
@@ -59,6 +78,7 @@ const createLiveTeasers = ({
           render={() => {
             return (
               <TeaserMyMagazine
+                placeholder={placeholder}
                 latestSubscribedArticles={data.latestSubscribedArticles}
                 latestProgressOrBookmarkedArticles={
                   data.latestProgressOrBookmarkedArticles
@@ -261,9 +281,21 @@ const createLiveTeasers = ({
           <LazyLoad
             type='div'
             noscript={false}
-            style={{ minHeight: LAZYLOADER_MYMAGAZINE_HEIGHT }}
+            style={{
+              minHeight: LAZYLOADER_MYMAGAZINE_HEIGHT,
+              backgroundColor: colors.negative.primaryBg
+            }}
           >
-            <MyMagazineWithData {...props} />
+            <MyMagazineWithData
+              placeholder={
+                props.editorPreview && (
+                  <Placeholder minHeight={LAZYLOADER_MYMAGAZINE_HEIGHT}>
+                    Meine Republik
+                  </Placeholder>
+                )
+              }
+              {...props}
+            />
           </LazyLoad>
         )
       },
@@ -271,7 +303,7 @@ const createLiveTeasers = ({
       editorModule: 'liveteaser',
       editorOptions: {
         type: 'LIVETEASERMYMAGAZINE',
-        insertButtonText: 'Meine Republik.',
+        insertButtonText: 'Meine Republik',
         insertId: 'mymagazine'
       }
     },
@@ -280,19 +312,7 @@ const createLiveTeasers = ({
         matchZone('LIVETEASER')(node) && node.data.id === 'end',
       props: node => node.data,
       component: ({ attributes, data, url, label }) => {
-        return (
-          <div
-            attributes={attributes}
-            style={{
-              padding: '20px 0',
-              backgroundColor: '#111',
-              color: '#f0f0f0',
-              textAlign: 'center'
-            }}
-          >
-            The End
-          </div>
-        )
+        return <Placeholder attributes={attributes}>The End</Placeholder>
       },
       isVoid: true,
       editorModule: 'liveteaser',


### PR DESCRIPTION
- `editorPreview` for `TeaserMyMagazine` when there is no content
- fix `SectionTitle` color, revert to using inherit instead of react context (was causing wrong coloured title above carousels, see screenshot)
- refactor `LazyLoad`, ensure no placeholder wrapper is left over after everything is ready
- refactor `editorPreview` naming in InfoBox

<img width="1732" alt="Screenshot 2020-09-30 at 22 28 21" src="https://user-images.githubusercontent.com/410211/94736320-53ab0400-036c-11eb-9f3a-a71701a903d4.png">