### PR TITLE
fix(colors): revert secondary

### DIFF
--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -24,6 +24,7 @@ const colorsDeprecated = {
   primary: '#00508C',
   primaryBg: '#BFE1FF',
   containerBg: '#FFF',
+  secondary: '#00335A',
   secondaryBg: '#D8EEFF',
   disabled: '#B8BDC1',
   text: '#191919',
@@ -78,8 +79,7 @@ const colorsDeprecated = {
     error: 'rgb(239,69,51)',
     disabled: '#242424'
   },
-  ...getJson('COLORS'),
-  secondary: '#009200'
+  ...getJson('COLORS')
 }
 
 // ToDos


### PR DESCRIPTION
Reverts the secondary color to previous version. Replacing everything with textSoft is too risky IMO and could lead to unwanted consequences. We need to look at individual usecases in components and look at "why is it necessary that it's secondary" and then choose either text, textSoft, primary or disabled for each case. 