### PR TITLE
Dark Mode Round 99

### DIFF
--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -248,6 +248,11 @@ If needed this can be overwritten with a custom `inlineLabelPosition`. Valid val
       "colorRange": [
         "#fdd49e", "#fdbb84", "#fc8d59"
       ],
+      "colorMapDark": {
+        "#fdd49e": "#807dba",
+        "#fdbb84": "#6a51a3",
+        "#fc8d59": "#54278f"
+      },
       "inlineValue": true,
       "inlineLabel": "label",
       "inlineLabelPosition": "pos"
@@ -270,5 +275,50 @@ Verzicht auf 8 bis 15 Stunden Flug pro Jahr,-2074,a,center
 Verzicht auf ca. 3500 Kilometer mit ÖV,-79,a,
     `.trim()} />
 </div>
+```
+
+## Dark Colors
+
+Maybe you've noticed the `colorMapDark` above. It can be used to switch out colors when in dark mode. This is how it looks when forced into dark:
+
+```react|dark
+<ColorContextProvider colorSchemeKey='dark'>
+  <CsvChart
+    config={{
+      "type": "Bar",
+      "y": "category",
+      "sort": "none",
+      "colorSort": "none",
+      "color": "label",
+      "colorRange": [
+        "#fdd49e", "#fdbb84", "#fc8d59"
+      ],
+      "colorMapDark": {
+        "#fdd49e": "#807dba",
+        "#fdbb84": "#6a51a3",
+        "#fc8d59": "#54278f"
+      },
+      "inlineValue": true,
+      "inlineLabel": "label",
+      "inlineLabelPosition": "pos"
+    }}
+    values={`
+category,value,label,pos
+Ca. 3500 Kilometer mehr mit ÖV,79,a,
+8 bis 15 Stunden mehr Flug pro Jahr,2074,a,center
+9 bis 16 Stunden mehr Flug pro Jahr,2074,a,
+9 bis 16 Stunden mehr Flug pro Jahr,200,b,
+10 bis 16 Stunden mehr Flug pro Jahr,2074,a,
+10 bis 16 Stunden mehr Flug pro Jahr,200,b,right
+10 bis 16 Stunden mehr Flug pro Jahr,200,c,left
+Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-2074,a,
+Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-200,b,left
+Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-200,c,right
+Verzicht auf 9 bis 16 Stunden Flug pro Jahr,-2074,a,
+Verzicht auf 9 bis 16 Stunden Flug pro Jahr,-200,b,
+Verzicht auf 8 bis 15 Stunden Flug pro Jahr,-2074,a,center
+Verzicht auf ca. 3500 Kilometer mit ÖV,-79,a,
+    `.trim()} />
+</ColorContextProvider>
 ```
 

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -248,7 +248,7 @@ If needed this can be overwritten with a custom `inlineLabelPosition`. Valid val
       "colorRange": [
         "#fdd49e", "#fdbb84", "#fc8d59"
       ],
