### PR TITLE
fix(TeaserActiveDebates): Filter unpublished comments

### DIFF
--- a/src/components/TeaserActiveDebates/ActiveDebates.js
+++ b/src/components/TeaserActiveDebates/ActiveDebates.js
@@ -176,6 +176,7 @@ ActiveDebates.data = {
           // - max 2 for first discussion, max 1 for the rest
           const nodes = discussion.comments.nodes.filter(comment => {
             if (
+              !comment.published ||
               (!comment.preview && !comment.highlight) ||
               !remainingComments ||
               !remainingCommentsPerDiscussion ||
@@ -241,6 +242,7 @@ query getFrontDiscussions($lastDays: Int!, $first: Int!, $featured: Int!) {
         totalCount
         nodes {
           id
+          published
           preview(length: 240) {
             string
             more


### PR DESCRIPTION
If a comment is unpublished, the author can still query `Comment.preview`.

Thus far, `TeaserActiveDebates` would have rendered that comment for said author despite being unpublished (and not visible to others).

This Pull Request intends to fix that.

