### PR TITLE
Color Labels

### DIFF
--- a/src/chart.js
+++ b/src/chart.js
@@ -1,1 +1,6 @@
-export { default as Chart, ChartTitle, ChartLead } from './components/Chart'
+export {
+  default as Chart,
+  ChartTitle,
+  ChartLead,
+  ChartLegend
+} from './components/Chart'

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -20,7 +20,7 @@ Schweiz,0.279
 USA,0.264
 Irland,0.236
     `.trim()} />
-  <Editorial.Note>Quelle: OECD 2015. Revenue Statistics 1965-2014. Bundesministerium der Finanzen 2016. Die wichtigsten Steuern im internationalen Vergleich 2015.</Editorial.Note>
+  <ChartLegend>Quelle: OECD 2015. Revenue Statistics 1965-2014. Bundesministerium der Finanzen 2016. Die wichtigsten Steuern im internationalen Vergleich 2015.</ChartLegend>
 </div>
 ```
 
@@ -63,7 +63,7 @@ Gesundheit und Sport,Betriebliche Weiterbildung,0.19
 "Natur, Technik, Computer",Betriebliche Weiterbildung,0.24
 nicht oder nur einstellig klassifizierbar,Betriebliche Weiterbildung,0.04
     `.trim()} />
-  <Editorial.Note>Quelle: Adult Education Survey 2014.</Editorial.Note>
+  <ChartLegend>Quelle: Adult Education Survey 2014.</ChartLegend>
 </div>
 ```
 
@@ -108,7 +108,7 @@ Sexuelle Belästigung,etwas,0.167
 Sexuelle Belästigung,ziemlich,0.047
 Sexuelle Belästigung,sehr stark,0.093
     `.trim()} />
-  <Editorial.Note>Quelle: Deutscher Viktimisierungssurvey 2012.</Editorial.Note>
+  <ChartLegend>Quelle: Deutscher Viktimisierungssurvey 2012.</ChartLegend>
 </div>
 ```
 
@@ -176,7 +176,7 @@ Bern,Nein,0.278,
 Luzern,Ja,0.687,
 Luzern,Nein,0.313,
     `.trim()} />
-  <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -201,7 +201,7 @@ Thomas,494,https://www.republik.ch/~tpreusse
 Peter,464
 Daniel,415,https://www.republik.ch/~daniel
     `.trim()} />
-  <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20180923/det620.html">Bundeskanzlei</Editorial.A></ChartLegend>
 </div>
 ```
 

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -30,9 +30,7 @@ import { getColorMapper } from './colorMaps'
 const COLUMN_PADDING = 20
 const COLUMN_TITLE_HEIGHT = 30
 const BAR_LABEL_HEIGHT = 15
-const AXIS_BOTTOM_HEIGHT = 20
-const AXIS_BOTTOM_PADDING = 8
-const X_TICK_TEXT_MARGIN = 0
+const AXIS_HEIGHT = 20
 const LOLLIPOP_PADDING = 7 // half of max pop height
 
 const BAR_STYLES = {
@@ -144,7 +142,6 @@ const BarChart = props => {
     values,
     width,
     mini,
-    children,
     tLabel,
     description,
     band,
@@ -355,7 +352,7 @@ const BarChart = props => {
 
       yPos +=
         height +
-        (hasXTicks ? AXIS_BOTTOM_HEIGHT : 0) +
+        (hasXTicks ? AXIS_HEIGHT : 0) +
         (isLollipop ? LOLLIPOP_PADDING : 0)
     }
   )
@@ -386,15 +383,17 @@ const BarChart = props => {
 
   return (
     <>
+      <ColorLegend inline values={colorLegendValues} />
       <svg width={width} height={yPos}>
         <desc>{description}</desc>
         {groupedData.map(group => {
           return (
             <g
               key={`group${group.title || 1}`}
-              transform={`translate(${group.x},${group.y})`}
+              transform={`translate(${group.x},${group.y +
+                (hasXTicks ? AXIS_HEIGHT : 0)})`}
             >
-              <text dy='1.5em' {...styles.groupTitle}>
+              <text dy='1.5em' y={-AXIS_HEIGHT} {...styles.groupTitle}>
                 {group.title}
               </text>
               {group.bars.map(bar => {
@@ -556,8 +555,9 @@ const BarChart = props => {
               })}
               {hasXTicks && (
                 <g
-                  transform={`translate(0,${group.groupHeight +
-                    AXIS_BOTTOM_PADDING})`}
+                  transform={`translate(0,${
+                    group.title ? COLUMN_TITLE_HEIGHT : 0
+                  })`}
                 >
                   {xTicks.map((tick, i) => {
                     let textAnchor = 'middle'
@@ -576,27 +576,16 @@ const BarChart = props => {
                       >
                         <line
                           {...styles.axisXLine}
-                          y1={
-                            -AXIS_BOTTOM_PADDING -
-                            group.groupHeight +
-                            group.firstBarY -
-                            (isLollipop ? LOLLIPOP_PADDING : 0)
-                          }
-                          y2={
-                            -AXIS_BOTTOM_PADDING +
-                            (isLollipop ? LOLLIPOP_PADDING : 0)
-                          }
+                          y1={0}
+                          y2={group.groupHeight}
                           style={{
                             stroke: highlightTick ? baseLineColor : undefined
                           }}
                         />
                         <text
                           {...styles.axisLabel}
-                          y={
-                            X_TICK_TEXT_MARGIN +
-                            (isLollipop ? LOLLIPOP_PADDING : 0)
-                          }
-                          dy='0.6em'
+                          y={0}
+                          dy='-0.5em'
                           textAnchor={textAnchor}
                           style={{
                             fill: highlightTick ? colors.text : undefined
@@ -613,18 +602,11 @@ const BarChart = props => {
           )
         })}
       </svg>
-      <div
-        style={{ marginTop: !hasXTicks && colorLegendValues.length ? 3 : 0 }}
-      >
-        <ColorLegend inline values={colorLegendValues} />
-        {children}
-      </div>
     </>
   )
 }
 
 export const propTypes = {
-  children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
   mini: PropTypes.bool,

--- a/src/components/Chart/ColorLegend.js
+++ b/src/components/Chart/ColorLegend.js
@@ -10,7 +10,6 @@ const styles = {
     marginBottom: 10
   }),
   inlineContainer: css({
-    marginBottom: 0,
     lineHeight: '12px'
   }),
   title: css({

--- a/src/components/Chart/Hemicycle.docs.md
+++ b/src/components/Chart/Hemicycle.docs.md
@@ -33,7 +33,7 @@ CSP,2011,1
 MCR,2011,1
 SVP,2011,65
     `.trim()} />
