### PR TITLE
Series Nav fixes

### DIFF
--- a/src/components/SeriesNav/SeriesNav.js
+++ b/src/components/SeriesNav/SeriesNav.js
@@ -110,17 +110,15 @@ function SeriesNav({
               )}
             </InfoBoxTitle>
             <InfoBoxText>
-              <span>
-                {series.description}
-                {titlePath && (
-                  <>
-                    {' '}
-                    <Link href={titlePath} passHref>
-                      <Editorial.A>Zur Serien-Übersicht</Editorial.A>
-                    </Link>
-                  </>
-                )}
-              </span>
+              {series.description}
+              {titlePath && (
+                <>
+                  {' '}
+                  <Link href={titlePath} passHref>
+                    <Editorial.A>Zur Serienübersicht</Editorial.A>
+                  </Link>
+                </>
+              )}
             </InfoBoxText>
           </InfoBox>
           {inlineAfterDescription}
@@ -154,11 +152,9 @@ function SeriesNav({
       </TeaserCarousel>
 
       {inline && PayNote && (
-        <div>
-          <ColorContextLocalExtension localColors={localInvertedColors}>
-            <PayNote context={context} repoId={repoId} inline />
-          </ColorContextLocalExtension>
-        </div>
+        <ColorContextLocalExtension localColors={localInvertedColors}>
+          <PayNote context={context} repoId={repoId} inline />
+        </ColorContextLocalExtension>
       )}
     </div>
   )

--- a/src/components/SeriesNav/SeriesNav.js
+++ b/src/components/SeriesNav/SeriesNav.js
@@ -10,10 +10,10 @@ import {
 } from '../InfoBox'
 import { Figure, FigureImage } from '../Figure'
 import { ColorContextLocalExtension } from '../Colors/ColorContext'
-import { useColorContext } from '../Colors/useColorContext'
 import Center, { PADDED_MAX_WIDTH_BREAKOUT } from '../Center'
 import SeriesNavTile from './SeriesNavTile'
 import { localInvertedColors } from '../../theme/colors'
+import { Editorial } from '../Typography'
 
 const DEFAULT_PAYNOTE_INDEX = 2
 
@@ -48,8 +48,6 @@ function SeriesNav({
   onEpisodeClick,
   aboveTheFold
 }) {
-  const [colorScheme] = useColorContext()
-
   const currentTile =
     repoId &&
     series.episodes.find(episode => episode.document?.repoId === repoId)
@@ -111,7 +109,14 @@ function SeriesNav({
                 series.title
               )}
             </InfoBoxTitle>
-            <InfoBoxText>{series.description}</InfoBoxText>
+            <InfoBoxText>
+              <span>
+                {series.description}{' '}
+                <Link href={titlePath} passHref>
+                  <Editorial.A>Zur Serien-Übersicht</Editorial.A>
+                </Link>
+              </span>
+            </InfoBoxText>
           </InfoBox>
           {inlineAfterDescription}
         </Center>
@@ -144,7 +149,7 @@ function SeriesNav({
       </TeaserCarousel>
 
       {inline && PayNote && (
-        <div {...colorScheme.set('backgroundColor', 'defaultInverted')}>
+        <div>
           <ColorContextLocalExtension localColors={localInvertedColors}>
             <PayNote context={context} repoId={repoId} inline />
           </ColorContextLocalExtension>

--- a/src/components/SeriesNav/SeriesNav.js
+++ b/src/components/SeriesNav/SeriesNav.js
@@ -37,6 +37,7 @@ const styles = {
 const DefaultLink = ({ children }) => children
 
 function SeriesNav({
+  t,
   repoId,
   series,
   inline,
@@ -115,7 +116,9 @@ function SeriesNav({
                 <>
                   {' '}
                   <Link href={titlePath} passHref>
-                    <Editorial.A>Zur Serienübersicht</Editorial.A>
+                    <Editorial.A>
+                      {t('styleguide/SeriesNav/seriesoverview')}
+                    </Editorial.A>
                   </Link>
                 </>
               )}
@@ -145,6 +148,7 @@ function SeriesNav({
                 Link={Link}
                 onEpisodeClick={onEpisodeClick}
                 aboveTheFold={aboveTheFold}
+                t={t}
               />
             )
           })}
@@ -168,7 +172,8 @@ SeriesNav.propTypes = {
   PayNote: PropTypes.func,
   inline: PropTypes.bool,
   height: PropTypes.number,
-  onEpisodeClick: PropTypes.func
+  onEpisodeClick: PropTypes.func,
+  t: PropTypes.func.isRequired
 }
 
 export default SeriesNav

--- a/src/components/SeriesNav/SeriesNav.js
+++ b/src/components/SeriesNav/SeriesNav.js
@@ -111,10 +111,15 @@ function SeriesNav({
             </InfoBoxTitle>
             <InfoBoxText>
               <span>
-                {series.description}{' '}
-                <Link href={titlePath} passHref>
-                  <Editorial.A>Zur Serien-Übersicht</Editorial.A>
-                </Link>
+                {series.description}
+                {titlePath && (
+                  <>
+                    {' '}
+                    <Link href={titlePath} passHref>
+                      <Editorial.A>Zur Serien-Übersicht</Editorial.A>
+                    </Link>
+                  </>
+                )}
               </span>
             </InfoBoxText>
           </InfoBox>

--- a/src/components/SeriesNav/SeriesNavTile.js
+++ b/src/components/SeriesNav/SeriesNavTile.js
@@ -19,6 +19,7 @@ const styles = {
   tile: css({
     marginBottom: 20,
     width: '100%',
+    minWidth: GRID_MIN_WIDTH,
     padding: TILE_GRID_PADDING,
     [`@media only screen and (min-width: ${OUTER_CONTAINER_PADDING * 2 +
       GRID_MIN_WIDTH * 2}px)`]: {

--- a/src/components/SeriesNav/SeriesNavTile.js
+++ b/src/components/SeriesNav/SeriesNavTile.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { css } from 'glamor'
 
 import { ColorContextLocalExtension } from '../Colors/ColorContext'
-import { useColorContext } from '../Colors/useColorContext'
 import {
   PADDING,
   TILE_MARGIN_RIGHT,
@@ -52,9 +51,7 @@ const SeriesNavTile = ({
   onEpisodeClick,
   aboveTheFold
 }) => {
-  const [colorScheme] = useColorContext()
-
-  const isInverted = !!(current || PayNote)
+  const isInverted = !!PayNote
   const content = PayNote ? (
     <PayNote context={context} repoId={repoId} index={index} />
   ) : (
@@ -73,7 +70,6 @@ const SeriesNavTile = ({
   return (
     <div
       {...(inline ? styles.inlineTile : styles.tile)}
-      {...(isInverted && colorScheme.set('backgroundColor', 'defaultInverted'))}
       style={{
         opacity: inactiveTile ? 0.6 : 1
       }}

--- a/src/components/SeriesNav/SeriesNavTile.js
+++ b/src/components/SeriesNav/SeriesNavTile.js
@@ -40,6 +40,7 @@ const styles = {
 }
 
 const SeriesNavTile = ({
+  t,
   episode,
   current,
   inline,
@@ -64,6 +65,7 @@ const SeriesNavTile = ({
       Link={Link}
       onEpisodeClick={onEpisodeClick}
       aboveTheFold={aboveTheFold}
+      t={t}
     />
   )
   const inactiveTile = !isInverted && !episode?.document?.meta?.path

--- a/src/components/SeriesNav/SeriesNavTileContent.js
+++ b/src/components/SeriesNav/SeriesNavTileContent.js
@@ -60,6 +60,7 @@ const styles = {
 const DefaultLink = ({ children }) => children
 
 const SeriesNavTileContent = ({
+  t,
   inline,
   episode,
   current,
@@ -96,7 +97,8 @@ const SeriesNavTileContent = ({
           {...(current ? styles.labelMedium : styles.labelRegular)}
           {...colorScheme.set('color', 'text')}
         >
-          {`${current ? 'Sie lesen: ' : ''}${episode.label}`}
+          {current ? `${t('styleguide/SeriesNav/current')} ` : null}
+          {episode.label}
         </p>
         {imageProps ? (
           <FigureImage aboveTheFold={aboveTheFold} {...imageProps} alt='' />

--- a/src/components/SeriesNav/SeriesNavTileContent.js
+++ b/src/components/SeriesNav/SeriesNavTileContent.js
@@ -36,13 +36,15 @@ const styles = {
     marginTop: 0,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+    whiteSpace: 'nowrap'
+  }),
+  labelRegular: css({
     ...sansSerifRegular12,
     [mUp]: {
       ...sansSerifRegular14
     }
   }),
-  currentLabel: css({
+  labelMedium: css({
     ...sansSerifMedium12,
     [mUp]: {
       ...sansSerifMedium14
@@ -91,7 +93,7 @@ const SeriesNavTileContent = ({
       <LinkContainer>
         <p
           {...styles.label}
-          {...(current && styles.currentLabel)}
+          {...(current ? styles.labelMedium : styles.labelRegular)}
           {...colorScheme.set('color', 'text')}
         >
           {`${current ? 'Sie lesen: ' : ''}${episode.label}`}
@@ -111,7 +113,7 @@ const SeriesNavTileContent = ({
       <LinkContainer>
         <p
           {...styles.label}
-          {...(current && styles.currentLabel)}
+          {...(current ? styles.labelMedium : styles.labelRegular)}
           {...colorScheme.set('color', 'text')}
         >
           {current ? 'Sie lesen: ' : null}

--- a/src/components/SeriesNav/SeriesNavTileContent.js
+++ b/src/components/SeriesNav/SeriesNavTileContent.js
@@ -97,7 +97,7 @@ const SeriesNavTileContent = ({
           {...(current ? styles.labelMedium : styles.labelRegular)}
           {...colorScheme.set('color', 'text')}
         >
-          {current ? `${t('styleguide/SeriesNav/current')} ` : null}
+          {current ? `${t('styleguide/SeriesNav/current')} ` : ''}
           {episode.label}
         </p>
         {imageProps ? (
@@ -118,7 +118,7 @@ const SeriesNavTileContent = ({
           {...(current ? styles.labelMedium : styles.labelRegular)}
           {...colorScheme.set('color', 'text')}
         >
-          {current ? 'Sie lesen: ' : null}
+          {current ? 'Sie lesen: ' : ''}
           {episode.label}
         </p>
         {imageProps ? (

--- a/src/components/SeriesNav/SeriesNavTileContent.js
+++ b/src/components/SeriesNav/SeriesNavTileContent.js
@@ -8,7 +8,9 @@ import {
   serifRegular15,
   serifRegular17,
   sansSerifRegular14,
-  sansSerifRegular12
+  sansSerifRegular12,
+  sansSerifMedium14,
+  sansSerifMedium12
 } from '../Typography/styles'
 import { useColorContext } from '../Colors/useColorContext'
 import { FigureImage } from '../Figure'
@@ -38,6 +40,12 @@ const styles = {
     ...sansSerifRegular12,
     [mUp]: {
       ...sansSerifRegular14
+    }
+  }),
+  currentLabel: css({
+    ...sansSerifMedium12,
+    [mUp]: {
+      ...sansSerifMedium14
     }
   }),
   plainlink: css({
@@ -81,7 +89,11 @@ const SeriesNavTileContent = ({
   if (inline) {
     return (
       <LinkContainer>
-        <p {...styles.label} {...colorScheme.set('color', 'text')}>
+        <p
+          {...styles.label}
+          {...(current && styles.currentLabel)}
+          {...colorScheme.set('color', 'text')}
+        >
           {`${current ? 'Sie lesen: ' : ''}${episode.label}`}
         </p>
         {imageProps ? (
@@ -97,7 +109,11 @@ const SeriesNavTileContent = ({
   return (
     <>
       <LinkContainer>
-        <p {...styles.label} {...colorScheme.set('color', 'text')}>
+        <p
+          {...styles.label}
+          {...(current && styles.currentLabel)}
+          {...colorScheme.set('color', 'text')}
+        >
           {current ? 'Sie lesen: ' : null}
           {episode.label}
         </p>

--- a/src/components/SeriesNav/__docs__/seriesNavExample.js
+++ b/src/components/SeriesNav/__docs__/seriesNavExample.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Interaction } from '../../Typography'
+import { useColorContext } from '../../Colors/ColorContext'
 
 export const repoId = '3'
 export const series = {
@@ -84,8 +85,12 @@ export const series = {
 }
 
 export const TestPayNote = ({ inline }) => {
+  const [colorScheme] = useColorContext()
   return (
-    <div style={{ height: '100%', padding: inline ? 5 : undefined }}>
+    <div
+      style={{ height: '100%', padding: inline ? 5 : undefined }}
+      {...colorScheme.set('backgroundColor', 'default')}
+    >
       <Interaction.P>Jetzt Probelesen</Interaction.P>
     </div>
   )

--- a/src/components/SeriesNav/docs.md
+++ b/src/components/SeriesNav/docs.md
@@ -16,6 +16,7 @@
       )
     }
     PayNote={TestPayNote}
+    t={t}
   />
 ```
 
@@ -27,5 +28,6 @@
     series={series}
     inline={true}
     PayNote={TestPayNote}
+    t={t}
   />
 ```

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-05-19T07:12:31.421Z",
+  "updated": "2021-06-15T13:41:23.989Z",
   "title": "live",
   "data": [
     {
@@ -122,6 +122,14 @@
       "key": "styleguide/CommentTreeCollapse/label",
       "value": "ausblenden",
       "undefined": " "
+    },
+    {
+      "key": "styleguide/SeriesNav/seriesoverview",
+      "value": "Zur Serienübersicht"
+    },
+    {
+      "key": "styleguide/SeriesNav/current",
+      "value": "Sie lesen:"
     },
     {
       "key": "styleguide/comment/header/updated",

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -537,7 +537,8 @@ const createTeasers = ({
         inline: !node.data.grid,
         ActionBar: ActionBar,
         PayNote: PayNote,
-        Link: Link
+        Link: Link,
+        t: t
       }
     },
     rules: [],

--- a/src/templates/Article/teasers.js
+++ b/src/templates/Article/teasers.js
@@ -527,7 +527,7 @@ const createTeasers = ({
   const seriesNav = {
     matchMdast: matchZone('SERIES_NAV'),
     component: ({ ...props }) => {
-      return <SeriesNav {...props} />
+      return <SeriesNav t={t} {...props} />
     },
     props: (node, index, parent, { ancestors }) => {
       const root = ancestors[ancestors.length - 1]
@@ -537,8 +537,7 @@ const createTeasers = ({
         inline: !node.data.grid,
         ActionBar: ActionBar,
         PayNote: PayNote,
-        Link: Link,
-        t: t
+        Link: Link
       }
     },
     rules: [],


### PR DESCRIPTION
- remove inverted current episode style and replace with medium label (leaves paynote as is for now)
before:
<img width="381" alt="Screenshot 2021-06-15 at 10 12 18" src="https://user-images.githubusercontent.com/20746301/122017603-6c582e80-cdc2-11eb-9fc5-b772d9569a5a.png">
after:
<img width="367" alt="Screenshot 2021-06-15 at 10 12 28" src="https://user-images.githubusercontent.com/20746301/122017595-6a8e6b00-cdc2-11eb-89fa-43917465bf0c.png">
before:
<img width="619" alt="Screenshot 2021-06-15 at 10 11 48" src="https://user-images.githubusercontent.com/20746301/122017607-6cf0c500-cdc2-11eb-8bb6-9e208fcad413.png">
after:
<img width="614" alt="Screenshot 2021-06-15 at 10 11 29" src="https://user-images.githubusercontent.com/20746301/122017620-6e21f200-cdc2-11eb-9461-c2f0c530d628.png">
before:
<img width="1062" alt="Screenshot 2021-06-15 at 10 15 41" src="https://user-images.githubusercontent.com/20746301/122018365-12a43400-cdc3-11eb-8d3f-ecf1a2991d1f.png">
after:
<img width="1055" alt="Screenshot 2021-06-15 at 10 15 34" src="https://user-images.githubusercontent.com/20746301/122018378-159f2480-cdc3-11eb-9829-f00ead8da2da.png">

- adds link to overview to inline description
<img width="751" alt="Screenshot 2021-06-15 at 10 20 00" src="https://user-images.githubusercontent.com/20746301/122018575-48e1b380-cdc3-11eb-8fa9-e3c5c5f09e76.png">

- adds minWidth to tiles 
before
<img width="570" alt="Screenshot 2021-06-15 at 10 22 26" src="https://user-images.githubusercontent.com/20746301/122018950-9d852e80-cdc3-11eb-859f-c48eb8f52a8c.png">
after
<img width="752" alt="Screenshot 2021-06-15 at 10 22 02" src="https://user-images.githubusercontent.com/20746301/122018955-9eb65b80-cdc3-11eb-9449-35e01cc6a9d5.png">