-      "colorMapDark": {
+      "colorDarkMapping": {
         "#fdd49e": "#807dba",
         "#fdbb84": "#6a51a3",
         "#fc8d59": "#54278f"
@@ -279,7 +279,7 @@ Verzicht auf ca. 3500 Kilometer mit ÖV,-79,a,
 
 ## Dark Colors
 
-Maybe you've noticed the `colorMapDark` above. It can be used to switch out colors when in dark mode. This is how it looks when forced into dark:
+Maybe you've noticed the `colorDarkMapping` above. It can be used to switch out colors when in dark mode. This is how it looks when forced into dark:
 
 ```react|dark
 <ColorContextProvider colorSchemeKey='dark'>
@@ -293,7 +293,7 @@ Maybe you've noticed the `colorMapDark` above. It can be used to switch out colo
       "colorRange": [
         "#fdd49e", "#fdbb84", "#fc8d59"
       ],
-      "colorMapDark": {
+      "colorDarkMapping": {
         "#fdd49e": "#807dba",
         "#fdbb84": "#6a51a3",
         "#fc8d59": "#54278f"

--- a/src/components/Chart/ColorLegend.js
+++ b/src/components/Chart/ColorLegend.js
@@ -72,7 +72,7 @@ const ColorLegend = ({ title, shape, values, maxWidth, inline }) => {
                   styles.color,
                   styles[shape === 'square' ? 'square' : 'circle']
                 )}
-                style={{ backgroundColor: value.color }}
+                {...colorScheme.set('backgroundColor', value.color, 'charts')}
               />
             )}
             {text}{' '}

--- a/src/components/Chart/Hemicycle.js
+++ b/src/components/Chart/Hemicycle.js
@@ -134,7 +134,7 @@ const Hemicycle = props => {
               return (
                 <path
                   key={`primaryPath${i}`}
-                  fill={fill}
+                  {...colorScheme.set('fill', fill, 'charts')}
                   d={arc({
                     outerRadius: outerRadiusPrimary,
                     innerRadius: innerRadiusPrimary,
@@ -203,7 +203,7 @@ const Hemicycle = props => {
               return (
                 <path
                   key={`secondaryPath${i}`}
-                  fill={fill}
+                  {...colorScheme.set('fill', fill, 'charts')}
                   d={arc({
                     outerRadius: outerRadiusSecondary,
                     innerRadius: innerRadiusSecondary,

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -227,7 +227,7 @@ const LineGroup = props => {
                       cx={startX - Y_CONNECTOR_PADDING - Y_CONNECTOR / 2}
                       cy={startLabelY + 0.5}
                       r={Y_CONNECTOR / 2}
-                      fill={lineColor}
+                      {...colorScheme.set('fill', lineColor, 'charts')}
                     />
                   )}
                   <text
@@ -243,7 +243,11 @@ const LineGroup = props => {
                 </g>
               )}
               {band && line.find(d => d.datum[`${band}_lower`]) && (
-                <path fill={lineColor} fillOpacity='0.2' d={bandArea(line)} />
+                <path
+                  {...colorScheme.set('fill', lineColor, 'charts')}
+                  fillOpacity='0.2'
+                  d={bandArea(line)}
+                />
               )}
               <path
                 fill='none'
@@ -259,7 +263,7 @@ const LineGroup = props => {
                       cx={endX + Y_CONNECTOR_PADDING + Y_CONNECTOR / 2}
                       cy={endLabelY + 0.5}
                       r={Y_CONNECTOR / 2}
-                      fill={lineColor}
+                      {...colorScheme.set('fill', lineColor, 'charts')}
                     />
                   )}
                   <text

--- a/src/components/Chart/Maps.js
+++ b/src/components/Chart/Maps.js
@@ -19,14 +19,11 @@ import ContextBox, { ContextBoxValue } from './ContextBox'
 
 import { sansSerifMedium14 } from '../Typography/styles'
 
-import colors from '../../theme/colors'
-
 const FEATURE_BG = '#E0E0E0'
 
 const styles = {
   columnTitle: css({
-    ...sansSerifMedium14,
-    fill: colors.text
+    ...sansSerifMedium14
   }),
   interactivePath: css({
     userSelect: 'none',
@@ -52,7 +49,8 @@ const Points = ({
   sizeRangeMax,
   hoverPoint,
   setHoverPoint,
-  opacity
+  opacity,
+  colorScheme
 }) => {
   const valueAccessor = d => (isNaN(d.value) ? 1 : d.value)
 
@@ -96,7 +94,7 @@ const Points = ({
               <circle
                 cy={-MARKER_HEIGHT}
                 r={MARKER_RADIUS}
-                fill={color}
+                {...colorScheme.set('fill', color, 'charts')}
                 stroke='white'
                 strokeWidth='1'
               />
@@ -104,7 +102,7 @@ const Points = ({
             {marker && (
               <line
                 y2={-MARKER_HEIGHT}
-                stroke={color}
+                {...colorScheme.set('stroke', color, 'charts')}
                 strokeWidth='2'
                 shapeRendering='crispEdges'
               />
@@ -121,7 +119,7 @@ const Points = ({
                 )}
                 <path
                   d={symbolPath(d)}
-                  fill={color}
+                  {...colorScheme.set('fill', color, 'charts')}
                   style={{
                     opacity
                   }}
@@ -324,7 +322,8 @@ export class GenericMap extends Component {
       colorLegendSize,
       colorLegendPosition,
       missingDataColor,
-      opacity
+      opacity,
+      colorScheme
     } = props
     const { loading, error, geoJson, hoverPoint } = state
 
@@ -407,6 +406,7 @@ export class GenericMap extends Component {
                   x={paddingLeft + mapWidth / 2}
                   textAnchor='middle'
                   {...styles.columnTitle}
+                  {...colorScheme.set('fill', 'text')}
                 >
                   {tLabel(title)}
                 </text>
@@ -439,7 +439,7 @@ export class GenericMap extends Component {
                       return (
                         <path
                           key={feature.id}
-                          fill={fill}
+                          {...colorScheme.set('fill', fill, 'charts')}
                           d={feature.path}
                           {...styles.interactivePath}
                           onTouchStart={() =>
@@ -488,6 +488,7 @@ export class GenericMap extends Component {
                   {props.points && (
                     <Points
                       data={data}
+                      colorScheme={colorScheme}
                       colorScale={colorScale}
                       colorAccessor={colorAccessor}
                       domain={domain}
@@ -609,7 +610,7 @@ GenericMap.defaultProps = {
   points: false,
   pointAttributes: [],
   choropleth: false,
-  missingDataColor: colors.divider,
+  missingDataColor: 'divider',
   ignoreMissingFeature: false,
   feature: 'feature',
   shape: 'circle',

--- a/src/components/Chart/ScatterPlots.js
+++ b/src/components/Chart/ScatterPlots.js
@@ -371,7 +371,11 @@ const ScatterPlot = ({
             <circle
               key={symbol.key}
               style={{ opacity }}
-              fill={colorMapper(colorAccessor(symbol.value))}
+              {...colorScheme.set(
+                'fill',
+                colorMapper(colorAccessor(symbol.value)),
+                'charts'
+              )}
               cx={symbol.cx}
               cy={symbol.cy}
               r={symbol.r}

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -310,7 +310,11 @@ const TimeBarChart = props => {
                     width={barWidth}
                     height={segment.height}
                     shapeRendering='crispEdges'
-                    fill={color(colorAccessor(segment))}
+                    {...colorScheme.set(
+                      'fill',
+                      color(colorAccessor(segment)),
+                      'charts'
+                    )}
                   />
                 ))}
               </g>

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -147,6 +147,8 @@ const Chart = props => {
       {!!width && (
         <ReactChart
           {...config}
+          // make colorScheme available for class components—maps
+          colorScheme={colorScheme}
           tLabel={tLabel}
           colorRanges={colorRanges}
           width={width}

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -20,6 +20,7 @@ import { fontRule } from '../Typography/Interaction'
 import { Note } from '../Typography/Editorial'
 import { convertStyleToRem, pxToRem } from '../Typography/utils'
 import { useColorContext } from '../Colors/useColorContext'
+import { ColorContextLocalExtension } from '../Colors/ColorContext'
 
 export const ReactCharts = {
   Bar,
@@ -137,7 +138,31 @@ const Chart = props => {
     }
   }, [fixedWidth])
 
-  return (
+  const colorContextExtension = useMemo(() => {
+    if (!config.colorMapDark) {
+      return null
+    }
+    const keys = Object.keys(config.colorMapDark)
+    return {
+      localColors: keys.reduce(
+        (localColors, key, i) => {
+          localColors.dark[`charts${i}`] = config.colorMapDark[key]
+          localColors.light[`charts${i}`] = key
+          return localColors
+        },
+        { dark: {}, light: {} }
+      ),
+      localMappings: keys.reduce(
+        (mappings, key, i) => {
+          mappings.charts[key] = `charts${i}`
+          return mappings
+        },
+        { charts: {} }
+      )
+    }
+  }, [config])
+
+  const content = (
     <div
       ref={fixedWidth ? undefined : ref}
       style={{
@@ -158,6 +183,16 @@ const Chart = props => {
       )}
     </div>
   )
+
+  if (colorContextExtension) {
+    return (
+      <ColorContextLocalExtension {...colorContextExtension}>
+        {content}
+      </ColorContextLocalExtension>
+    )
+  }
+
+  return content
 }
 
 Chart.propTypes = {

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -118,7 +118,9 @@ const Chart = props => {
   const width = fixedWidth || stateWidth
   const ReactChart = ReactCharts[config.type]
 
-  const colorRanges = useMemo(() => createRanges(colorScheme), [colorScheme])
+  const colorRanges = useMemo(() => createRanges(colorScheme.ranges), [
+    colorScheme
+  ])
 
   const ref = useRef()
   useEffect(() => {

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -141,14 +141,14 @@ const Chart = props => {
   }, [fixedWidth])
 
   const colorContextExtension = useMemo(() => {
-    if (!config.colorMapDark) {
+    if (!config.colorDarkMapping) {
       return null
     }
-    const keys = Object.keys(config.colorMapDark)
+    const keys = Object.keys(config.colorDarkMapping)
     return {
       localColors: keys.reduce(
         (localColors, key, i) => {
-          localColors.dark[`charts${i}`] = config.colorMapDark[key]
+          localColors.dark[`charts${i}`] = config.colorDarkMapping[key]
           localColors.light[`charts${i}`] = key
           return localColors
         },

--- a/src/components/Colors/ColorContext.js
+++ b/src/components/Colors/ColorContext.js
@@ -163,6 +163,34 @@ export const ColorContextLocalExtension = ({
   )
 }
 
+export const ColorHtmlBodyColors = ({ colorSchemeKey = 'auto' }) => {
+  return (
+    <style
+      key={colorSchemeKey}
+      dangerouslySetInnerHTML={{
+        __html:
+          colorSchemeKey === 'auto'
+            ? [
+                // default light
+                `html, body { background-color: ${colors.light.default}; color: ${colors.light.text}; }`,
+                // dark via user preference
+                `html[data-user-color-scheme="dark"], html[data-user-color-scheme="dark"] body { background-color: ${colors.dark.default}; color: ${colors.dark.text}; }`,
+                // os dark preference
+                `@media (prefers-color-scheme: dark) {`,
+                [
+                  // auto dark via media query
+                  `html, body { background-color: ${colors.dark.default}; color: ${colors.dark.text}; }`,
+                  // light via user preference when os is dark
+                  `html[data-user-color-scheme="light"], html[data-user-color-scheme="light"] body { background-color: ${colors.light.default}; color: ${colors.light.text}; }`
+                ].join('\n'),
+                `}`
+              ].join('\n')
+            : `html, body { background-color: ${colors[colorSchemeKey].default}; color: ${colors[colorSchemeKey].text}; }`
+      }}
+    />
+  )
+}
+
 export const ColorContextProvider = ({
   colorSchemeKey = 'auto',
   root = false,
@@ -208,36 +236,29 @@ export const ColorContextProvider = ({
 
   return (
     <ColorContext.Provider value={colorValue}>
-      {root && (
+      {root && colorSchemeKey === 'auto' && (
         <style
           key={colorSchemeKey}
           dangerouslySetInnerHTML={{
-            __html:
-              colorSchemeKey === 'auto'
-                ? [
-                    // default light
-                    `html, body { background-color: ${colors.light.default}; color: ${colors.light.text}; }`,
-                    `:root { ${generateCSSColorDefinitions(colors.light)} }`,
-                    // dark via user preference
-                    `html[data-user-color-scheme="dark"], html[data-user-color-scheme="dark"] body { background-color: ${colors.dark.default}; color: ${colors.dark.text}; }`,
-                    `:root[data-user-color-scheme="dark"] { ${generateCSSColorDefinitions(
-                      colors.dark
-                    )} }`,
-                    // os dark preference
-                    `@media (prefers-color-scheme: dark) {`,
-                    [
-                      // auto dark via media query
-                      `html, body { background-color: ${colors.dark.default}; color: ${colors.dark.text}; }`,
-                      `:root { ${generateCSSColorDefinitions(colors.dark)} }`,
-                      // light via user preference when os is dark
-                      `html[data-user-color-scheme="light"], html[data-user-color-scheme="light"] body { background-color: ${colors.light.default}; color: ${colors.light.text}; }`,
-                      `:root[data-user-color-scheme="light"] { ${generateCSSColorDefinitions(
-                        colors.light
-                      )} }`
-                    ].join('\n'),
-                    `}`
-                  ].join('\n')
-                : `html, body { background-color: ${colorValue.default}; color: ${colorValue.text}; }`
+            __html: [
+              // default light
+              `:root { ${generateCSSColorDefinitions(colors.light)} }`,
+              // dark via user preference
+              `:root[data-user-color-scheme="dark"] { ${generateCSSColorDefinitions(
+                colors.dark
+              )} }`,
+              // os dark preference
+              `@media (prefers-color-scheme: dark) {`,
+              [
+                // auto dark via media query
+                `:root { ${generateCSSColorDefinitions(colors.dark)} }`,
+                // light via user preference when os is dark
+                `:root[data-user-color-scheme="light"] { ${generateCSSColorDefinitions(
+                  colors.light
+                )} }`
+              ].join('\n'),
+              `}`
+            ].join('\n')
           }}
         />
       )}

--- a/src/components/Colors/ColorContext.js
+++ b/src/components/Colors/ColorContext.js
@@ -40,26 +40,28 @@ const createScheme = specificColors => {
     schemeKey: colorDefinitions.schemeKey,
     CSSVarSupport: colorDefinitions.CSSVarSupport,
     colorDefinitions,
-    sequential: [
-      'sequential100',
-      'sequential95',
-      'sequential90',
-      'sequential85',
-      'sequential80',
-      'sequential75',
-      'sequential70',
-      'sequential65',
-      'sequential60',
-      'sequential55',
-      'sequential50'
-    ].map(key => colorDefinitions[key]),
-    sequential3: ['sequential100', 'sequential80', 'sequential60'].map(
-      key => colorDefinitions[key]
-    ),
-    opposite3: ['opposite100', 'opposite80', 'opposite60'].map(
-      key => colorDefinitions[key]
-    ),
-    discrete: colorDefinitions.discrete,
+    ranges: {
+      sequential: [
+        'sequential100',
+        'sequential95',
+        'sequential90',
+        'sequential85',
+        'sequential80',
+        'sequential75',
+        'sequential70',
+        'sequential65',
+        'sequential60',
+        'sequential55',
+        'sequential50'
+      ].map(key => colorDefinitions[key]),
+      sequential3: ['sequential100', 'sequential80', 'sequential60'].map(
+        key => colorDefinitions[key]
+      ),
+      opposite3: ['opposite100', 'opposite80', 'opposite60'].map(
+        key => colorDefinitions[key]
+      ),
+      discrete: colorDefinitions.discrete
+    },
     set: memoize(createColorRule, (...args) => args.join('.')),
     getCSSColor
   }

--- a/src/components/Colors/docs.md
+++ b/src/components/Colors/docs.md
@@ -24,6 +24,8 @@ Force dark mode:
 </ColorContextProvider>
 ```
 
+Be careful with this one: democracy dies in darkness.
+
 You may also only force a section within your React tree by using nested `ColorContextProvider` without the root flag:
 
 ```react
@@ -151,3 +153,108 @@ Instead use a native `span` to set your color:
 ```
 
 Notable exceptions: setting fill on icons. We'll ensure that our icon components always support setting a `fill` via `colorScheme.set` from the outside.
+
+## Local Extensions
+
+E.g. for charts.
+
+```react
+<ColorContextLocalExtension localColors={{
+  light: {
+    chart1: '#007fff'
+  },
+  dark: {
+    chart1: '#ff0099'
+  }
+}} localMappings={{
+  charts: {
+    '#007fff': 'chart1'
+  }
+}}>
+  <GetColorScheme>
+    {(colorScheme) => <>
+      <div
+        {...colorScheme.set('backgroundColor', 'chart1')}
+        style={{
+          width: 40,
+          height: 20
+        }} />
+      <div
+        {...colorScheme.set('backgroundColor', '#007fff', 'charts')}
+        style={{
+          width: 40,
+          height: 20
+        }} />
+    </>}
+  </GetColorScheme>
+</ColorContextLocalExtension>
+```
+
+```react|span-3,dark
+<ColorContextProvider colorSchemeKey='dark'>
+<ColorContextLocalExtension localColors={{
+  light: {
+    chart1: '#007fff'
+  },
+  dark: {
+    chart1: '#ff0099'
+  }
+}} localMappings={{
+  charts: {
+    '#007fff': 'chart1'
+  }
+}}>
+  <GetColorScheme>
+    {(colorScheme) => <>
+      <div
+        {...colorScheme.set('backgroundColor', 'chart1')}
+        style={{
+          width: 40,
+          height: 20
+        }} />
+      <div
+        {...colorScheme.set('backgroundColor', '#007fff', 'charts')}
+        style={{
+          width: 40,
+          height: 20
+        }} />
+    </>}
+  </GetColorScheme>
+</ColorContextLocalExtension>
+</ColorContextProvider>
+```
+
+```react|span-3
+<ColorContextProvider colorSchemeKey='light'>
+<ColorContextLocalExtension localColors={{
+  light: {
+    chart1: '#007fff'
+  },
+  dark: {
+    chart1: '#ff0099'
+  }
+}} localMappings={{
+  charts: {
+    '#007fff': 'chart1'
+  }
+}}>
+  <GetColorScheme>
+    {(colorScheme) => <>
+      <div
+        {...colorScheme.set('backgroundColor', 'chart1')}
+        style={{
+          width: 40,
+          height: 20
+        }} />
+      <div
+        {...colorScheme.set('backgroundColor', '#007fff', 'charts')}
+        style={{
+          width: 40,
+          height: 20
+        }} />
+    </>}
+  </GetColorScheme>
+</ColorContextLocalExtension>
+</ColorContextProvider>
+```
+

--- a/src/components/Colors/useColorContext.js
+++ b/src/components/Colors/useColorContext.js
@@ -1,7 +1,1 @@
-import { useContext } from 'react'
-import ColorContext from './ColorContext'
-
-export const useColorContext = () => {
-  const colorContext = useContext(ColorContext)
-  return [colorContext]
-}
+export { useColorContext } from './ColorContext'

--- a/src/components/Discussion/Internal/Comment/CommentCountIcon.js
+++ b/src/components/Discussion/Internal/Comment/CommentCountIcon.js
@@ -19,17 +19,16 @@ const styles = {
   })
 }
 