-  <Editorial.Note>Quelle: BFS.</Editorial.Note>
+  <ChartLegend>Quelle: BFS.</ChartLegend>
 </div>
 ```
 # Single
@@ -63,7 +63,7 @@ CSP,2015,1
 MCR,2015,1
 SVP,2015,65
     `.trim()} />
-  <Editorial.Note>Quelle: BFS.</Editorial.Note>
+  <ChartLegend>Quelle: BFS.</ChartLegend>
 </div>
 ```
 

--- a/src/components/Chart/Hemicycle.js
+++ b/src/components/Chart/Hemicycle.js
@@ -122,26 +122,25 @@ const Hemicycle = props => {
           })`}
         >
           <g transform={`translate(${w >> 1},${hemicycleOffset})`}>
-            {primaryAngles.map(d => {
+            {primaryAngles.map((d, i) => {
               const datum = primaryVals.find(g => g.label === d[2])
               const fill = color(datum[colorProp])
               return (
-                <>
-                  <path
-                    fill={fill}
-                    d={arc({
-                      outerRadius: outerRadiusPrimary,
-                      innerRadius: innerRadiusPrimary,
-                      startAngle: d[0],
-                      endAngle: d[1] + 0.001
-                    })}
-                  />
-                </>
+                <path
+                  key={`primaryPath${i}`}
+                  fill={fill}
+                  d={arc({
+                    outerRadius: outerRadiusPrimary,
+                    innerRadius: innerRadiusPrimary,
+                    startAngle: d[0],
+                    endAngle: d[1] + 0.001
+                  })}
+                />
               )
             })}
             {primaryAngles
               .filter((d, i) => primaryVals[i].value >= inlineLabelThreshold)
-              .map(d => {
+              .map((d, i) => {
                 const isMajorParty = Math.abs(d[1] - d[0]) > MAX_ARC / 10
                 const datum = primaryVals.find(g => g.label === d[2])
                 const fill = color(datum[colorProp])
@@ -164,7 +163,7 @@ const Hemicycle = props => {
                     : 'start'
 
                 return (
-                  <g transform={`translate(${x},${y})`}>
+                  <g key={`primaryText${i}`} transform={`translate(${x},${y})`}>
                     <text
                       {...styles.label}
                       x={0}
@@ -188,21 +187,20 @@ const Hemicycle = props => {
                   </g>
                 )
               })}
-            {secondaryAngles.map(d => {
+            {secondaryAngles.map((d, i) => {
               const datum = secondaryVals.find(g => g.label === d[2])
               const fill = color(datum[colorProp])
               return (
-                <>
-                  <path
-                    fill={fill}
-                    d={arc({
-                      outerRadius: outerRadiusSecondary,
-                      innerRadius: innerRadiusSecondary,
-                      startAngle: d[0],
-                      endAngle: d[1] + 0.001
-                    })}
-                  />
-                </>
+                <path
+                  key={`secondaryPath${i}`}
+                  fill={fill}
+                  d={arc({
+                    outerRadius: outerRadiusSecondary,
+                    innerRadius: innerRadiusSecondary,
+                    startAngle: d[0],
+                    endAngle: d[1] + 0.001
+                  })}
+                />
               )
             })}
           </g>

--- a/src/components/Chart/Hemicycle.js
+++ b/src/components/Chart/Hemicycle.js
@@ -254,7 +254,8 @@ export const propTypes = {
   values: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
-      value: PropTypes.number.isRequired
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired
     })
   ).isRequired
 }

--- a/src/components/Chart/Lines.docs.md
+++ b/src/components/Chart/Lines.docs.md
@@ -91,7 +91,7 @@ year,gender,at_age,value
 2014,Total,0,80.92
 2015,Total,0,80.57
     `.trim()} />
-  <Editorial.Note>Quelle: <Editorial.A href='http://www.humanmortality.de/'>Human Mortality Database</Editorial.A>. University of California, Berkeley (USA) und Max-Planck-Institut </Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href='http://www.humanmortality.de/'>Human Mortality Database</Editorial.A>. University of California, Berkeley (USA) und Max-Planck-Institut </ChartLegend>
 </div>
 ```
 
@@ -476,7 +476,7 @@ date,value
 2018-02-23,10162.116666666667
 2018-02-24,9697.956
     `.trim()} />
-  <Editorial.Note>Quelle: blockchain.info</Editorial.Note>
+  <ChartLegend>Quelle: blockchain.info</ChartLegend>
 </div>
 ```
 
@@ -570,10 +570,10 @@ Gesamt,2012,7.00601,6.94204,7.06998
 Gesamt,2013,7.05254,7.00163,7.10346
 Gesamt,2014,7.13645,7.11445,7.15846
     `.trim()} />
-  <Editorial.Note>
+  <ChartLegend>
     Quelle: Berechnungen des DIW Berlin, SOEPv32.1.<br />
     Die Arbeitszufriedenheit wird auf einer Skala von 0 (sehr unzufrieden) bis 10 (sehr zufrieden) gemessen.
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 
@@ -5715,9 +5715,9 @@ inc,group,category,value
 1000000,neu ,Mittelstandsinitiative,0.117
     `.trim()}
   />
-  <Editorial.Note>
+  <ChartLegend>
     Steuerbelastung für Allein­stehende bei der einfachen Staats­steuer inklusive Kirchen­steuer. Lesebeispiel: Bei einem steuer­baren Einkommen von 200’000 Franken beträgt der Steuer­tarif 8,9 Prozent. Quelle: <Editorial.A href="https://wahlen-abstimmungen.zh.ch/internet/justiz_inneres/wahlen-abstimmungen/de/service/shared/aktuelle-abstimmung/2-aktuelle-abstimmung-kantonal/_jcr_content/contentPar/downloadlist/downloaditems/2205_1544179949713.spooler.download.1576484211868.pdf/Abstimmungszeitung_9_Februar_2020.pdf">Kanton Zürich</Editorial.A>
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 
@@ -5997,9 +5997,9 @@ year,category,value
 2018,Konsumentenpeise,730.1
     `.trim()}
     />
-  <Editorial.Note>
+  <ChartLegend>
     Quelle: BFS
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 
@@ -6110,8 +6110,8 @@ bereits Infizierte,2020-03-15,12726,12726,12726
 bereits Infizierte,2020-03-16,13801,13801,13801
     `.trim()}
     />
-  <Editorial.Note>
+  <ChartLegend>
     Quelle: BAG Situationsberichtes als XLS bis zum 26. März (aufsummiert, Stand 29. March 08:00)
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```

--- a/src/components/Chart/Lines.docs.md
+++ b/src/components/Chart/Lines.docs.md
@@ -484,6 +484,8 @@ date,value
 
 Use a `band` column base name with `_lower` and `_upper` data to display bands, e.g. confidence intervals, around your lines.
 
+Also note: When values are too close for clear differentiation a color circle is shown before the end value and label.
+
 ```react
 <div>
   <ChartTitle>Entwicklung der Arbeitszufriedenheit nach Einkommensgruppen</ChartTitle>
@@ -581,6 +583,8 @@ Gesamt,2014,7.13645,7.11445,7.15846
 
 Use a `"xScale": "ordinal"` to display values not representable as JavaScript dates, e.g. going back 500’000 years. Use `"xSort": "none"` if the data is already sorted.
 
+End values can be disabled with `"endValue": false`. Should only be done when the value is truely irrelevant.
+
 ```react
 <div>
   <ChartTitle>Sonneneinstrahlung</ChartTitle>
@@ -593,7 +597,8 @@ Use a `"xScale": "ordinal"` to display values not representable as JavaScript da
       "xScale": "ordinal",
       "xSort": "none",
       "xTicks": ["-500k", "-250k", "0"],
-      "color": "label"
+      "color": "label",
+      "endValue": false
     }}
     values={`
 year,value

--- a/src/components/Chart/Lines.docs.md
+++ b/src/components/Chart/Lines.docs.md
@@ -583,7 +583,7 @@ Gesamt,2014,7.13645,7.11445,7.15846
 
 Use a `"xScale": "ordinal"` to display values not representable as JavaScript dates, e.g. going back 500’000 years. Use `"xSort": "none"` if the data is already sorted.
 
-End values can be disabled with `"endValue": false`. Should only be done when the value is truely irrelevant.
+End values can be disabled with `"endValue": false`. Should only be done when the value is truly irrelevant.
 
 ```react
 <div>

--- a/src/components/Chart/Lines.docs.md
+++ b/src/components/Chart/Lines.docs.md
@@ -6053,7 +6053,7 @@ Also if you have multiple charts after each other with varying end labels you ca
         "2020-03-26"
       ],
       "endLabelWidth": 160,
-      "paddingTop": 10,
+      "paddingTop": 8,
       "xAnnotations": [
         {
           "x1": "2020-03-16",

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -444,7 +444,7 @@ LineGroup.propTypes = {
 }
 
 const LineChart = props => {
-  const { width, mini, children, description, band, bandLegend, endDy } = props
+  const { width, mini, description, band, bandLegend, endDy } = props
 
   const {
     data,
@@ -550,8 +550,27 @@ const LineChart = props => {
       })
     )
 
+  const visibleColorLegendValues = []
+    .concat(props.colorLegend !== false && colorLegend && colorLegendValues)
+    .concat(
+      !mini &&
+        band &&
+        bandLegend && {
+          label: (
+            <span {...styles.bandLegend}>
+              <span {...styles.bandBar} />
+              {` ${bandLegend}`}
+            </span>
+          )
+        }
+    )
+    .filter(Boolean)
+
   return (
-    <div>
+    <>
+      <div style={{ paddingLeft, paddingRight }}>
+        <ColorLegend inline values={visibleColorLegendValues} />
+      </div>
       <svg
         width={width}
         height={rows * columnHeight + (rows - 1) * Y_GROUP_MARGIN}
@@ -588,37 +607,11 @@ const LineChart = props => {
           )
         })}
       </svg>
-      <div>
-        <div style={{ paddingLeft, paddingRight }}>
-          <ColorLegend
-            inline
-            values={[]
-              .concat(
-                props.colorLegend !== false && colorLegend && colorLegendValues
-              )
-              .concat(
-                !mini &&
-                  band &&
-                  bandLegend && {
-                    label: (
-                      <span {...styles.bandLegend}>
-                        <span {...styles.bandBar} />
-                        {` ${bandLegend}`}
-                      </span>
-                    )
-                  }
-              )
-              .filter(Boolean)}
-          />
-        </div>
-        {children}
-      </div>
-    </div>
+    </>
   )
 }
 
 export const propTypes = {
-  children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
   mini: PropTypes.bool,

--- a/src/components/Chart/Lollipops.docs.md
+++ b/src/components/Chart/Lollipops.docs.md
@@ -24,7 +24,7 @@ Altersgruppen,55-64 Jahre,2014,0.132,0.112,0.151
 Altersgruppen,65-74 Jahre,2014,0.141,0.110,0.171
 Altersgruppen,über 74 Jahre,2014,0.133,0.120,0.146
     `.trim()} />
-  <Editorial.Note>Quelle: Berechnungen des DIW Berlin, SOEPv32.1.</Editorial.Note>
+  <ChartLegend>Quelle: Berechnungen des DIW Berlin, SOEPv32.1.</ChartLegend>
 </div>
 ```
 

--- a/src/components/Chart/Maps.docs.md
+++ b/src/components/Chart/Maps.docs.md
@@ -26,7 +26,7 @@ lat,lon,name
 39.933333,116.383333,"Peking"
 49.28098,-123.12244,"Vancouver"
 `.trim()} />
-  <Editorial.Note>Geobasis: <Editorial.A href="https://github.com/topojson/world-atlas">World Atlas TopoJSON</Editorial.A></Editorial.Note>
+  <ChartLegend>Geobasis: <Editorial.A href="https://github.com/topojson/world-atlas">World Atlas TopoJSON</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -153,7 +153,7 @@ lat,lon,name
       113.4872,22.92145,"Guangzhou",6.1392,"China"
       126.9629,37.48175,"Seoul",12.989,"South Korea"
     `.trim()} />
-  <Editorial.Note>Geobasis: <Editorial.A href="https://github.com/topojson/world-atlas">World Atlas TopoJSON</Editorial.A></Editorial.Note>
+  <ChartLegend>Geobasis: <Editorial.A href="https://github.com/topojson/world-atlas">World Atlas TopoJSON</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -364,7 +364,7 @@ feature,value
 894,63
 716,59.05
     `.trim()} />
-  <Editorial.Note>Geobasis: <Editorial.A href="https://github.com/topojson/world-atlas">World Atlas TopoJSON</Editorial.A></Editorial.Note>
+  <ChartLegend>Geobasis: <Editorial.A href="https://github.com/topojson/world-atlas">World Atlas TopoJSON</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -439,7 +439,7 @@ npx -p topojson geo2topo -q 1e5 nuts=nuts-projected-clean.json cb=nuts-compositi
       }
     }}
     values={''} />
