### PR TITLE
Discussion: Hide unpublished nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
     "semantic-release": "semantic-release",
     "commitmsg": "validate-commit-msg",
     "precommit": "lint-staged",
-    "translations": "gsheets --key=1sMS5u4SIFY2loAmx8jftDXqTbq2RheJLY7FBeXSm1Tc --title=live --pretty --out src/lib/translations.json"
+    "translations-raw": "gsheets --key=1sMS5u4SIFY2loAmx8jftDXqTbq2RheJLY7FBeXSm1Tc --title=live --pretty --out src/lib/translations.json",
+    "translations": "npm run translations-raw && git add -p src/lib/translations.json && git checkout -- src/lib/translations.json"
   },
   "lint-staged": {
     "*.js": [

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -91,8 +91,6 @@ export const CommentTeaser = ({
     discussion,
     tags,
     parentIds,
-    published,
-    adminUnpublished,
     displayAuthor,
     preview,
     featuredText,
@@ -153,8 +151,6 @@ export const CommentTeaser = ({
               t={t}
               comment={{
                 id,
-                published,
-                adminUnpublished,
                 displayAuthor,
                 createdAt
               }}

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -91,6 +91,8 @@ export const CommentTeaser = ({
     discussion,
     tags,
     parentIds,
+    published,
+    adminUnpublished,
     displayAuthor,
     preview,
     featuredText,
@@ -149,7 +151,13 @@ export const CommentTeaser = ({
           <div {...styles.header}>
             <Header
               t={t}
-              comment={{ id, displayAuthor, createdAt }}
+              comment={{
+                id,
+                published,
+                adminUnpublished,
+                displayAuthor,
+                createdAt
+              }}
               menu={menu}
             />
           </div>

--- a/src/components/Discussion/Internal/Comment/Actions.js
+++ b/src/components/Discussion/Internal/Comment/Actions.js
@@ -195,13 +195,15 @@ export const Actions = ({
           <UnpublishIcon {...colorScheme.set('fill', 'text')} />
         </IconButton>
       )}
-      <IconButton
-        onClick={onShare}
-        title={t('styleguide/CommentActions/share')}
-      >
-        <ShareIcon {...colorScheme.set('fill', 'text')} />
-      </IconButton>
-      {userCanReport && onReport && (
+      {published && (
+        <IconButton
+          onClick={onShare}
+          title={t('styleguide/CommentActions/share')}
+        >
+          <ShareIcon {...colorScheme.set('fill', 'text')} />
+        </IconButton>
+      )}
+      {published && userCanReport && onReport && (
         <IconButton
           disabled={userReportedAt}
           onClick={handleReport}
@@ -219,66 +221,69 @@ export const Actions = ({
           </span>
         </IconButton>
       )}
-      <div {...styles.votes}>
-        {!!(featuredText || actions.featureComment) && (
-          <IconButton
-            type='left'
-            title={
-              featuredAt
-                ? t('styleguide/CommentActions/featured', {
-                    date: dateFormat(new Date(featuredAt)),
-                    time: hmFormat(new Date(featuredAt)),
-                    text: featuredText
-                  })
-                : t('styleguide/CommentActions/feature')
-            }
-            onClick={
-              actions.featureComment && (() => actions.featureComment(comment))
-            }
-          >
-            <FeaturedIcon
-              {...colorScheme.set('fill', featuredText ? 'primary' : 'text')}
-            />
-          </IconButton>
-        )}
-        <div {...styles.vote}>
-          <IconButton
-            selected={userVote === 'UP'}
-            vote={true}
-            onClick={onUpvote}
-            title={t('styleguide/CommentActions/upvote')}
-          >
-            <MdKeyboardArrowUp />
-          </IconButton>
-          <span
-            title={t.pluralize('styleguide/CommentActions/upvote/count', {
-              count: upVotes
-            })}
-          >
-            {upVotes}
-          </span>
+      {published && (
+        <div {...styles.votes}>
+          {!!(featuredText || actions.featureComment) && (
+            <IconButton
+              type='left'
+              title={
+                featuredAt
+                  ? t('styleguide/CommentActions/featured', {
+                      date: dateFormat(new Date(featuredAt)),
+                      time: hmFormat(new Date(featuredAt)),
+                      text: featuredText
+                    })
+                  : t('styleguide/CommentActions/feature')
+              }
+              onClick={
+                actions.featureComment &&
+                (() => actions.featureComment(comment))
+              }
+            >
+              <FeaturedIcon
+                {...colorScheme.set('fill', featuredText ? 'primary' : 'text')}
+              />
+            </IconButton>
+          )}
+          <div {...styles.vote}>
+            <IconButton
+              selected={userVote === 'UP'}
+              vote={true}
+              onClick={onUpvote}
+              title={t('styleguide/CommentActions/upvote')}
+            >
+              <MdKeyboardArrowUp />
+            </IconButton>
+            <span
+              title={t.pluralize('styleguide/CommentActions/upvote/count', {
+                count: upVotes
+              })}
+            >
+              {upVotes}
+            </span>
+          </div>
+          <div {...styles.voteDivider} {...colorScheme.set('color', 'text')}>
+            /
+          </div>
+          <div {...styles.vote}>
+            <span
+              title={t.pluralize('styleguide/CommentActions/downvote/count', {
+                count: downVotes
+              })}
+            >
+              {downVotes}
+            </span>
+            <IconButton
+              selected={userVote === 'DOWN'}
+              vote={true}
+              onClick={onDownvote}
+              title={t('styleguide/CommentActions/downvote')}
+            >
+              <MdKeyboardArrowDown />
+            </IconButton>
+          </div>
         </div>
-        <div {...styles.voteDivider} {...colorScheme.set('color', 'text')}>
-          /
-        </div>
-        <div {...styles.vote}>
-          <span
-            title={t.pluralize('styleguide/CommentActions/downvote/count', {
-              count: downVotes
-            })}
-          >
-            {downVotes}
-          </span>
-          <IconButton
-            selected={userVote === 'DOWN'}
-            vote={true}
-            onClick={onDownvote}
-            title={t('styleguide/CommentActions/downvote')}
-          >
-            <MdKeyboardArrowDown />
-          </IconButton>
-        </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/components/Discussion/Internal/Comment/Body.js
+++ b/src/components/Discussion/Internal/Comment/Body.js
@@ -58,9 +58,6 @@ export const Body = ({ t, comment, context }) => {
 
   return (
     <>
-      {!published && (
-        <div {...styles.unpublished}>{t('styleguide/comment/unpublished')}</div>
-      )}
       {bodyNode}
       {userCanEdit &&
         (() => {

--- a/src/components/Discussion/Internal/Comment/Header.js
+++ b/src/components/Discussion/Internal/Comment/Header.js
@@ -163,8 +163,8 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
     displayAuthor,
     updatedAt,
     createdAt,
-    published,
-    adminUnpublished,
+    published = true,
+    adminUnpublished = false,
     comments,
     parentIds = []
   } = comment

--- a/src/components/Discussion/Internal/Comment/Header.js
+++ b/src/components/Discussion/Internal/Comment/Header.js
@@ -163,6 +163,8 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
     displayAuthor,
     updatedAt,
     createdAt,
+    published,
+    adminUnpublished,
     comments,
     parentIds = []
   } = comment
@@ -187,7 +189,7 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
       {(() => {
         const n = parentIds.length - config.nestLimit
         if (n < 0) {
-          if (!profilePicture) {
+          if (!profilePicture || !published) {
             return null
           }
           return (
@@ -214,43 +216,54 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
         }
       })()}
       <div {...styles.center}>
-        <Link displayAuthor={displayAuthor} passHref>
-          <a {...styles.name} {...colorScheme.set('color', 'text')}>
-            {name}
-          </a>
-        </Link>
+        {!published && (
+          <div {...styles.name} {...colorScheme.set('color', 'textSoft')}>
+            {(adminUnpublished &&
+              t('styleguide/comment/header/unpublishedByAdmin')) ||
+              t('styleguide/comment/header/unpublishedByUser')}
+          </div>
+        )}
+        {published && (
+          <Link displayAuthor={displayAuthor} passHref>
+            <a {...styles.name} {...colorScheme.set('color', 'text')}>
+              {name}
+            </a>
+          </Link>
+        )}
         <div {...styles.meta} {...colorScheme.set('color', 'textSoft')}>
-          {credential && (
-            <div
-              {...styles.credential}
-              title={
-                credential.verified
-                  ? t(
-                      'styleguide/comment/header/verifiedCredential',
-                      undefined,
-                      ''
-                    )
-                  : undefined
-              }
-            >
+          {published && credential && (
+            <>
               <div
-                {...styles.descriptionText}
-                {...colorScheme.set(
-                  'color',
-                  credential.verified ? 'text' : 'textSoft'
-                )}
+                {...styles.credential}
+                title={
+                  credential.verified
+                    ? t(
+                        'styleguide/comment/header/verifiedCredential',
+                        undefined,
+                        ''
+                      )
+                    : undefined
+                }
               >
-                {credential.description}
+                <div
+                  {...styles.descriptionText}
+                  {...colorScheme.set(
+                    'color',
+                    credential.verified ? 'text' : 'textSoft'
+                  )}
+                >
+                  {credential.description}
+                </div>
+                {credential.verified && (
+                  <MdCheck
+                    {...styles.verifiedCheck}
+                    {...colorScheme.set('color', 'primary')}
+                  />
+                )}
               </div>
-              {credential.verified && (
-                <MdCheck
-                  {...styles.verifiedCheck}
-                  {...colorScheme.set('color', 'primary')}
-                />
-              )}
-            </div>
+              <div style={{ whiteSpace: 'pre' }}>{' · '}</div>
+            </>
           )}
-          {credential && <div style={{ whiteSpace: 'pre' }}>{' · '}</div>}
           <div
             {...styles.timeago}
             {...colorScheme.set('color', 'textSoft')}
@@ -265,7 +278,7 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
               </a>
             </Link>
           </div>
-          {isUpdated && (
+          {published && isUpdated && (
             <div
               {...styles.timeago}
               {...colorScheme.set('color', 'textSoft')}

--- a/src/components/Discussion/Internal/docs.md
+++ b/src/components/Discussion/Internal/docs.md
@@ -127,7 +127,7 @@ Comments can be unpublished. Header will replace author with a label.
 <Comment.Header t={t} comment={comments.comment3} />
 ```
 
-If comment was unpublished by admin (`adminUnpublish`), label will indicate that.
+If comment was unpublished by admin (`adminUnpublished`), label will indicate that.
 
 ```react|noSource
 <Comment.Header t={t} comment={comments.comment4} />

--- a/src/components/Discussion/Internal/docs.md
+++ b/src/components/Discussion/Internal/docs.md
@@ -121,6 +121,18 @@ If the comment is below a certain depth, we hide the profile picture and instead
 />
 ```
 
+Comments can be unpublished. Header will replace author with a label.
+
+```react|noSource
+<Comment.Header t={t} comment={comments.comment3} />
+```
+
+If comment was unpublished by admin (`adminUnpublish`), label will indicate that.
+
+```react|noSource
+<Comment.Header t={t} comment={comments.comment4} />
+```
+
 #### Body
 
 The **Body** component (shown on the left) includes the optional **Context** component (shown right) above the comment text. Context is a bold title line and optional description line. The context lines do not wrap, they are cut of with an ellipsis.
@@ -150,11 +162,7 @@ The body component automatically collapses the text if it's too long. Whether co
 <Comment.Body t={t} comment={comments.comment5} context={commentContext} />
 ```
 
-Comments can be unpublished. These comments are still visible, but the content is replaced with a placeholder.
-
-```react|noSource
-<Comment.Body t={t} comment={comments.comment2} />
-```
+Comments can be unpublished. Content is dropped.
 
 If the comment is unpublished by the user themselves, they will still see the content, can edit it and publish again. If the comment was unpublished by an admin the user will see a different note.
 

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -141,11 +141,11 @@
     },
     {
       "key": "styleguide/comment/header/unpublishedByUser",
-      "value": "Beitrag zurückgezogen"
+      "value": "(von User zurückgezogen)"
     },
     {
       "key": "styleguide/comment/header/unpublishedByAdmin",
-      "value": "Beitrag von Redaktion verborgen"
+      "value": "(von der Redaktion verborgen)"
     },
     {
       "key": "styleguide/comment/edit/submit",

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -140,6 +140,14 @@
       "value": "Rolle definieren"
     },
     {
+      "key": "styleguide/comment/header/unpublishedByUser",
+      "value": "Beitrag zurückgezogen"
+    },
+    {
+      "key": "styleguide/comment/header/unpublishedByAdmin",
+      "value": "Beitrag von Redaktion verborgen"
+    },
+    {
       "key": "styleguide/comment/edit/submit",
       "value": "bearbeiten"
     },
@@ -149,11 +157,11 @@
     },
     {
       "key": "styleguide/comment/unpublished/userCanEdit",
-      "value": "Bearbeiten Sie den Beitrag um ihn erneut zu publizieren."
+      "value": "Bearbeiten Sie den Beitrag, um ihn erneut zu publizieren."
     },
     {
       "key": "styleguide/comment/adminUnpublished",
-      "value": "Leider mussen wir Ihren Beitrag unveröffentlichen. Wenden sie sich an kontakt@republik.ch."
+      "value": "Leider mussten wir Ihren Beitrag verbergen. Wenden Sie sich bitte an kontakt@republik.ch."
     },
     {
       "key": "styleguide/AudioPlayer/aria",


### PR DESCRIPTION
Comments can be unpublished. Header will replace author with a label.

<img width="507" alt="Bildschirmfoto 2020-12-16 um 12 52 47" src="https://user-images.githubusercontent.com/331800/102345476-bf7d3000-3f9d-11eb-9179-cb174d1ab61b.png">

If comment was unpublished by admin (`adminUnpublished`), label will indicate that.

<img width="509" alt="Bildschirmfoto 2020-12-16 um 12 52 53" src="https://user-images.githubusercontent.com/331800/102345496-c4da7a80-3f9d-11eb-9962-66ef1814ce48.png">
