### PR TITLE
add rewind & skip buttons

### DIFF
--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -6,6 +6,8 @@ import Pause from 'react-icons/lib/md/pause'
 import Rewind from 'react-icons/lib/md/skip-previous'
 import Close from 'react-icons/lib/md/close'
 import Download from 'react-icons/lib/md/file-download'
+import Forward from 'react-icons/lib/md/forward-30'
+import Replay from 'react-icons/lib/md/replay-30'
 
 import { ellipsize } from '../../lib/styleMixins'
 import { timeFormat } from '../../lib/timeFormat'
@@ -36,7 +38,9 @@ const SIZE = {
   play: 30,
   rewind: 26,
   close: 30,
-  download: 22
+  download: 22,
+  forward: 22,
+  replay: 22
 }
 
 const barStyle = {
@@ -93,7 +97,7 @@ const styles = {
   download: css({
     position: 'absolute',
     top: '50%',
-    left: SIZE.rewind + SIZE.play + ICON_SPACING,
+    left: SIZE.play + SIZE.rewind + SIZE.replay + SIZE.forward + ICON_SPACING,
     marginTop: -10,
     textAlign: 'center'
   }),
@@ -462,7 +466,11 @@ class AudioPlayer extends Component {
     } = this.state
     const isVideo = src.mp4 || src.hls
     const leftIconsWidth =
-      SIZE.rewind + SIZE.play + (download ? SIZE.download + ICON_SPACING : 0)
+      SIZE.play +
+      SIZE.rewind +
+      SIZE.replay +
+      SIZE.forward +
+      (download ? SIZE.download + ICON_SPACING : 0)
     const rightIconsWidth = closeHandler ? SIZE.close : 0
     const uiTextStyle = {
       maxWidth: `calc(100% - ${leftIconsWidth + rightIconsWidth + 20}px)`,
@@ -582,6 +590,42 @@ class AudioPlayer extends Component {
             >
               <Rewind
                 size={SIZE.rewind}
+                {...(playEnabled && progress > 0
+                  ? colorScheme.set('fill', 'text')
+                  : colorScheme.set('fill', 'disabled'))}
+              />
+            </button>
+            <button
+              {...styles.button}
+              onClick={
+                playEnabled
+                  ? () => {
+                      this.setTime(this.audio.currentTime - 30)
+                    }
+                  : null
+              }
+              title={t('styleguide/AudioPlayer/partialrewind')}
+            >
+              <Replay
+                size={SIZE.replay}
+                {...(playEnabled && progress > 0
+                  ? colorScheme.set('fill', 'text')
+                  : colorScheme.set('fill', 'disabled'))}
+              />
+            </button>
+            <button
+              {...styles.button}
+              onClick={
+                playEnabled
+                  ? () => {
+                      this.setTime(this.audio.currentTime + 30)
+                    }
+                  : null
+              }
+              title={t('styleguide/AudioPlayer/partialfastforward')}
+            >
+              <Forward
+                size={SIZE.forward}
                 {...(playEnabled && progress > 0
                   ? colorScheme.set('fill', 'text')
                   : colorScheme.set('fill', 'disabled'))}

--- a/src/components/AudioPlayer/Player.js
+++ b/src/components/AudioPlayer/Player.js
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types'
 import { css, merge } from 'glamor'
 import Play from 'react-icons/lib/md/play-arrow'
 import Pause from 'react-icons/lib/md/pause'
-import Rewind from 'react-icons/lib/md/skip-previous'
 import Close from 'react-icons/lib/md/close'
 import Download from 'react-icons/lib/md/file-download'
 import Forward from 'react-icons/lib/md/forward-30'
-import Replay from 'react-icons/lib/md/replay-30'
+import Replay from 'react-icons/lib/md/replay-10'
 
 import { ellipsize } from '../../lib/styleMixins'
 import { timeFormat } from '../../lib/timeFormat'
@@ -36,7 +35,6 @@ const ICON_SPACING = 8
 
 const SIZE = {
   play: 30,
-  rewind: 26,
   close: 30,
   download: 22,
   forward: 22,
@@ -97,7 +95,7 @@ const styles = {
   download: css({
     position: 'absolute',
     top: '50%',
-    left: SIZE.play + SIZE.rewind + SIZE.replay + SIZE.forward + ICON_SPACING,
+    left: SIZE.play + SIZE.replay + SIZE.forward + ICON_SPACING,
     marginTop: -10,
     textAlign: 'center'
   }),
@@ -467,7 +465,6 @@ class AudioPlayer extends Component {
     const isVideo = src.mp4 || src.hls
     const leftIconsWidth =
       SIZE.play +
-      SIZE.rewind +
       SIZE.replay +
       SIZE.forward +
       (download ? SIZE.download + ICON_SPACING : 0)
@@ -567,6 +564,24 @@ class AudioPlayer extends Component {
           <div {...styles.buttons}>
             <button
               {...styles.button}
+              onClick={
+                playEnabled
+                  ? () => {
+                      this.setTime(this.audio.currentTime - 10)
+                    }
+                  : null
+              }
+              title={t('styleguide/AudioPlayer/partialrewind')}
+            >
+              <Replay
+                size={SIZE.replay}
+                {...(playEnabled && progress > 0
+                  ? colorScheme.set('fill', 'text')
+                  : colorScheme.set('fill', 'disabled'))}
+              />
+            </button>
+            <button
+              {...styles.button}
               onClick={playEnabled ? this.toggle : null}
               title={t(`styleguide/AudioPlayer/${playing ? 'pause' : 'play'}`)}
               aria-live='assertive'
@@ -582,36 +597,6 @@ class AudioPlayer extends Component {
               {playing && (
                 <Pause size={SIZE.play} {...colorScheme.set('fill', 'text')} />
               )}
-            </button>
-            <button
-              {...styles.button}
-              onClick={playEnabled ? () => this.setTime(0) : null}
-              title={t('styleguide/AudioPlayer/rewind')}
-            >
-              <Rewind
-                size={SIZE.rewind}
-                {...(playEnabled && progress > 0
-                  ? colorScheme.set('fill', 'text')
-                  : colorScheme.set('fill', 'disabled'))}
-              />
-            </button>
-            <button
-              {...styles.button}
-              onClick={
-                playEnabled
-                  ? () => {
-                      this.setTime(this.audio.currentTime - 30)
-                    }
-                  : null
-              }
-              title={t('styleguide/AudioPlayer/partialrewind')}
-            >
-              <Replay
-                size={SIZE.replay}
-                {...(playEnabled && progress > 0
-                  ? colorScheme.set('fill', 'text')
-                  : colorScheme.set('fill', 'disabled'))}
-              />
             </button>
             <button
               {...styles.button}

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -200,6 +200,14 @@
       "value": "Nochmal versuchen"
     },
     {
+      "key": "styleguide/AudioPlayer/partialrewind",
+      "value": "30 Sekunden zurück"
+    },
+    {
+      "key": "styleguide/AudioPlayer/partialfastforward",
+      "value": "30 Sekunden vorwärts"
+    },
+    {
       "key": "styleguide/video/dnt/note",
       "value": "Dies ist ein {player}-Video. Wenn Sie das Video abspielen, kann {platform} Sie tracken."
     },

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -176,10 +176,6 @@
       "value": "Anhalten"
     },
     {
-      "key": "styleguide/AudioPlayer/rewind",
-      "value": "Von Anfang an"
-    },
-    {
       "key": "styleguide/AudioPlayer/download",
       "value": "Herunterladen"
     },
@@ -201,7 +197,7 @@
     },
     {
       "key": "styleguide/AudioPlayer/partialrewind",
-      "value": "30 Sekunden zurück"
+      "value": "10 Sekunden zurück"
     },
     {
       "key": "styleguide/AudioPlayer/partialfastforward",


### PR DESCRIPTION
This pull request is a first shot at addressing issue #312.

I added forward and backward buttons to the player that skip forward/backward 30 seconds in the audio file when clicked. 
10 or 5 seconds would be the alternative to skipping 30 seconds as these icons are also available in the Material Iconset.

This is how the new buttons look (screenshot taken from the styleguide):
<img src="https://user-images.githubusercontent.com/16801528/111066990-2e492700-84c2-11eb-8639-726eee03168a.png" width="800">

<img src="https://user-images.githubusercontent.com/16801528/111066994-37d28f00-84c2-11eb-891e-bcbbf8bae8e3.png" width="800">

<img src="https://user-images.githubusercontent.com/16801528/111067008-46b94180-84c2-11eb-9362-ad5ae69059c5.png" width="500">

<img src="https://user-images.githubusercontent.com/16801528/111067016-4f117c80-84c2-11eb-9ca1-ff885bb4ebe7.png" height="500">

Some remaining questions from my side:
Should we make the button display optional? (as with the download button)
And the mobile view seems a bit crowded with buttons now: should we display them on mobile?

Would love to hear your thoughts about my first PR in one of the orbiting Repos.