-  <Editorial.Note>Geobasis: <Editorial.A href="https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/nuts">NUTS 2016 20M L2</Editorial.A></Editorial.Note>
+  <ChartLegend>Geobasis: <Editorial.A href="https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/nuts">NUTS 2016 20M L2</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -513,7 +513,7 @@ npx -p topojson toposimplify -p 1 < nuts-topo.json > nuts2013-20m-l2-custom-gdp.
       }
     }}
     values={data.nuts13mCHdGDP} />
-  <Editorial.Note>Quelle: Eurostat. Das BIP pro Kopf ist nach Kaufkraft bereinigt. Geobasis: <Editorial.A href="https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/nuts">NUTS 2013 20M L2</Editorial.A>, ohne entlegene Gebiete, fusionierte Schweiz</Editorial.Note>
+  <ChartLegend>Quelle: Eurostat. Das BIP pro Kopf ist nach Kaufkraft bereinigt. Geobasis: <Editorial.A href="https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/nuts">NUTS 2013 20M L2</Editorial.A>, ohne entlegene Gebiete, fusionierte Schweiz</ChartLegend>
 </div>
 ```
 
@@ -606,7 +606,7 @@ MK,Nord Mazedonien,
 RO,Rumänien,
 RS,Serbien,
     `.trim()} />
