### PR TITLE
fix(Tweet): wordwrap

### DIFF
--- a/src/components/Social/Tweet.js
+++ b/src/components/Social/Tweet.js
@@ -32,7 +32,8 @@ const styles = {
     [mUp]: {
       ...convertStyleToRem(sansSerifRegular18)
     },
-    '& a': linkStyle
+    wordWrap: 'break-word',
+    '& a': { linkStyle }
   }),
   mediaContainer: css({
     display: 'inline-block',

--- a/src/components/Social/docs.md
+++ b/src/components/Social/docs.md
@@ -18,7 +18,7 @@ Supported props:
   userName='Christof Moser'
   userScreenName='@christof_moser'
   date={new Date(2017, 11, 15)}
-  html='One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections.'
+  html='One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. https://twitter.com/RepublikMagazin/status/869979987276742656'
 />
 ```
 


### PR DESCRIPTION
before:
![Screenshot 2020-11-03 at 13 00 34](https://user-images.githubusercontent.com/20746301/97982879-b3198b00-1dd4-11eb-9abf-97d202d47bad.jpg)

after:
![Screenshot 2020-11-03 at 13 00 21](https://user-images.githubusercontent.com/20746301/97982884-b4e34e80-1dd4-11eb-9727-355c2369e621.jpg)

