### PR TITLE
Current Minute

### DIFF
--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -15,6 +15,7 @@ import {
   CommentBodyFeaturedText
 } from '../CommentBody/web'
 import { IconLink, Context, Header } from '../Discussion/Internal/Comment'
+import RelativeTime from '../Discussion/Internal/Comment/RelativeTime'
 import RawHtml from '../RawHtml/'
 import { useColorContext } from '../Colors/ColorContext'
 import {
@@ -266,12 +267,8 @@ export const CommentTeaser = ({
           {!displayAuthor && (
             <div {...styles.timeago} {...colorScheme.set('color', 'textSoft')}>
               <Link comment={comment} discussion={discussion} passHref>
-                <a {...styles.linkUnderline} suppressHydrationWarning>
-                  {formatTimeRelative(new Date(createdAt), {
-                    ...clock,
-                    now,
-                    direction: 'past'
-                  })}
+                <a {...styles.linkUnderline}>
+                  <RelativeTime {...clock} date={createdAt} />
                 </a>
               </Link>
             </div>

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -6,7 +6,7 @@ import { mUp } from '../../theme/mediaQueries'
 import { underline } from '../../lib/styleMixins'
 import { inQuotes } from '../../lib/inQuotes'
 import { useMediaQuery } from '../../lib/useMediaQuery'
-import useCurrentMinute from '../../lib/useCurrentMinute'
+import { useCurrentMinute } from '../../lib/useCurrentMinute'
 
 import { serifRegular14, sansSerifMedium15 } from '../Typography/styles'
 import { A } from '../Typography/'

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -6,6 +6,8 @@ import { mUp } from '../../theme/mediaQueries'
 import { underline } from '../../lib/styleMixins'
 import { inQuotes } from '../../lib/inQuotes'
 import { useMediaQuery } from '../../lib/useMediaQuery'
+import useCurrentMinute from '../../lib/useCurrentMinute'
+
 import { serifRegular14, sansSerifMedium15 } from '../Typography/styles'
 import { A } from '../Typography/'
 import {
@@ -121,8 +123,8 @@ export const CommentTeaser = ({
    * A reduced version of DiscussionContext value, just enough so we can render
    * the Comment Header component.
    */
+  const now = useCurrentMinute()
   const clock = {
-    now: Date.now(),
     t,
     isDesktop
   }
@@ -267,6 +269,7 @@ export const CommentTeaser = ({
                 <a {...styles.linkUnderline} suppressHydrationWarning>
                   {formatTimeRelative(new Date(createdAt), {
                     ...clock,
+                    now,
                     direction: 'past'
                   })}
                 </a>

--- a/src/components/CommentTeaser/CommentTeaser.js
+++ b/src/components/CommentTeaser/CommentTeaser.js
@@ -6,7 +6,6 @@ import { mUp } from '../../theme/mediaQueries'
 import { underline } from '../../lib/styleMixins'
 import { inQuotes } from '../../lib/inQuotes'
 import { useMediaQuery } from '../../lib/useMediaQuery'
-import { useCurrentMinute } from '../../lib/useCurrentMinute'
 
 import { serifRegular14, sansSerifMedium15 } from '../Typography/styles'
 import { A } from '../Typography/'
@@ -124,7 +123,6 @@ export const CommentTeaser = ({
    * A reduced version of DiscussionContext value, just enough so we can render
    * the Comment Header component.
    */
-  const now = useCurrentMinute()
   const clock = {
     t,
     isDesktop

--- a/src/components/CommentTeaser/docs.md
+++ b/src/components/CommentTeaser/docs.md
@@ -35,7 +35,7 @@ Props:
 ```react|noSource,span-3
 <CommentTeaser
   id="X"
-  createdAt="2021-04-14T17:34:00.000Z"
+  createdAt={(new Date()).toISOString()}
   preview={{
     string: "Die Zeitungskäufe von Christoph Blocher, die Selbstideologisierung der NZZ, die Frankenstein-Monster-Strategie der Tamedia: Ehrlich gesagt wäre es uns lieber",
     more: true
@@ -66,7 +66,7 @@ Props:
 ```react|noSource,span-3
 <CommentTeaser
   id="X"
-  createdAt="2019-01-01"
+  createdAt={(new Date()).toISOString()}
   displayAuthor={{
     profilePicture: '/static/profilePicture1.png',
     name: 'Christof Moser',

--- a/src/components/CommentTeaser/docs.md
+++ b/src/components/CommentTeaser/docs.md
@@ -35,7 +35,7 @@ Props:
 ```react|noSource,span-3
 <CommentTeaser
   id="X"
-  createdAt="2019-01-01"
+  createdAt="2021-04-14T17:34:00.000Z"
   preview={{
     string: "Die Zeitungskäufe von Christoph Blocher, die Selbstideologisierung der NZZ, die Frankenstein-Monster-Strategie der Tamedia: Ehrlich gesagt wäre es uns lieber",
     more: true

--- a/src/components/Discussion/DiscussionContext.docs.js
+++ b/src/components/Discussion/DiscussionContext.docs.js
@@ -8,7 +8,8 @@ import React from 'react'
 export const createSampleDiscussionContextValue = ({
   t,
   isAdmin = false,
-  actions = {}
+  actions = {},
+  userWaitUntil = null
 }) => ({
   /**
    * Admin users have elevated priviledges, they can for example unpublish
@@ -42,7 +43,7 @@ export const createSampleDiscussionContextValue = ({
      * ISO 8601 string. If set then the user must wait until that time before
      * they can write another comment.
      */
-    userWaitUntil: null,
+    userWaitUntil,
 
     rules: {
       maxLength: null

--- a/src/components/Discussion/DiscussionContext.docs.js
+++ b/src/components/Discussion/DiscussionContext.docs.js
@@ -96,7 +96,6 @@ export const createSampleDiscussionContextValue = ({
    * The current time, isDesktop and a translate function for timeahead, timeago and timeduration.
    */
   clock: {
-    now: Date.now(),
     isDesktop: true,
     t
   },

--- a/src/components/Discussion/Internal/Comment/Actions.js
+++ b/src/components/Discussion/Internal/Comment/Actions.js
@@ -80,6 +80,29 @@ const styles = {
   })
 }
 
+const ReplyIconButton = ({ userWaitUntil, clock, onReply, colorScheme, t }) => {
+  const now = useCurrentMinute()
+  let replyBlockedMessage
+  const waitUntilDate = userWaitUntil && new Date(userWaitUntil)
+  if (waitUntilDate && waitUntilDate > now) {
+    replyBlockedMessage = t('styleguide/CommentComposer/wait', {
+      time: formatTimeRelative(waitUntilDate, { ...clock, now })
+    })
+  }
+
+  return (
+    <IconButton
+      disabled={!!replyBlockedMessage}
+      onClick={onReply}
+      title={replyBlockedMessage || t('styleguide/CommentActions/answer')}
+    >
+      <ReplyIcon
+        {...colorScheme.set('fill', replyBlockedMessage ? 'disabled' : 'text')}
+      />
+    </IconButton>
+  )
+}
+
 export const Actions = ({
   t,
   comment,
@@ -138,16 +161,6 @@ export const Actions = ({
     }
   })()
 
-  const now = useCurrentMinute()
-  const replyBlockedMessage = (() => {
-    const waitUntilDate = userWaitUntil && new Date(userWaitUntil)
-    if (waitUntilDate && waitUntilDate > now) {
-      return t('styleguide/CommentComposer/wait', {
-        time: formatTimeRelative(waitUntilDate, { ...clock, now })
-      })
-    }
-  })()
-
   const handleReport = () => {
     if (window.confirm(t('styleguide/CommentActions/reportMessage'))) {
       onReport()
@@ -168,18 +181,13 @@ export const Actions = ({
         </IconButton>
       )}
       {onReply && !!displayAuthor && (
-        <IconButton
-          disabled={!!replyBlockedMessage}
-          onClick={onReply}
-          title={replyBlockedMessage || t('styleguide/CommentActions/answer')}
-        >
-          <ReplyIcon
-            {...colorScheme.set(
-              'fill',
-              replyBlockedMessage ? 'disabled' : 'text'
-            )}
-          />
-        </IconButton>
+        <ReplyIconButton
+          onReply={onReply}
+          colorScheme={colorScheme}
+          t={t}
+          userWaitUntil={userWaitUntil}
+          clock={clock}
+        />
       )}
       {userCanEdit && onEdit && (
         <IconButton

--- a/src/components/Discussion/Internal/Comment/Actions.js
+++ b/src/components/Discussion/Internal/Comment/Actions.js
@@ -14,7 +14,7 @@ import { sansSerifMedium14 } from '../../../Typography/styles'
 import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
 import { timeFormat } from '../../../../lib/timeFormat'
 import { useColorContext } from '../../../Colors/useColorContext'
-import useCurrentMinute from '../../../../lib/useCurrentMinute'
+import { useCurrentMinute } from '../../../../lib/useCurrentMinute'
 
 const dateFormat = timeFormat('%d.%m.%Y')
 const hmFormat = timeFormat('%H:%M')

--- a/src/components/Discussion/Internal/Comment/Actions.js
+++ b/src/components/Discussion/Internal/Comment/Actions.js
@@ -14,6 +14,7 @@ import { sansSerifMedium14 } from '../../../Typography/styles'
 import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
 import { timeFormat } from '../../../../lib/timeFormat'
 import { useColorContext } from '../../../Colors/useColorContext'
+import useCurrentMinute from '../../../../lib/useCurrentMinute'
 
 const dateFormat = timeFormat('%d.%m.%Y')
 const hmFormat = timeFormat('%H:%M')
@@ -137,11 +138,12 @@ export const Actions = ({
     }
   })()
 
+  const now = useCurrentMinute()
   const replyBlockedMessage = (() => {
     const waitUntilDate = userWaitUntil && new Date(userWaitUntil)
-    if (waitUntilDate && waitUntilDate > clock.now) {
+    if (waitUntilDate && waitUntilDate > now) {
       return t('styleguide/CommentComposer/wait', {
-        time: formatTimeRelative(waitUntilDate, clock)
+        time: formatTimeRelative(waitUntilDate, { ...clock, now })
       })
     }
   })()

--- a/src/components/Discussion/Internal/Comment/Header.js
+++ b/src/components/Discussion/Internal/Comment/Header.js
@@ -10,6 +10,7 @@ import { onlyS } from '../../../../theme/mediaQueries'
 
 import { ellipsize, underline } from '../../../../lib/styleMixins'
 import { timeFormat } from '../../../../lib/timeFormat'
+import useCurrentMinute from '../../../../lib/useCurrentMinute'
 
 import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
 import * as config from '../../config'
@@ -161,6 +162,8 @@ const MoreIconWithProps = props => (
 
 export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
   const { clock, discussion, Link } = React.useContext(DiscussionContext)
+  const now = useCurrentMinute()
+
   const [colorScheme] = useColorContext()
   const {
     displayAuthor,
@@ -276,6 +279,7 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
               <a {...styles.linkUnderline} suppressHydrationWarning>
                 {formatTimeRelative(new Date(createdAt), {
                   ...clock,
+                  now,
                   direction: 'past'
                 })}
               </a>

--- a/src/components/Discussion/Internal/Comment/Header.js
+++ b/src/components/Discussion/Internal/Comment/Header.js
@@ -10,14 +10,14 @@ import { onlyS } from '../../../../theme/mediaQueries'
 
 import { ellipsize, underline } from '../../../../lib/styleMixins'
 import { timeFormat } from '../../../../lib/timeFormat'
-import { useCurrentMinute } from '../../../../lib/useCurrentMinute'
-
-import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
+import { DiscussionContext } from '../../DiscussionContext'
 import * as config from '../../config'
 import { convertStyleToRem, pxToRem } from '../../../Typography/utils'
 import CalloutMenu from '../../../Callout/CalloutMenu'
 import { useColorContext } from '../../../Colors/useColorContext'
 import IconButton from '../../../IconButton'
+
+import RelativeTime from './RelativeTime'
 
 export const profilePictureSize = 40
 export const profilePictureMargin = 10
@@ -162,7 +162,6 @@ const MoreIconWithProps = props => (
 
 export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
   const { clock, discussion, Link } = React.useContext(DiscussionContext)
-  const now = useCurrentMinute()
 
   const [colorScheme] = useColorContext()
   const {
@@ -276,12 +275,8 @@ export const Header = ({ t, comment, menu, isExpanded, onToggle }) => {
             title={titleDate(createdAt)}
           >
             <Link discussion={discussion} comment={comment} passHref>
-              <a {...styles.linkUnderline} suppressHydrationWarning>
-                {formatTimeRelative(new Date(createdAt), {
-                  ...clock,
-                  now,
-                  direction: 'past'
-                })}
+              <a {...styles.linkUnderline}>
+                <RelativeTime {...clock} date={createdAt} />
               </a>
             </Link>
           </div>

--- a/src/components/Discussion/Internal/Comment/Header.js
+++ b/src/components/Discussion/Internal/Comment/Header.js
@@ -10,7 +10,7 @@ import { onlyS } from '../../../../theme/mediaQueries'
 
 import { ellipsize, underline } from '../../../../lib/styleMixins'
 import { timeFormat } from '../../../../lib/timeFormat'
-import useCurrentMinute from '../../../../lib/useCurrentMinute'
+import { useCurrentMinute } from '../../../../lib/useCurrentMinute'
 
 import { DiscussionContext, formatTimeRelative } from '../../DiscussionContext'
 import * as config from '../../config'

--- a/src/components/Discussion/Internal/Comment/RelativeTime.js
+++ b/src/components/Discussion/Internal/Comment/RelativeTime.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { useCurrentMinute } from '../../../../lib/useCurrentMinute'
+import { formatTimeRelative } from '../../DiscussionContext'
+
+const RelativeTime = ({ date, t, isDesktop, direction = 'past' }) => {
+  const now = useCurrentMinute()
+
+  return (
+    <span suppressHydrationWarning>
+      {formatTimeRelative(new Date(date), {
+        t,
+        isDesktop,
+        now,
+        direction
+      })}
+    </span>
+  )
+}
+
+export default RelativeTime

--- a/src/components/Discussion/Internal/docs.md
+++ b/src/components/Discussion/Internal/docs.md
@@ -241,6 +241,25 @@ The buttons / icons below the comment. The reply button is disabled if the discu
 </DiscussionContext.Provider>
 ```
 
+
+```react|noSource,span-2
+<DiscussionContext.Provider
+  value={createSampleDiscussionContextValue({ 
+    t,
+    userWaitUntil: '2050-01-01'
+  })}
+>
+  <Comment.Actions
+    t={t}
+    comment={comments.withAdminActions}
+    onUnpublish={() => {}}
+    onReport={() => {}}
+    onReply={() => {}}
+    onEdit={() => {}}
+  />
+</DiscussionContext.Provider>
+```
+
 ```react|noSource,span-2
 <Comment.Actions
   t={t}

--- a/src/components/TeaserActiveDebates/DebateTeaser.js
+++ b/src/components/TeaserActiveDebates/DebateTeaser.js
@@ -54,7 +54,6 @@ export const DebateTeaser = ({
   const discussionContextValue = {
     discussion,
     clock: {
-      now: Date.now(),
       isDesktop,
       t
     },

--- a/src/lib.js
+++ b/src/lib.js
@@ -146,6 +146,7 @@ export { CommentList } from './components/Discussion/Tree'
 export { DiscussionContext } from './components/Discussion/DiscussionContext'
 
 export { useMediaQuery } from './lib/useMediaQuery'
+export { useCurrentMinute } from './lib/useCurrentMinute'
 export { useBoundingClientRect } from './lib/useBoundingClientRect'
 export { usePrevious } from './lib/usePrevious'
 export { useDebounce } from './lib/useDebounce'

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-12-02T09:44:47.421Z",
+  "updated": "2021-04-14T20:45:47.534Z",
   "title": "live",
   "data": [
     {
@@ -25,6 +25,10 @@
     {
       "key": "styleguide/CommentComposer/etiquette",
       "value": "Etikette"
+    },
+    {
+      "key": "styleguide/CommentComposer/wait",
+      "value": "Sie können {time} wieder einen Beitrag schreiben."
     },
     {
       "key": "styleguide/CommentActions/expand",
@@ -141,7 +145,7 @@
     },
     {
       "key": "styleguide/comment/header/unpublishedByUser",
-      "value": "(von User zurückgezogen)"
+      "value": "(durch User zurückgezogen)"
     },
     {
       "key": "styleguide/comment/header/unpublishedByAdmin",

--- a/src/lib/useCurrentMinute.js
+++ b/src/lib/useCurrentMinute.js
@@ -28,7 +28,7 @@ const rmSetter = setter => {
   }
 }
 
-const useCurrentMinute = () => {
+export const useCurrentMinute = () => {
   const [now, setNow] = useState(() => Date.now())
   useEffect(() => {
     addSetter(setNow)
@@ -38,5 +38,3 @@ const useCurrentMinute = () => {
   }, [])
   return now
 }
-
-export default useCurrentMinute

--- a/src/lib/useCurrentMinute.js
+++ b/src/lib/useCurrentMinute.js
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react'
+
+let setters = []
+
+let timeout = null
+const startTimer = () => {
+  const currentTime = new Date()
+  const msLeft = 1000 - currentTime.getMilliseconds() + 50
+  const msToNextMinute = (60 - currentTime.getSeconds()) * 1000 + msLeft
+  timeout = setTimeout(() => {
+    const now = Date.now()
+    setters.forEach(setter => setter(now))
+    startTimer()
+  }, msToNextMinute)
+}
+
+const addSetter = setter => {
+  setters.push(setter)
+  if (timeout === null) {
+    startTimer()
+  }
+}
+const rmSetter = setter => {
+  setters = setters.filter(s => s !== setter)
+  if (!setter.length) {
+    clearTimeout(timeout)
+    timeout = null
+  }
+}
+
+const useCurrentMinute = () => {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    addSetter(setNow)
+    return () => {
+      rmSetter(setNow)
+    }
+  }, [])
+  return now
+}
+
+export default useCurrentMinute

--- a/src/lib/useCurrentMinute.js
+++ b/src/lib/useCurrentMinute.js
@@ -5,13 +5,16 @@ let setters = []
 let timeout = null
 const startTimer = () => {
   const currentTime = new Date()
-  const msLeft = 1000 - currentTime.getMilliseconds() + 50
+  const msLeft = 1000 - currentTime.getMilliseconds()
   const msToNextMinute = (60 - currentTime.getSeconds()) * 1000 + msLeft
+  // ensure timer runs in new minute and with at least 5 seconds in between
+  const msToNextRun = Math.max(msToNextMinute + 500, 5 * 1000)
+  clearTimeout(timeout)
   timeout = setTimeout(() => {
     const now = Date.now()
     setters.forEach(setter => setter(now))
     startTimer()
-  }, msToNextMinute)
+  }, msToNextRun)
 }
 
 const addSetter = setter => {

--- a/src/lib/useCurrentMinute.js
+++ b/src/lib/useCurrentMinute.js
@@ -7,7 +7,7 @@ const startTimer = () => {
   const currentTime = new Date()
   const msLeft = 1000 - currentTime.getMilliseconds()
   const msToNextMinute = (60 - currentTime.getSeconds()) * 1000 + msLeft
-  // ensure timer runs in new minute and with at least 5 seconds in between
+  // ensure timer runs in new minute and with at least 5 seconds in between runs
   const msToNextRun = Math.max(msToNextMinute + 500, 5 * 1000)
   clearTimeout(timeout)
   timeout = setTimeout(() => {


### PR DESCRIPTION
Move `now` out of discussion context and instead into an `useCurrentMinute` hook. The new hook is then directly used around the DOM element that relies on the current time. This greatly reduced the React conciliation effort necessary.

Before it took at least 40ms, often 60 to 90ms on an M1 with Chrome:
<img width="650" alt="Screenshot 2021-04-14 at 21 26 54" src="https://user-images.githubusercontent.com/410211/114792522-d5063900-9d88-11eb-96a7-14e8c4ecf225.png">

Afterwards we're down to 20ms:
<img width="581" alt="Screenshot 2021-04-15 at 01 14 21" src="https://user-images.githubusercontent.com/410211/114792607-f8c97f00-9d88-11eb-90af-01bf23b78142.png">

Even tested in IE11 and eliminates the worst freezes. Generally I'd expect this to have a greater positiv impact on slower devices.