-  <Editorial.Note>Geobasis: <Editorial.A href="https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/countries">Eurostat Countries 2016 20M</Editorial.A></Editorial.Note>
+  <ChartLegend>Geobasis: <Editorial.A href="https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/countries">Eurostat Countries 2016 20M</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -747,7 +747,7 @@ NE,0.309
 GE,0.322
 JU,0.257
     `.trim()} />
-  <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20140518/can584.html">Bundeskanzlei</Editorial.A></Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20140518/can584.html">Bundeskanzlei</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -799,7 +799,7 @@ NE,0.309
 GE,0.322
 JU,0.257
     `.trim()} />
-  <Editorial.Note>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20140518/can584.html">Bundeskanzlei</Editorial.A></Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href="https://www.bk.admin.ch/ch/d/pore/va/20140518/can584.html">Bundeskanzlei</Editorial.A></ChartLegend>
 </div>
 ```
 
@@ -823,6 +823,6 @@ JU,0.257
       }
     }}
     values={data.mun} />
-  <Editorial.Note>Quelle: <Editorial.A href="https://www.haupt.ch/Verlag/Buecher/Natur/Umwelt-Oekologie/Zersiedelung-messen-und-begrenzen.html">Fachbuch «Zersiedelung messen und begrenzen»</Editorial.A>, <Editorial.A href="https://www.bfs.admin.ch/bfs/de/home/dienstleistungen/geostat/geodaten-bundesstatistik/administrative-grenzen/generalisierte-gemeindegrenzen.html">BFS</Editorial.A></Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href="https://www.haupt.ch/Verlag/Buecher/Natur/Umwelt-Oekologie/Zersiedelung-messen-und-begrenzen.html">Fachbuch «Zersiedelung messen und begrenzen»</Editorial.A>, <Editorial.A href="https://www.bfs.admin.ch/bfs/de/home/dienstleistungen/geostat/geodaten-bundesstatistik/administrative-grenzen/generalisierte-gemeindegrenzen.html">BFS</Editorial.A></ChartLegend>
 </div>
 ```

