### PR TITLE
fix(BarChart): render bars with labels last

### DIFF
--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -420,6 +420,8 @@ const BarChart = props => {
             iXOffset
           }
         })
+        // The sorting ensures that sequences with a label will be rendered last,
+        // preventing overflowing labels to be painted over by the next sequence.
         .sort(a => {
           if (!inlineLabel) {
             return 1

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -570,7 +570,7 @@ const BarChart = props => {
                               {...styles.barLabel}
                               {...colorScheme.set('fill', 'text')}
                               x={
-                                valueTextStartAnchor
+                                segment.valueTextStartAnchor
                                   ? segment.x +
                                     segment.width +
                                     4 +
@@ -581,7 +581,7 @@ const BarChart = props => {
                                     (isLollipop ? 8 : 0)
                               }
                               textAnchor={
-                                valueTextStartAnchor ? 'start' : 'end'
+                                segment.valueTextStartAnchor ? 'start' : 'end'
                               }
                               y={bar.height / 2}
                               dy='.35em'


### PR DESCRIPTION
Two steps:
1. calculate everything needed to render the `segments` based on their original order (the `map`part of `precalculatedData`)
2. if an `inlineLabel` is present, sort the `segments` so that the ones with a label get rendered last (`sort` part)