### PR TITLE
fix(Discussion): consistent share icon (and position swap)

### DIFF
--- a/src/components/Discussion/Internal/Comment/Actions.js
+++ b/src/components/Discussion/Internal/Comment/Actions.js
@@ -8,7 +8,7 @@ import UnpublishIcon from 'react-icons/lib/md/visibility-off'
 import ReportIcon from 'react-icons/lib/md/flag'
 import EditIcon from 'react-icons/lib/md/edit'
 import ReplyIcon from 'react-icons/lib/md/reply'
-import ShareIcon from 'react-icons/lib/md/share'
+import ShareIcon from '../../../Icons/CustomIcons/ShareIconIOS'
 import FeaturedIcon from 'react-icons/lib/md/star-outline'
 import { sansSerifMedium14 } from '../../../Typography/styles'
 import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
@@ -195,14 +195,6 @@ export const Actions = ({
           <UnpublishIcon {...colorScheme.set('fill', 'text')} />
         </IconButton>
       )}
-      {published && (
-        <IconButton
-          onClick={onShare}
-          title={t('styleguide/CommentActions/share')}
-        >
-          <ShareIcon {...colorScheme.set('fill', 'text')} />
-        </IconButton>
-      )}
       {published && userCanReport && onReport && (
         <IconButton
           disabled={userReportedAt}
@@ -219,6 +211,14 @@ export const Actions = ({
               </span>
             )}
           </span>
+        </IconButton>
+      )}
+      {published && (
+        <IconButton
+          onClick={onShare}
+          title={t('styleguide/CommentActions/share')}
+        >
+          <ShareIcon {...colorScheme.set('fill', 'text')} />
         </IconButton>
       )}
       {published && (

--- a/src/components/Icons/CustomIcons/ShareIconIOS.js
+++ b/src/components/Icons/CustomIcons/ShareIconIOS.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+// Based on MdExitToApp
+
+const Icon = ({ size = '1em', ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox='0 0 24 24'
+    fill='currentColor'
+    style={{ verticalAlign: 'middle' }}
+    {...props}
+  >
+    <path d='M8.41 9.41L7 8L12 3L17 8L15.59 9.41L13 6.83V16.5H11V6.83L8.41 9.41ZM21 20V11H19V20H5V11H3L3 20C3 21.1 3.9 22 5 22H19C19.5304 22 20.0391 21.7893 20.4142 21.4142C20.7893 21.0391 21 20.5304 21 20Z' />
+  </svg>
+)
+
+export default Icon


### PR DESCRIPTION
result:

![Screenshot 2021-02-12 at 11 38 17](https://user-images.githubusercontent.com/20746301/107758415-219cac00-6d27-11eb-899d-c38bfcfda1d8.jpg)