--- a/src/components/Chart/Maps.docs.md
+++ b/src/components/Chart/Maps.docs.md
@@ -480,7 +480,7 @@ npx -p topojson toposimplify -p 1 < nuts-topo.json > nuts2013-20m-l2-custom-gdp.
 ```react
 <div>
   <ChartTitle>Zentraleuropäischer Wohlstandsgürtel</ChartTitle>
-  <ChartLead>2016 BIP pro Kopf nach Regionen</ChartLead>
+  <ChartLead>2016 nach Regionen</ChartLead>
   <CsvChart
     config={{
       "type": "ProjectedMap",

--- a/src/components/Chart/Maps.js
+++ b/src/components/Chart/Maps.js
@@ -317,7 +317,6 @@ export class GenericMap extends Component {
     const { props, state } = this
     const {
       width,
-      children,
       mini,
       tLabel,
       description,
@@ -379,6 +378,21 @@ export class GenericMap extends Component {
 
     return (
       <div style={{ position: 'relative' }}>
+        <div style={legendStyle}>
+          {!!props.geotiffLegendTitle && (
+            <ColorLegend
+              title={tLabel(props.geotiffLegendTitle)}
+              values={props.geotiffLegend}
+            />
+          )}
+          {!!props.colorLegend && (
+            <ColorLegend
+              title={tLabel(props.legendTitle)}
+              shape={props.shape}
+              values={colorLegendValues}
+            />
+          )}
+        </div>
         <svg width={width} height={columnHeight * rows}>
           <desc>{description}</desc>
           {groupedData.map(({ values: groupData, key: title }) => {
@@ -502,24 +516,6 @@ export class GenericMap extends Component {
             <Loader loading={loading} error={error} />
           </div>
         )}
-        <div>
-          <div style={legendStyle}>
-            {!!props.geotiffLegendTitle && (
-              <ColorLegend
-                title={tLabel(props.geotiffLegendTitle)}
-                values={props.geotiffLegend}
-              />
-            )}
-            {!!props.colorLegend && (
-              <ColorLegend
-                title={tLabel(props.legendTitle)}
-                shape={props.shape}
-                values={colorLegendValues}
-              />
-            )}
-          </div>
-          {children}
-        </div>
         {hasTooltips && this.renderTooltips()}
         {this.renderPointTooltip()}
       </div>
@@ -537,7 +533,6 @@ const featuresShape = PropTypes.shape({
 })
 
 export const propTypes = {
-  children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
   // full width map, dynamic height

--- a/src/components/Chart/ScatterPlots.docs.md
+++ b/src/components/Chart/ScatterPlots.docs.md
@@ -218,9 +218,9 @@ Yemen,3770,0.865,Asia
 Zambia,3630,0.288,Africa
 Zimbabwe,1910,0.78,Africa
       `.trim()} />