-const Icon = ({ size, fill }) => (
+const Icon = ({ size, fill, ...props }) => (
   <svg
     width={size}
     height={size}
     viewBox='0 0 24 24'
     style={{ verticalAlign: 'middle' }}
+    fill='currentColor'
+    {...props}
   >
-    <path
-      d='M9,22A1,1 0 0,1 8,21V18H4A2,2 0 0,1 2,16V4C2,2.89 2.9,2 4,2H20A2,2 0 0,1 22,4V16A2,2 0 0,1 20,18H13.9L10.2,21.71C10,21.9 9.75,22 9.5,22V22H9M10,16V19.08L13.08,16H20V4H4V16H10Z'
-      fill={fill}
-    />
+    <path d='M9,22A1,1 0 0,1 8,21V18H4A2,2 0 0,1 2,16V4C2,2.89 2.9,2 4,2H20A2,2 0 0,1 22,4V16A2,2 0 0,1 20,18H13.9L10.2,21.71C10,21.9 9.75,22 9.5,22V22H9M10,16V19.08L13.08,16H20V4H4V16H10Z' />
   </svg>
 )
 

--- a/src/components/Dossier/Subheader.js
+++ b/src/components/Dossier/Subheader.js
@@ -24,15 +24,12 @@ const styles = {
 
 const Subheader = ({ children, singleColumn }) => {
   const [colorScheme] = useColorContext()
-  const colors = css({
-    color: colorScheme.text
-  })
 
   return (
     <h2
       {...styles.subheader}
       {...(singleColumn ? {} : styles.spaced)}
-      {...colors}
+      {...colorScheme.set('color', 'text')}
     >
       {children}
     </h2>

--- a/src/components/Figure/Caption.js
+++ b/src/components/Figure/Caption.js
@@ -22,12 +22,13 @@ const styles = {
 
 export const Caption = ({ children, attributes }) => {
   const [colorScheme] = useColorContext()
-  const colors = css({
-    color: colorScheme.text
-  })
 
   return (
-    <figcaption {...attributes} {...styles.caption} {...colors}>
+    <figcaption
+      {...attributes}
+      {...styles.caption}
+      {...colorScheme.set('color', 'text')}
+    >
       {children}
     </figcaption>
   )

--- a/src/components/IconButton/index.js
+++ b/src/components/IconButton/index.js
@@ -45,13 +45,13 @@ const IconButton = React.forwardRef(
         <Icon
           {...styles.icon}
           size={ICON_SIZE}
-          fill={fill || colorScheme.text}
+          {...colorScheme.set('fill', fill || 'text')}
         />
         {label && (
           <span
             {...styles.label}
             {...styles.long}
-            style={{ color: fill || colorScheme.text }}
+            {...colorScheme.set('color', fill || 'text')}
           >
             {label}
           </span>
@@ -60,7 +60,7 @@ const IconButton = React.forwardRef(
           <span
             {...styles.label}
             {...styles.short}
-            style={{ color: fill || colorScheme.text }}
+            {...colorScheme.set('color', fill || 'text')}
           >
             {labelShort}
           </span>

--- a/src/components/IconButton/index.js
+++ b/src/components/IconButton/index.js
@@ -17,6 +17,7 @@ const IconButton = React.forwardRef(
       labelShort,
       title,
       fill,
+      fillColorName,
       onClick,
       children,
       style
@@ -26,6 +27,8 @@ const IconButton = React.forwardRef(
     const Element = href ? 'a' : 'button'
     const customStyles = style || null
     const [colorScheme] = useColorContext()
+
+    const fillValue = fill || fillColorName || 'text'
 
     return (
       <Element
@@ -45,13 +48,13 @@ const IconButton = React.forwardRef(
         <Icon
           {...styles.icon}
           size={ICON_SIZE}
-          {...colorScheme.set('fill', fill || 'text')}
+          {...colorScheme.set('fill', fillValue)}
         />
         {label && (
           <span
             {...styles.label}
             {...styles.long}
-            {...colorScheme.set('color', fill || 'text')}
+            {...colorScheme.set('color', fillValue)}
           >
             {label}
           </span>
@@ -60,7 +63,7 @@ const IconButton = React.forwardRef(
           <span
             {...styles.label}
             {...styles.short}
-            {...colorScheme.set('color', fill || 'text')}
+            {...colorScheme.set('color', fillValue)}
           >
             {labelShort}
           </span>

--- a/src/components/Social/Tweet.js
+++ b/src/components/Social/Tweet.js
@@ -9,6 +9,7 @@ import { Header } from './Header'
 import PlayIcon from 'react-icons/lib/md/play-arrow'
 import { convertStyleToRem } from '../Typography/utils'
 import { useColorContext } from '../Colors/useColorContext'
+import RawHtml from '../RawHtml'
 
 const styles = {
   container: css({
@@ -28,12 +29,11 @@ const styles = {
     }
   }),
   text: css({
+    wordWrap: 'break-word',
     ...convertStyleToRem(sansSerifRegular15),
     [mUp]: {
       ...convertStyleToRem(sansSerifRegular18)
-    },
-    wordWrap: 'break-word',
-    '& a': { linkStyle }
+    }
   }),
   mediaContainer: css({
     display: 'inline-block',
@@ -48,6 +48,8 @@ const styles = {
     top: 'calc(50% - 40px)'
   })
 }
+
+const Text = props => <p {...styles.text} {...props} />
 
 const Tweet = ({
   attributes,
@@ -75,11 +77,7 @@ const Tweet = ({
         handle={userScreenName}
         date={date}
       />
-      <p
-        {...styles.text}
-        {...colorScheme.set('color', 'text')}
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      <RawHtml type={Text} dangerouslySetInnerHTML={{ __html: html }} />
       {image && (
         <Figure>
           <a href={url} {...styles.mediaContainer}>

--- a/src/components/Social/docs.md
+++ b/src/components/Social/docs.md
@@ -18,7 +18,7 @@ Supported props:
   userName='Christof Moser'
   userScreenName='@christof_moser'
   date={new Date(2017, 11, 15)}
-  html='One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. https://twitter.com/RepublikMagazin/status/869979987276742656'
+  html='One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. <a href=\"https://twitter.com/RepublikMagazin/status/869979987276742656\" target=\"_blank\" rel=\"noopener noreferrer\">twitter.com/RepublikMagazin/status/869979987276742656</a>'
 />
 ```
 

--- a/src/components/TeaserCarousel/Format.js
+++ b/src/components/TeaserCarousel/Format.js
@@ -3,15 +3,20 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { sansSerifMedium14 } from '../Typography/styles'
 import { useColorContext } from '../Colors/useColorContext'
+import CarouselContext, { defaultValue } from './Context'
+
 const styles = css({
   ...sansSerifMedium14,
   margin: '0 0 10px 0'
 })
 
 const Format = ({ children, color }) => {
+  const context = React.useContext(CarouselContext)
+  const textColor = color || context.color
+  const mapping = textColor === defaultValue.color ? 'format' : undefined
   const [colorScheme] = useColorContext()
   return (
-    <div {...colorScheme.set('color', color || 'text', 'format')} {...styles}>
+    <div {...colorScheme.set('color', textColor, mapping)} {...styles}>
       {children}
     </div>
   )

--- a/src/components/TeaserCarousel/docs.md
+++ b/src/components/TeaserCarousel/docs.md
@@ -2,8 +2,8 @@ A `<TeaserCarousel />` is a row of tiles through which the user can scroll horiz
 
 Supported props:
 - `bgColor` (string): Sets the carousel background color, (default: colorsScheme.default).
-- `color` (string): Sets the text color (default: colorScheme.text). Overrides tile text color if no color is set on tiles.
-- `outline` (string|bool): Sets tile outline color default (undefined = no outline, true = colorScheme.divider).
+- `color` (string): Sets the text color (default: text from colorScheme). Overrides tile text color if no color is set on tiles.
+- `outline` (string|bool): Sets tile outline color default (undefined = no outline, true = divider from colorScheme).
 - `bigger` (bool): use bigger style for cards
 - `article` (bool): margin and smaller max width for tiles (optimised to align with article column)
 

--- a/src/components/TeaserFront/CreditLink.js
+++ b/src/components/TeaserFront/CreditLink.js
@@ -12,16 +12,15 @@ const getHoverColor = labColor =>
 const CreditLink = React.forwardRef(
   ({ attributes, children, color, collapsedColor, ...props }, ref) => {
     const [colorScheme] = useColorContext()
-    const textColor = color ? color : colorScheme.text
-    const labColor = lab(textColor)
     const labCollapsedColor = collapsedColor && lab(collapsedColor)
-    const hoverColor = color ? getHoverColor(labColor) : colorScheme.lightText
 
     const baseColorStyle = {
-      color: textColor,
+      color: color || colorScheme.getCSSColor('text'),
       '@media (hover)': {
         ':hover': {
-          color: hoverColor
+          color: color
+            ? getHoverColor(lab(color))
+            : colorScheme.getCSSColor('textSoft')
         }
       }
     }

--- a/src/components/TeaserFront/TileRow.js
+++ b/src/components/TeaserFront/TileRow.js
@@ -148,16 +148,22 @@ export const TeaserFrontTileRow = ({
   const [colorScheme] = useColorContext()
   const autoBorders = css({
     '& .tile': {
-      borderTop: `1px solid ${colorScheme.divider}`
+      borderTopWidth: 1,
+      borderTopStyle: 'solid',
+      borderTopColor: colorScheme.getCSSColor('divider')
     },
     [mUp]: {
       '& .tile': {
-        borderLeft: `1px solid ${colorScheme.divider}`
+        borderLeftWidth: 1,
+        borderLeftStyle: 'solid',
+        borderLeftColor: colorScheme.getCSSColor('divider')
       }
     },
     [breakoutUp]: {
       '& .tile:nth-child(2n+1)': {
-        borderLeft: `1px solid ${colorScheme.divider}`
+        borderLeftWidth: 1,
+        borderLeftStyle: 'solid',
+        borderLeftColor: colorScheme.getCSSColor('divider')
       }
     }
   })
@@ -172,7 +178,9 @@ export const TeaserFrontTileRow = ({
       ? css({
           '& .tile': {
             textAlign: 'left',
-            borderTop: `1px solid ${colorScheme.divider}`,
+            borderTopWidth: 1,
+            borderTopStyle: 'solid',
+            borderTopColor: colorScheme.getCSSColor('divider'),
             padding: '25px 0',
             [mUp]: {
               padding: '25px 0'

--- a/src/components/TeaserMyMagazine/TeaserMyMagazine.js
+++ b/src/components/TeaserMyMagazine/TeaserMyMagazine.js
@@ -41,10 +41,8 @@ const TeaserMyMagazine = ({
 
   return (
     <div
-      style={{
-        // for color inherit below, e.g. TeaserSectionTitle
-        color: colorScheme.text
-      }}
+      // for color inherit below, e.g. TeaserSectionTitle
+      {...colorScheme.set('color', 'text')}
     >
       <section {...css(styles.section)}>
         <div role='group' {...css(styles.row, styles.withHighlight)}>
@@ -97,7 +95,7 @@ const TeaserMyMagazine = ({
                 return (
                   <div
                     {...styles.tile}
-                    style={{ border: `1px solid ${colorScheme.divider}` }}
+                    {...colorScheme.set('borderColor', 'divider')}
                     key={id}
                   >
                     {formatMeta ? (
@@ -115,7 +113,7 @@ const TeaserMyMagazine = ({
                       <Link href={path} passHref>
                         <a
                           {...styles.tileHeadline}
-                          style={{ color: colorScheme.text }}
+                          {...colorScheme.set('color', 'text')}
                         >
                           {limitedTitle(title, 100)}
                         </a>
@@ -220,6 +218,8 @@ const styles = {
     justifyContent: 'space-between',
     alignItems: 'flex-start',
     marginBottom: 16,
+    borderWidth: 1,
+    borderStyle: 'solid',
     ':last-child': {
       marginBottom: 30,
       [mUp]: {

--- a/src/index.js
+++ b/src/index.js
@@ -755,6 +755,7 @@ ReactDOM.render(
                 title: 'Bars',
                 imports: {
                   ...require('./components/Typography'),
+                  ColorContextProvider,
                   ChartTitle: require('./components/Chart').ChartTitle,
                   ChartLead: require('./components/Chart').ChartLead,
                   ChartLegend: require('./components/Chart').ChartLegend,

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,10 @@ import { fontFaces } from './theme/fonts'
 import { createFormatter } from './lib/translate'
 import { DiscussionContext } from './components/Discussion/DiscussionContext'
 import { createSampleDiscussionContextValue } from './components/Discussion/DiscussionContext.docs'
-import { ColorContextProvider } from './components/Colors/ColorContext'
+import {
+  ColorContextProvider,
+  useColorContext
+} from './components/Colors/ColorContext'
 
 simulations(true)
 // prevent speedy in catalog
@@ -941,7 +944,14 @@ ReactDOM.render(
                   Container: require('./templates/Article/Container').default,
                   ...require('./components/Typography'),
                   ColorContextProvider,
-                  ...require('./components/Colors/useColorContext'),
+                  ColorContextLocalExtension: require('./components/Colors/ColorContext')
+                    .ColorContextLocalExtension,
+                  useColorContext,
+                  GetColorScheme: ({ children }) => {
+                    const [colorScheme] = useColorContext()
+
+                    return children(colorScheme)
+                  },
                   css
                 }
               }

--- a/src/lib.js
+++ b/src/lib.js
@@ -40,7 +40,9 @@ export { Collapsable } from './components/Collapsable'
 export { default as CalloutMenu } from './components/Callout/CalloutMenu'
 export {
   default as ColorContext,
-  ColorContextProvider
+  ColorContextProvider,
+  ColorContextLocalExtension,
+  ColorHtmlBodyColors
 } from './components/Colors/ColorContext'
 export { useColorContext } from './components/Colors/useColorContext'
 export {

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -200,12 +200,7 @@ const colors = {
   }
 }
 
-// identify all variable color keys
-export const variableColorKeys = Object.keys(colors.light).filter(
-  color => colors.light[color] !== colors.dark[color]
-)
-
-//add all deprecated colors, but only if they don't exist in new colors (no overwrites)
+// add all deprecated colors, but only if they don't exist in new colors (no overwrites)
 Object.keys(colorsDeprecated).forEach(key => {
   if (!colors[key]) {
     colors[key] = colorsDeprecated[key]

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -136,7 +136,8 @@ const colors = {
     opposite80: 'rgb(187,21,26)',
     opposite60: 'rgb(239,69,51)',
     neutral: '#bbb',
-    discrete
+    discrete,
+    chartsInverted: '#000000'
   },
   dark: {
     logo: '#FFFFFF',
@@ -184,7 +185,8 @@ const colors = {
     opposite80: 'rgb(239,69,51)',
     opposite60: 'rgb(252, 138, 107)',
     neutral: '#bbb',
-    discrete
+    discrete,
+    chartsInverted: '#FFFFFF'
   },
   mappings: {
     format: {
@@ -193,9 +195,8 @@ const colors = {
       '#282828': 'accentColorMeta'
     },
     charts: {
-      '#000': 'accentColorMeta',
-      '#000000': 'accentColorMeta',
-      '#111111': 'accentColorMeta'
+      '#000': 'chartsInverted',
+      '#000000': 'chartsInverted'
     }
   }
 }


### PR DESCRIPTION
- feat(colors): ColorContextLocalExtension
- feat(Charts): custom dark mode colors via colorDarkMapping
- fix(Charts): add missing color mappings for dark mode
- refactor(colors): clean naming, always use `set` or `getCSSColor`

`ColorContextLocalExtension` allows to define new variables for a specific local react tree.

Based on that support for `colorDarkMapping` in chart configs was added. Allowing to re-map certain bright colors to dark colors when in dark mode. Not sure about naming yet. 

<img width="863" alt="Screenshot 2020-11-19 at 23 53 23" src="https://user-images.githubusercontent.com/410211/99734042-74691d80-2ac2-11eb-8a12-f43e83051b73.png">


Also `colorScheme.text` et al are no longer available.