### PR TITLE
fix(ShareImage): add missing line-height

### DIFF
--- a/src/components/ShareImage/ShareImagePreview.js
+++ b/src/components/ShareImage/ShareImagePreview.js
@@ -167,6 +167,7 @@ const ShareImagePreview = ({
             fontSize: fontSize || SHARE_IMAGE_DEFAULTS.fontSize,
             color: inverted ? '#FFF' : '#000',
             width: shareImage && '80%',
+            lineHeight: 1.25,
             border:
               preview && textContainerOverflow ? '1px dotted red' : 'none',
             maxHeight:


### PR DESCRIPTION
There was no line-height specified on the div containing the share image text. For ShareImages with GT-America, this lead to the scrollHeight sometimes to being higher than the clientHeight. It would also cut off the lower parts of the text:

before:
<img width="88" alt="Screenshot 2021-05-25 at 14 24 13" src="https://user-images.githubusercontent.com/20746301/119497909-5f1cc680-bd65-11eb-9c1c-dfa92791e688.png">
<img width="463" alt="Screenshot 2021-05-25 at 14 24 58" src="https://user-images.githubusercontent.com/20746301/119497938-6512a780-bd65-11eb-95e7-d036baeac44b.png">

by setting a proper line-height (html defaults to 1.15, which is not enough for gt america):
<img width="87" alt="Screenshot 2021-05-25 at 14 24 19" src="https://user-images.githubusercontent.com/20746301/119497965-6ba11f00-bd65-11eb-81e7-e59dea205073.png">
<img width="462" alt="Screenshot 2021-05-25 at 14 25 13" src="https://user-images.githubusercontent.com/20746301/119498058-82477600-bd65-11eb-8159-d6430dbd3830.png">