-  <Editorial.Note style={{marginTop: 10}}>
+  <ChartLegend>
     Quelle: <Editorial.A href='https://gapm.io/dgdppc'>Gapminder</Editorial.A> basierend auf World Bank, A. Maddison, M. Lindgren, IMF & mehr (Einkommen) und <Editorial.A href='http://cdiac.ess-dive.lbl.gov/trends/emis/meth_reg.html'>CDIAC</Editorial.A> (CO<Sub>2</Sub>)
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 
@@ -299,9 +299,9 @@ year,label,detail,family,position,lrgen,vote_abs,inline_pos,inline,inline_countr
 2017,Bürgerlich–Demokratische Partei,"Schweiz
 0,10 Mio. Stimmen im 2015",konservativ,3.625,6.25,103476,bottom,,
       `.trim()} />
-  <Editorial.Note style={{marginTop: 10}}>
+  <ChartLegend>
     Quelle: <Editorial.A href='https://www.chesdata.eu/our-surveys/'>Chapel Hill Expert Survey 2017 und 2014</Editorial.A>, <Editorial.A href='http://www.parlgov.org/'>ParlGov database</Editorial.A>
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 

--- a/src/components/Chart/ScatterPlots.js
+++ b/src/components/Chart/ScatterPlots.js
@@ -205,7 +205,6 @@ class ScatterPlot extends Component {
     const {
       width,
       description,
-      children,
       values,
       tLabel,
       inlineLabelPosition,
@@ -350,8 +349,19 @@ class ScatterPlot extends Component {
 
     const yLinesPaddingLeft = paddingLeft < 2 ? paddingLeft : 0
 
+    const colorLegendValues = []
+      .concat(
+        props.colorLegend &&
+          (props.colorLegendValues || colorValues).map(colorValue => ({
+            color: color(colorValue),
+            label: colorValue
+          }))
+      )
+      .filter(Boolean)
+
     return (
       <div style={{ position: 'relative' }}>
+        <ColorLegend inline values={colorLegendValues} />
         <svg width={width} height={height} ref={this.setContainerRef}>
           <desc>{description}</desc>
           {this.symbols.map((symbol, i) => (
@@ -523,26 +533,12 @@ class ScatterPlot extends Component {
           xFormat: xAxis.format,
           yFormat: yAxis.format
         })}
-        <ColorLegend
-          inline
-          values={[]
-            .concat(
-              props.colorLegend &&
-                (props.colorLegendValues || colorValues).map(colorValue => ({
-                  color: color(colorValue),
-                  label: colorValue
-                }))
-            )
-            .filter(Boolean)}
-        />
-        {children}
       </div>
     )
   }
 }
 
 export const propTypes = {
-  children: PropTypes.node,
   values: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number,

--- a/src/components/Chart/Slopes.docs.md
+++ b/src/components/Chart/Slopes.docs.md
@@ -23,7 +23,7 @@ year,gender,at_age,value
 1990,Total,0,75.35
 2015,Total,0,80.57
     `.trim()} />
