### PR TITLE
fix(ShareImage): replace border with boxShadow on Twitter

### DIFF
--- a/src/components/ShareImage/ShareImagePreview.js
+++ b/src/components/ShareImage/ShareImagePreview.js
@@ -17,6 +17,7 @@ export const socialPreviewStyles = {
 const styles = {
   container: css({
     position: 'relative',
+    marginTop: 4,
     width: SHARE_IMAGE_WIDTH,
     height: SHARE_IMAGE_HEIGHT,
     backgroundColor: '#000',
@@ -137,8 +138,7 @@ const ShareImagePreview = ({
               shareImageJustify[
                 textPosition || SHARE_IMAGE_DEFAULTS.textPosition
               ]) ||
-            'center',
-          borderWidth: socialPreview ? 2 : 0
+            'center'
         }}
       >
         {format?.image && !shareImage && (

--- a/src/components/ShareImage/SharePreviewTwitter.js
+++ b/src/components/ShareImage/SharePreviewTwitter.js
@@ -4,7 +4,9 @@ import { css } from 'glamor'
 export const imageStyle = css({
   borderTopLeftRadius: 15,
   borderTopRightRadius: 15,
-  border: '1px solid rgb(204, 214, 221)'
+  // boxshadow of image is 2x that of text container beacuse
+  // a scale 0.5 is applied on it.
+  boxShadow: '0px 0px 2px 2px rgb(204, 214, 221)'
 })
 
 const styles = {
@@ -15,8 +17,7 @@ const styles = {
     width: 600,
     borderBottomRightRadius: 15,
     borderBottomLeftRadius: 15,
-    border: '1px solid rgb(204, 214, 221)',
-    borderTop: 'none',
+    boxShadow: '0px 0px 1px 1px rgb(204, 214, 221)',
     padding: '10.5px 14px',
     fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
     maxHeight: 120,


### PR DESCRIPTION
fixes bug that katrin pointed out: Because a border of 2px was applied to the twitter preview and not the facebook preview (in publikator), the two would break words at different sizes:

<img width="360" alt="Screen Shot 2021-05-11 at 12 40 05" src="https://user-images.githubusercontent.com/20746301/117816668-0deddc80-b267-11eb-8d31-f49857087a64.png">


new result with box-shadow, which doesn't take up space like borders do:
<img width="643" alt="Screenshot 2021-05-11 at 14 39 33" src="https://user-images.githubusercontent.com/20746301/117816468-d2eba900-b266-11eb-95b3-38a9c57cd8f3.png">
