### PR TITLE
Fix format color in dark context

### DIFF
--- a/src/components/Colors/useColorContext.js
+++ b/src/components/Colors/useColorContext.js
@@ -10,6 +10,7 @@ export const useColorContext = () => {
       ...colors,
       ...colorContext
     }
+    const { formatColorMap = {} } = colorScheme
     // precomputed css rules which are often used
     const colorRules = {
       textColor: css({
@@ -19,7 +20,13 @@ export const useColorContext = () => {
     return [
       {
         ...colorScheme,
-        rules: colorRules
+        rules: colorRules,
+        formatColorMapper: color => {
+          if (formatColorMap[color]) {
+            return formatColorMap[color]
+          }
+          return color
+        }
       }
     ]
   }, [colorContext])

--- a/src/components/TeaserFeed/index.js
+++ b/src/components/TeaserFeed/index.js
@@ -72,12 +72,12 @@ export const TeaserFeed = ({
       ? Headlines.Scribble
       : Headlines.Editorial
   const borderColor = formatMeta.title
-    ? formatMeta.color || colors[formatMeta.kind]
+    ? colorScheme.formatColorMapper(formatMeta.color || colors[formatMeta.kind])
     : template === 'format'
-    ? metaColor || colors[metaKind]
+    ? colorScheme.formatColorMapper(metaColor || colors[metaKind])
     : colorScheme.text
   const titleColor = metaColor
-    ? metaColor
+    ? colorScheme.formatColorMapper(metaColor)
     : template === 'format'
     ? borderColor
     : colorScheme.text

--- a/src/components/TeaserMyMagazine/TeaserMyMagazine.js
+++ b/src/components/TeaserMyMagazine/TeaserMyMagazine.js
@@ -247,14 +247,18 @@ WrappedTeaserMyMagazine.data = {
                 shortTitle
                 title
                 credits
+                prepublication
                 path
+                kind
+                template
+                color
                 format {
                   id
                   meta {
-                    title
-                    kind
-                    template
                     path
+                    title
+                    color
+                    kind
                   }
                 }
               }

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -77,7 +77,11 @@ const colors = {
     fill: '#FFF',
     lightFill: '#555',
     error: 'rgb(239,69,51)',
-    disabled: '#242424'
+    disabled: '#242424',
+    formatColorMap: {
+      '#000': '#fff',
+      '#000000': '#fff'
+    }
   },
   ...getJson('COLORS')
 }

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -80,7 +80,8 @@ const colors = {
     disabled: '#242424',
     formatColorMap: {
       '#000': '#fff',
-      '#000000': '#fff'
+      '#000000': '#fff',
+      '#282828': '#fff'
     }
   },
   ...getJson('COLORS')


### PR DESCRIPTION
Monkey patch color values in teaser feed elements in a dark context:

<img width="1526" alt="Screenshot 2020-09-30 at 23 28 42" src="https://user-images.githubusercontent.com/410211/94830849-4b0a0a80-040c-11eb-9d05-0c0b1307a12b.png">

becomes bright:

<img width="1333" alt="Screenshot 2020-10-01 at 17 34 22" src="https://user-images.githubusercontent.com/410211/94830931-5f4e0780-040c-11eb-9ee2-7fc818391c01.png">