-  <Editorial.Note>Quelle: <Editorial.A href='http://www.humanmortality.de/'>Human Mortality Database</Editorial.A>. University of California, Berkeley (USA) und Max-Planck-Institut </Editorial.Note>
+  <ChartLegend>Quelle: <Editorial.A href='http://www.humanmortality.de/'>Human Mortality Database</Editorial.A>. University of California, Berkeley (USA) und Max-Planck-Institut </ChartLegend>
 </div>
 ```
 

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -229,7 +229,6 @@ By default a four digit year column is expected. Use `x`, `timeParse` and `timeF
   <CsvChart
     config={{
       "type": "TimeBar",
-      "color": "bilanzposition",
       "numberFormat": ".3s",
       "unit": "",
       "x": "date",

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -209,13 +209,11 @@ Stickstofftrifluorid,2014,20278.8000
 Stickstofftrifluorid,2015,11885.2000
 Stickstofftrifluorid,2016,12000.0000
     `.trim()} />
-  <Editorial.Note style={{marginTop: 10, marginBottom: 0}}>
-    *ohne Kohlendioxid aus Landnutzung, Landnutzungsänderungen und Forstwirtschaft. Daten für 2016 sind vorläufig.
-  </Editorial.Note>
-  <Editorial.Note style={{marginTop: 10}}>
+  <ChartLegend>
+    *ohne Kohlendioxid aus Landnutzung, Landnutzungsänderungen und Forstwirtschaft. Daten für 2016 sind vorläufig.<br />
     Quelle: Umweltbundesamt, Nationale Treibhausgas-Inventare 1990 bis 2015 (Stand 02/2017) und Schätzung für 2016 (Stand 03/2017).
     <br /><Editorial.A href='https://creativecommons.org/licenses/by-nc-nd/4.0/deed.de'>CC BY-NC-ND 4.0 Bundesregierung</Editorial.A>
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 
@@ -454,9 +452,9 @@ date,bilanzposition,value
 2018-01,Devisenanlagen,790125000000
 2018-02,Devisenanlagen,759715000000
     `.trim()} />
-  <Editorial.Note style={{marginTop: 10}}>
+  <ChartLegend>
     Quelle: SNB
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```
 
@@ -510,9 +508,9 @@ year,value,type
 2015,2337300888.72,Überschuss
 2016,751559663.61,Überschuss
     `.trim()} />
-  <Editorial.Note style={{marginTop: 10}}>
+  <ChartLegend>
     Quelle: <Editorial.A href='https://www.efv.admin.ch/efv/de/home/finanzberichterstattung/bundeshaushalt_ueb/stat_kennz_bundeshh.html'>Eidgenössische Finanzverwaltung</Editorial.A>
-  </Editorial.Note>
+  </ChartLegend>
 
 </div>
 ```
@@ -745,8 +743,8 @@ year,value,color
 2019,0.023,positiv
 2020,-0.056,negativ
     `.trim()} />
-  <Editorial.Note style={{marginTop: 10}}>
+  <ChartLegend>
     Quellen: <Editorial.A href='https://apps.bea.gov/iTable/iTable.cfm?reqid=19&step=2#reqid=19&step=2&isuri=1&1921=survey'>Bureau of Economic Analysis (BEA)</Editorial.A>, <Editorial.A href='https://www.cbo.gov/publication/56335'>CBO</Editorial.A>
