### PR TITLE
fix(IconButton): display labels in IE11

### DIFF
--- a/src/components/IconButton/index.js
+++ b/src/components/IconButton/index.js
@@ -115,11 +115,11 @@ const styles = {
   long: css({
     display: 'none',
     [mUp]: {
-      display: 'initial'
+      display: 'inline'
     }
   }),
   short: css({
-    display: 'initial',
+    display: 'inline',
     [mUp]: {
       display: 'none'
     }


### PR DESCRIPTION
see https://caniuse.com/css-initial-value

I don't see any benefit of using initial here but maybe I'm overseeing something.

<img width="519" alt="Screenshot 2020-11-23 at 15 45 28" src="https://user-images.githubusercontent.com/410211/99976024-39593980-2da3-11eb-8fe9-f6c1910ec604.png">
<img width="956" alt="Screenshot 2020-11-23 at 15 48 07" src="https://user-images.githubusercontent.com/410211/99976093-4c6c0980-2da3-11eb-86be-e308ffa518f5.png">

### With explicit inline

<img width="839" alt="Screenshot 2020-11-23 at 15 45 38" src="https://user-images.githubusercontent.com/410211/99976028-3a8a6680-2da3-11eb-91f6-29e28942b09a.png">

<img width="779" alt="Screenshot 2020-11-23 at 15 48 50" src="https://user-images.githubusercontent.com/410211/99976185-69084180-2da3-11eb-8c88-b1847459911e.png">
