### PR TITLE
Bar Fixes

### DIFF
--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -253,7 +253,8 @@ Bar values can also work in advanced cases if one wants to display the total of 
         "#fdbb84": "#6a51a3",
         "#fc8d59": "#54278f"
       },
-      "showBarValues": true
+      "showBarValues": true,
+      "xTicks": [0]
     }}
     values={`
 category,value,label,pos

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -241,33 +241,39 @@ Bar values can also work in advanced cases if one wants to display the total of 
   <CsvChart
     config={{
       "type": "Bar",
-      "y": "category",
-      "sort": "none",
-      "colorSort": "none",
-      "color": "label",
-      "colorRange": [
-        "#fdd49e", "#fdbb84", "#fc8d59"
-      ],
-      "colorDarkMapping": {
-        "#fdd49e": "#807dba",
-        "#fdbb84": "#6a51a3",
-        "#fc8d59": "#54278f"
-      },
+      "y": "gender",
+      "color": "age",
+      "colorLegend": true,
       "showBarValues": true,
+      "sort": "none",
+      "domain": [-2000, 20000],
       "xTicks": [0]
     }}
     values={`
-category,value,label,pos
-Ca. 3500 Kilometer mehr mit ÖV,79,a,
-10 bis 16 Stunden mehr Flug pro Jahr,2074,a,
-10 bis 16 Stunden mehr Flug pro Jahr,200,b,right
-10 bis 16 Stunden mehr Flug pro Jahr,200,c,left
-Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-2074,a,
-Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-200,b,left
-Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-200,c,right
-Verzicht auf ca. 3500 Kilometer mit ÖV,-79,a,
-Yin und Yang,-100,,
-Yin und Yang,100,,
+age,gender,value
+0-9,Women,71
+10-19,Women,504
+20-29,Women,2270
+30-39,Women,2351
+40-49,Women,2728
+50-59,Women,3233
+60-69,Women,1613
+70-79,Women,1315
+80+,Women,2468
+0-9,Men,84
+10-19,Men,361
+20-29,Men,1534
+30-39,Men,1761
+40-49,Men,2042
+50-59,Men,2964
+60-69,Men,2034
+70-79,Men,1566
+80+,Men,1597
+80+,Cats,-100
+0-9,Cats,100
+10-19,Cats,100
+20-29,Cats,10
+80+,Dogs,-200
     `.trim()} />
 </div>
 ```

--- a/src/components/Chart/Bars.docs.md
+++ b/src/components/Chart/Bars.docs.md
@@ -232,6 +232,47 @@ Absinth,-0.8
 
 ## Advanced Labeling
 
+### Bar Values
+
+Bar values can also work in advanced cases if one wants to display the total of a bar.
+
+```react
+<div>
+  <CsvChart
+    config={{
+      "type": "Bar",
+      "y": "category",
+      "sort": "none",
+      "colorSort": "none",
+      "color": "label",
+      "colorRange": [
+        "#fdd49e", "#fdbb84", "#fc8d59"
+      ],
+      "colorDarkMapping": {
+        "#fdd49e": "#807dba",
+        "#fdbb84": "#6a51a3",
+        "#fc8d59": "#54278f"
+      },
+      "showBarValues": true
+    }}
+    values={`
+category,value,label,pos
+Ca. 3500 Kilometer mehr mit ÖV,79,a,
+10 bis 16 Stunden mehr Flug pro Jahr,2074,a,
+10 bis 16 Stunden mehr Flug pro Jahr,200,b,right
+10 bis 16 Stunden mehr Flug pro Jahr,200,c,left
+Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-2074,a,
+Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-200,b,left
+Verzicht auf 10 bis 16 Stunden Flug pro Jahr,-200,c,right
+Verzicht auf ca. 3500 Kilometer mit ÖV,-79,a,
+Yin und Yang,-100,,
+Yin und Yang,100,,
+    `.trim()} />
+</div>
+```
+
+### Inline Positions
+
 By default the first and middle bar segment labels are `left` and the last (if not also the first) is `right` ordiented. For negative values `right` and `left` are flipped.
 
 If needed this can be overwritten with a custom `inlineLabelPosition`. Valid values are: `left`, `right`, `center`.

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -262,11 +262,11 @@ const BarChart = props => {
         height: style.height,
         segments: barSegments,
         first,
-        max: barSegments.reduce(
+        sumPositiv: barSegments.reduce(
           (sum, segment) => sum + Math.max(0, segment.value),
           0
         ),
-        min: barSegments.reduce(
+        sumNegative: barSegments.reduce(
           (sum, segment) => sum + Math.min(0, segment.value),
           0
         )
@@ -276,8 +276,8 @@ const BarChart = props => {
     return {
       title,
       bars,
-      max: max(bars, bar => bar.max),
-      min: min(bars, bar => bar.min),
+      maxPositiv: max(bars, bar => bar.sumPositiv),
+      minNegative: min(bars, bar => bar.sumNegative),
       height: gY,
       firstBarY
     }
@@ -285,8 +285,14 @@ const BarChart = props => {
 
   // setup x scale
   const xDomain = props.domain || [
-    Math.min(0, min(groupedData.map(d => d.min).concat(props.xTicks || []))),
-    Math.max(0, max(groupedData.map(d => d.max).concat(props.xTicks || [])))
+    Math.min(
+      0,
+      min(groupedData.map(d => d.minNegative).concat(props.xTicks || []))
+    ),
+    Math.max(
+      0,
+      max(groupedData.map(d => d.maxPositiv).concat(props.xTicks || []))
+    )
   ]
   const x = scaleLinear()
     .domain(xDomain)
@@ -314,13 +320,13 @@ const BarChart = props => {
   // stack bars
   groupedData.forEach(group => {
     group.bars.forEach(bar => {
-      let xPosPositiv = xZero
-      let xPosNegativ = xZero
+      let xPosPositive = xZero
+      let xPosNegative = xZero
       bar.segments.forEach((d, i) => {
         d.color = color(colorAccessor(d))
         const size = x(d.value) - xZero
         d.x =
-          size > 0 ? Math.floor(xPosPositiv) : Math.floor(xPosNegativ + size)
+          size > 0 ? Math.floor(xPosPositive) : Math.floor(xPosNegative + size)
 
         d.width = Math.ceil(Math.abs(size))
         // snap last to last xTick if within one pixel
@@ -333,9 +339,9 @@ const BarChart = props => {
         }
 
         if (size > 0) {
-          xPosPositiv += size
+          xPosPositive += size
         } else {
-          xPosNegativ += size
+          xPosNegative += size
         }
         const isLast = last(bar.segments, i)
         d.valueTextStartAnchor =
@@ -379,8 +385,8 @@ const BarChart = props => {
           d.iXOffset = d.width / 2
         }
       })
-      bar.xPosPositiv = xPosPositiv
-      bar.xPosNegativ = xPosNegativ
+      bar.xPosPositive = xPosPositive
+      bar.xPosNegative = xPosNegative
     })
   })
 
@@ -466,8 +472,8 @@ const BarChart = props => {
               </text>
               {group.bars.map(bar => {
                 const href = bar.first.datum[link]
-                const hasNegativeValues = bar.xPosNegativ !== xZero
-                const hasPositiveValues = bar.xPosPositiv !== xZero
+                const hasNegativeValues = bar.xPosNegative !== xZero
+                const hasPositiveValues = bar.xPosPositive !== xZero
                 let barLabel = (
                   <text
                     {...styles.barLabel}
@@ -610,28 +616,28 @@ const BarChart = props => {
                       ))}
                     {showBarValues && (
                       <>
-                        {bar.min && (
+                        {bar.sumNegative && (
                           <text
                             {...styles.barLabel}
                             {...colorScheme.set('fill', 'text')}
-                            x={bar.xPosNegativ - 6 - (isLollipop ? 8 : 0)}
+                            x={bar.xPosNegative - 6 - (isLollipop ? 8 : 0)}
                             textAnchor='end'
                             y={bar.y + bar.height / 2}
                             dy='.35em'
                           >
-                            {xAxis.format(bar.min)}
+                            {xAxis.format(bar.sumNegative)}
                           </text>
                         )}
-                        {bar.max && (
+                        {bar.sumPositiv && (
                           <text
                             {...styles.barLabel}
                             {...colorScheme.set('fill', 'text')}
-                            x={bar.xPosPositiv + 6 + (isLollipop ? 8 : 0)}
+                            x={bar.xPosPositive + 6 + (isLollipop ? 8 : 0)}
                             textAnchor='start'
                             y={bar.y + bar.height / 2}
                             dy='.35em'
                           >
-                            {xAxis.format(bar.max)}
+                            {xAxis.format(bar.sumPositiv)}
                           </text>
                         )}
                       </>

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -507,112 +507,116 @@ const BarChart = props => {
                   // eslint-disable-next-line jsx-a11y/anchor-is-valid
                   barLabel = <a xlinkHref={href}>{barLabel}</a>
                 }
-                const segments = bar.segments.map(segment => ({
-                  data: segment,
-                  Component: () => (
-                    <g transform={`translate(0,${bar.y})`}>
-                      <rect
-                        x={segment.x}
-                        {...colorScheme.set('fill', segment.color, 'charts')}
-                        width={segment.width}
-                        height={bar.height}
-                      />
-                      {(inlineValue || inlineLabel) && (
-                        <Fragment>
-                          <text
-                            {...styles.inlineLabel}
-                            x={segment.x + segment.iXOffset}
-                            y={bar.style.inlineTop}
-                            dy='1em'
-                            fontSize={bar.style.fontSize}
-                            {...colorScheme.set(
-                              'fill',
-                              segment.shiftInlineText
-                                ? 'text'
-                                : getTextColor(segment.color)
-                            )}
-                            textAnchor={segment.iTextAnchor}
-                          >
-                            {subsup.svg(segment.inlineLabel)}
-                          </text>
-                          {inlineSecondaryLabel && (
-                            <text
-                              {...styles.inlineLabel}
-                              x={segment.x + segment.iXOffset}
-                              y={bar.style.inlineTop + bar.style.fontSize + 5}
-                              dy='1em'
-                              fontSize={bar.style.secondaryFontSize}
-                              {...colorScheme.set(
-                                'fill',
-                                segment.shiftInlineText
-                                  ? 'text'
-                                  : getTextColor(segment.color)
-                              )}
-                              textAnchor={segment.iTextAnchor}
-                            >
-                              {subsup.svg(segment.datum[inlineSecondaryLabel])}
-                            </text>
-                          )}
-                        </Fragment>
-                      )}
-                      {isLollipop && band && (
-                        <rect
-                          rx={bar.style.popHeight / 2}
-                          ry={bar.style.popHeight / 2}
-                          x={x(+segment.datum[`${band}_lower`])}
-                          y={bar.height / 2 - bar.style.popHeight / 2}
-                          width={
-                            x(+segment.datum[`${band}_upper`]) -
-                            x(+segment.datum[`${band}_lower`])
-                          }
-                          {...colorScheme.set('fill', segment.color, 'charts')}
-                          height={bar.style.popHeight}
-                          fillOpacity='0.3'
-                        />
-                      )}
-                      {isLollipop && (
-                        <circle
-                          cx={
-                            segment.x +
-                            (segment.value >= 0 ? segment.width - 1 : 0)
-                          }
-                          cy={bar.height / 2}
-                          r={
-                            Math.floor(
-                              bar.style.popHeight - bar.style.stroke / 2
-                            ) / 2
-                          }
-                          {...colorScheme.set('fill', 'textInverted')}
-                          {...colorScheme.set(
-                            'stroke',
-                            segment.color,
-                            'charts'
-                          )}
-                          strokeWidth={bar.style.stroke}
-                        />
-                      )}
-                    </g>
-                  )
-                }))
 
                 return (
                   <g key={`bar${bar.y}`}>
                     {barLabel}
-                    {segments
+                    {bar.segments
                       .sort((a, b) => {
                         if (
                           !inlineLabel ||
-                          (a.data.datum[inlineLabel] &&
-                            b.data.datum[inlineLabel]) ||
-                          (!a.data.datum[inlineLabel] &&
-                            !b.data.datum[inlineLabel])
+                          (a.datum[inlineLabel] && b.datum[inlineLabel]) ||
+                          (!a.datum[inlineLabel] && !b.datum[inlineLabel])
                         ) {
                           return 0
                         }
-                        return a.data.datum[inlineLabel] ? 1 : -1
+                        return a.datum[inlineLabel] ? 1 : -1
                       })
                       .map((segment, i) => (
-                        <segment.Component key={`seg${i}`} />
+                        <g key={`seg${i}`} transform={`translate(0,${bar.y})`}>
+                          <rect
+                            x={segment.x}
+                            {...colorScheme.set(
+                              'fill',
+                              segment.color,
+                              'charts'
+                            )}
+                            width={segment.width}
+                            height={bar.height}
+                          />
+                          {(inlineValue || inlineLabel) && (
+                            <Fragment>
+                              <text
+                                {...styles.inlineLabel}
+                                x={segment.x + segment.iXOffset}
+                                y={bar.style.inlineTop}
+                                dy='1em'
+                                fontSize={bar.style.fontSize}
+                                {...colorScheme.set(
+                                  'fill',
+                                  segment.shiftInlineText
+                                    ? 'text'
+                                    : getTextColor(segment.color)
+                                )}
+                                textAnchor={segment.iTextAnchor}
+                              >
+                                {subsup.svg(segment.inlineLabel)}
+                              </text>
+                              {inlineSecondaryLabel && (
+                                <text
+                                  {...styles.inlineLabel}
+                                  x={segment.x + segment.iXOffset}
+                                  y={
+                                    bar.style.inlineTop + bar.style.fontSize + 5
+                                  }
+                                  dy='1em'
+                                  fontSize={bar.style.secondaryFontSize}
+                                  {...colorScheme.set(
+                                    'fill',
+                                    segment.shiftInlineText
+                                      ? 'text'
+                                      : getTextColor(segment.color)
+                                  )}
+                                  textAnchor={segment.iTextAnchor}
+                                >
+                                  {subsup.svg(
+                                    segment.datum[inlineSecondaryLabel]
+                                  )}
+                                </text>
+                              )}
+                            </Fragment>
+                          )}
+                          {isLollipop && band && (
+                            <rect
+                              rx={bar.style.popHeight / 2}
+                              ry={bar.style.popHeight / 2}
+                              x={x(+segment.datum[`${band}_lower`])}
+                              y={bar.height / 2 - bar.style.popHeight / 2}
+                              width={
+                                x(+segment.datum[`${band}_upper`]) -
+                                x(+segment.datum[`${band}_lower`])
+                              }
+                              {...colorScheme.set(
+                                'fill',
+                                segment.color,
+                                'charts'
+                              )}
+                              height={bar.style.popHeight}
+                              fillOpacity='0.3'
+                            />
+                          )}
+                          {isLollipop && (
+                            <circle
+                              cx={
+                                segment.x +
+                                (segment.value >= 0 ? segment.width - 1 : 0)
+                              }
+                              cy={bar.height / 2}
+                              r={
+                                Math.floor(
+                                  bar.style.popHeight - bar.style.stroke / 2
+                                ) / 2
+                              }
+                              {...colorScheme.set('fill', 'textInverted')}
+                              {...colorScheme.set(
+                                'stroke',
+                                segment.color,
+                                'charts'
+                              )}
+                              strokeWidth={bar.style.stroke}
+                            />
+                          )}
+                        </g>
                       ))}
                     {showBarValues && (
                       <>

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -365,6 +365,8 @@ const BarChart = props => {
           d.iXOffset = d.width / 2
         }
       })
+      bar.xPosPositiv = xPosPositiv
+      bar.xPosNegativ = xPosNegativ
     })
   })
 
@@ -555,30 +557,6 @@ const BarChart = props => {
                           strokeWidth={bar.style.stroke}
                         />
                       )}
-                      {showBarValues && (
-                        <text
-                          {...styles.barLabel}
-                          {...colorScheme.set('fill', 'text')}
-                          x={
-                            segment.valueTextStartAnchor
-                              ? segment.x +
-                                segment.width +
-                                4 +
-                                (isLollipop ? 8 : 0)
-                              : segment.x +
-                                (segment.value >= 0 ? segment.width : 0) -
-                                4 -
-                                (isLollipop ? 8 : 0)
-                          }
-                          textAnchor={
-                            segment.valueTextStartAnchor ? 'start' : 'end'
-                          }
-                          y={bar.height / 2}
-                          dy='.35em'
-                        >
-                          {xAxis.format(segment.value)}
-                        </text>
-                      )}
                     </g>
                   )
                 }))
@@ -602,6 +580,34 @@ const BarChart = props => {
                       .map((segment, i) => (
                         <segment.Component key={`seg${i}`} />
                       ))}
+                    {showBarValues && (
+                      <>
+                        {bar.min && (
+                          <text
+                            {...styles.barLabel}
+                            {...colorScheme.set('fill', 'text')}
+                            x={bar.xPosNegativ - 6 - (isLollipop ? 8 : 0)}
+                            textAnchor='end'
+                            y={bar.y + bar.height / 2}
+                            dy='.35em'
+                          >
+                            {xAxis.format(bar.min)}
+                          </text>
+                        )}
+                        {bar.max && (
+                          <text
+                            {...styles.barLabel}
+                            {...colorScheme.set('fill', 'text')}
+                            x={bar.xPosPositiv + 6 + (isLollipop ? 8 : 0)}
+                            textAnchor='start'
+                            y={bar.y + bar.height / 2}
+                            dy='.35em'
+                          >
+                            {xAxis.format(bar.max)}
+                          </text>
+                        )}
+                      </>
+                    )}
                   </g>
                 )
               })}

--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -73,7 +73,7 @@ const sFormat = (tLabel, precision = 4, pow, type = 'r') => {
   const numberFormat4 = swissNumbers.format('d')
   const numberFormat5 = swissNumbers.format(',d')
   const numberFormat = value => {
-    if (String(Math.round(value)).length > 4) {
+    if (String(Math.abs(Math.round(value))).length > 4) {
       return numberFormat5(value)
     }
     return numberFormat4(value)
@@ -82,7 +82,7 @@ const sFormat = (tLabel, precision = 4, pow, type = 'r') => {
   const numberFormatWithSuffix4 = swissNumbers.format(`.${precision}${type}`)
   const numberFormatWithSuffix5 = swissNumbers.format(`,.${precision}${type}`)
   const numberFormatWithSuffix = value => {
-    if (String(Math.round(value)).length > 4) {
+    if (String(Math.abs(Math.round(value))).length > 4) {
       return numberFormatWithSuffix5(value)
     }
     return numberFormatWithSuffix4(value)
@@ -107,7 +107,7 @@ export const getFormat = (numberFormat, tLabel) => {
     specifier.comma = false
     const numberFormat4 = swissNumbers.format(specifier)
     return value => {
-      if (String(Math.round(value)).length > 4) {
+      if (String(Math.abs(Math.round(value))).length > 4) {
         return numberFormat5(value)
       }
       return numberFormat4(value)

--- a/src/components/Chart/utils.test.js
+++ b/src/components/Chart/utils.test.js
@@ -58,3 +58,16 @@ test('calculateAxis with two decimal digit ticks', assert => {
   )
   assert.end()
 })
+
+test('thousand separator', assert => {
+  const axis = calculateAxis('s', tLabel, [-10000, 10000], 'Gini-Koeffizient', {
+    ticks: []
+  })
+
+  assert.equal(axis.format(-1000), '-1000', 'format without thousand separator')
+  assert.equal(axis.format(1000), '1000', 'format without thousand separator')
+
+  assert.equal(axis.format(-10000), '-10’000', 'format with thousand separator')
+  assert.equal(axis.format(10000), '10’000', 'format with thousand separator')
+  assert.end()
+})


### PR DESCRIPTION
Changes
- sum `showBarValues`
- improve rendering precision of bar segments
- rm thousand separator for minus four digits (-1000 to -9999)

### sum `showBarValues`

<img width="1040" alt="Screenshot 2021-05-14 at 16 41 40" src="https://user-images.githubusercontent.com/410211/118288889-177c7c00-b4d5-11eb-8f24-25b71a9b96f8.png">

### rendering precision

| before | after |
|-|-|
| <img width="386" alt="Screenshot 2021-05-14 at 16 41 03" src="https://user-images.githubusercontent.com/410211/118287224-878a0280-b4d3-11eb-9837-09629c623bb7.png"> | <img width="396" alt="Screenshot 2021-05-14 at 16 41 14" src="https://user-images.githubusercontent.com/410211/118287178-7ccf6d80-b4d3-11eb-8a01-617f01c6eb9c.png"> |
| <img width="230" alt="Screenshot 2021-05-14 at 16 42 12" src="https://user-images.githubusercontent.com/410211/118287562-d9cb2380-b4d3-11eb-83f7-f6eaca2a2a93.png"> | <img width="238" alt="Screenshot 2021-05-14 at 16 42 26" src="https://user-images.githubusercontent.com/410211/118287579-de8fd780-b4d3-11eb-89e3-7caccfe283aa.png"> |