-  </Editorial.Note>
+  </ChartLegend>
 </div>
 ```

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -97,7 +97,6 @@ const TimeBarChart = props => {
     values,
     width,
     mini,
-    children,
     tLabel,
     description,
     yAnnotations,
@@ -150,7 +149,13 @@ const TimeBarChart = props => {
     .domain(
       props.domain
         ? props.domain
-        : [Math.min(0, min(bars, d => d.down)), max(bars, d => d.up)]
+        : [
+            Math.min(
+              0,
+              min(bars, d => d.down)
+            ),
+            max(bars, d => d.up)
+          ]
     )
     .range([innerHeight, 0])
 
@@ -286,8 +291,19 @@ const TimeBarChart = props => {
 
   const xFormat = timeFormat(props.timeFormat || props.timeParse)
 
+  const colorLegendValues = []
+    .concat(
+      props.colorLegend &&
+        (props.colorLegendValues || colorValues).map(colorValue => ({
+          color: color(colorValue),
+          label: tLabel(colorValue)
+        }))
+    )
+    .filter(Boolean)
+
   return (
-    <div>
+    <>
+      <ColorLegend inline values={colorLegendValues} />
       <svg width={width} height={innerHeight + paddingTop + AXIS_BOTTOM_HEIGHT}>
         <desc>{description}</desc>
         <g transform={`translate(0,${paddingTop})`}>
@@ -479,29 +495,11 @@ const TimeBarChart = props => {
           })}
         </g>
       </svg>
-      <div>
-        {!mini && (
-          <ColorLegend
-            inline
-            values={[]
-              .concat(
-                props.colorLegend &&
-                  (props.colorLegendValues || colorValues).map(colorValue => ({
-                    color: color(colorValue),
-                    label: tLabel(colorValue)
-                  }))
-              )
-              .filter(Boolean)}
-          />
-        )}
-        {children}
-      </div>
-    </div>
+    </>
   )
 }
 
 export const propTypes = {
-  children: PropTypes.node,
   values: PropTypes.array.isRequired,
   padding: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -20,6 +20,7 @@ import {
   sansSerifRegular19
 } from '../Typography/styles'
 import { fontRule } from '../Typography/Interaction'
+import { Note } from '../Typography/Editorial'
 import { convertStyleToRem, pxToRem } from '../Typography/utils'
 
 export const ReactCharts = {
@@ -91,6 +92,10 @@ export const ChartLead = ({ children, ...props }) => (
   <p {...props} {...styles.p} {...fontRule}>
     {children}
   </p>
+)
+
+export const ChartLegend = ({ children, ...props }) => (
+  <Note style={{ marginTop: 15 }}>{children}</Note>
 )
 
 class Chart extends Component {

--- a/src/index.js
+++ b/src/index.js
@@ -748,6 +748,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -760,6 +761,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -772,6 +774,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -784,6 +787,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -796,6 +800,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -808,6 +813,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -821,6 +827,7 @@ ReactDOM.render(
                 data: { ...require('./components/Chart/Maps.docs.data') },
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },
@@ -833,6 +840,7 @@ ReactDOM.render(
                 ...require('./components/Typography'),
                 ChartTitle: require('./components/Chart').ChartTitle,
                 ChartLead: require('./components/Chart').ChartLead,
+                ChartLegend: require('./components/Chart').ChartLegend,
                 CsvChart: require('./components/Chart/Csv'),
                 t
               },

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -11,7 +11,7 @@ import * as Scribble from '../../components/Typography/Scribble'
 import { TeaserFeed } from '../../components/TeaserFeed'
 import IllustrationHtml from '../../components/IllustrationHtml'
 import CsvChart from '../../components/Chart/Csv'
-import { ChartTitle, ChartLead } from '../../components/Chart'
+import { ChartTitle, ChartLead, ChartLegend } from '../../components/Chart'
 import ErrorBoundary from '../../components/ErrorBoundary'
 
 import { Figure, CoverTextTitleBlockHeadline } from '../../components/Figure'
@@ -570,10 +570,8 @@ const createSchema = ({
                   {
                     matchMdast: (node, index, parent) =>
                       matchParagraph(node) && matchLast(node, index, parent),
-                    component: Editorial.Note,
-                    props: () => ({
-                      style: { marginTop: 10 }
-                    }),
+                    component: ChartLegend,
+                    props: () => ({}),
                     editorModule: 'paragraph',
                     editorOptions: {
                       type: 'CHARTNOTE',


### PR DESCRIPTION
Changes
- lines: remove y connector lines
- lines:use y connector circles when necessary (more than one label has been moved from the center of the line)
- lines: support `"endValue": false`. Should only be done when the value is truly irrelevant.
- all: up color legend before chart, except for hemicycle where the color legend only contains values that are below the display threshold
- bars: move x axis label on top too
- all: clean up

### Before and After Screenshots

#### Lines

<img width="1509" alt="Screenshot 2020-10-09 at 09 15 05" src="https://user-images.githubusercontent.com/410211/95555561-464be480-0a12-11eb-9095-bbb8253e0452.png">

<img width="1515" alt="Screenshot 2020-10-09 at 09 15 45" src="https://user-images.githubusercontent.com/410211/95555596-54016a00-0a12-11eb-9f0f-6a82338865fc.png">

<img width="1516" alt="Screenshot 2020-10-09 at 09 16 32" src="https://user-images.githubusercontent.com/410211/95555613-5cf23b80-0a12-11eb-8a0d-46368ffecedd.png">

#### All

<img width="1514" alt="Screenshot 2020-10-09 at 09 13 48" src="https://user-images.githubusercontent.com/410211/95555681-71363880-0a12-11eb-9d80-bc2059462a94.png">
<img width="1507" alt="Screenshot 2020-10-09 at 09 17 23" src="https://user-images.githubusercontent.com/410211/95555689-74312900-0a12-11eb-80ad-be09c9aaee03.png">
<img width="850" alt="Screenshot 2020-10-09 at 09 19 24" src="https://user-images.githubusercontent.com/410211/95555692-75625600-0a12-11eb-92e0-066769db649b.png">

#### Bars

<img width="1508" alt="Screenshot 2020-10-09 at 09 13 10" src="https://user-images.githubusercontent.com/410211/95555709-7b583700-0a12-11eb-9155-df7cc0fd5b94.png">
