### PR TITLE
fix(ShareImage): swap editorial default font

### DIFF
--- a/src/components/ShareImage/ShareImagePreview.js
+++ b/src/components/ShareImage/ShareImagePreview.js
@@ -36,7 +36,7 @@ const styles = {
     width: '100%',
     whiteSpace: 'pre-wrap',
     textAlign: 'center',
-    ...fontStyles.serifBold,
+    ...fontStyles.serifTitle,
     zIndex: 1
   }),
   formatTitle: css({
@@ -55,7 +55,7 @@ const styles = {
 
 const formatFonts = {
   scribble: 'cursiveTitle',
-  editorial: 'serifBold',
+  editorial: 'serifTitle',
   meta: 'sansSerifRegular'
 }
 
@@ -65,7 +65,7 @@ const shareImageJustify = {
 }
 
 export const SHARE_IMAGE_DEFAULTS = {
-  customFontStyle: 'serifBold',
+  customFontStyle: 'serifTitle',
   textPosition: 'bottom',
   fontSize: 60
 }


### PR DESCRIPTION
The default text of ShareTafeln is actually the Republik Font (serifTitle) and not the GT America (serifBold). See example from sketch file: 

![Screenshot 2021-04-19 at 10 11 29](https://user-images.githubusercontent.com/20746301/115203311-9dd0b880-a0f7-11eb-9e91-659c3ef6be97.jpg)
![Screenshot 2021-04-19 at 10 11 45](https://user-images.githubusercontent.com/20746301/115203350-a628f380-a0f7-11eb-8775-d86adc801fb4.jpg)

GT America is never used in ShareImages, which lucky for us means we can just swap the two fonts.

Sketch file for reference:
https://drive.google.com/file/d/1ywqwE-We-izYf1psxtvll1q4fuw5gi3d/view?usp=sharing