### PR TITLE
improve Discussion Composer prefill experience

### DIFF
--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -55,8 +55,10 @@ const styles = {
  * particular, this allows the frontend to directly display the CommentComposer
  * if there is text stored in localStorage.
  */
-export const commentComposerStorageKey = discussionId =>
-  `commentComposerText:${discussionId}`
+export const commentComposerStorageKey = (discussionId, parentId) => {
+  const key = `commentComposerText:${discussionId}`
+  return parentId ? key + `:${parentId}` : key
+}
 
 export const CommentComposer = props => {
   const {
@@ -98,7 +100,7 @@ export const CommentComposer = props => {
    * provided through props. This way the user won't lose their text if the browser
    * crashes or if they inadvertently close the composer.
    */
-  const localStorageKey = commentComposerStorageKey(discussionId)
+  const localStorageKey = commentComposerStorageKey(discussionId, parentId)
   const [text, setText] = React.useState(() => {
     if (props.initialText) {
       return props.initialText


### PR DESCRIPTION
This is my proposal on how to improve the prefill experience in the Discussion Composer. (#362)
Instead of only saving the discussionId, the id of the comment the user wants to reply to is saved aswell. The draft is only restored when both ids match.
For root comments, the behaviour is not changed.

I tested if this new behaviour works well within the republik frontend by locally building the library as a package and passing  the parentId prop to the key function.

This is how it looks in action:

https://user-images.githubusercontent.com/16801528/111913132-0aab5100-8a6d-11eb-8f87-f04cc5079ca1.mp4

This change will probably cause confusion in the first few days/weeks after the change is introduced. Because the drafts that are currently saved as replies to comments, won't be restored. But they won't be lost, as they can still be restored in the root comment field. 
I don't see something we can do to prevent this though, as there's no way we can migrate the data. 
But if it is well communicated in a short Update article, I think this confusion can be avoided almost completely. 
Additionally in the long term it will cause less confusion which in my opinion totally outweighs the possibly caused confusion in the short term.