### PR TITLE
Fix Svg Export

### DIFF
--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -669,6 +669,7 @@ const BarChart = props => {
                     const highlightTick = tick === 0 && highlightZero
                     return (
                       <g
+                        data-axis
                         key={`tick${tick}`}
                         transform={`translate(${x(tick)},0)`}
                       >

--- a/src/components/Chart/Lines.js
+++ b/src/components/Chart/Lines.js
@@ -168,7 +168,11 @@ const LineGroup = props => {
           textAnchor = 'start'
         }
         return (
-          <g key={`x${tick}`} transform={`translate(${x(tick)},${xAxisY})`}>
+          <g
+            data-axis
+            key={`x${tick}`}
+            transform={`translate(${x(tick)},${xAxisY})`}
+          >
             <line
               {...styles.axisXLine}
               {...colorScheme.set('stroke', 'text')}
@@ -292,7 +296,7 @@ const LineGroup = props => {
         }
       )}
       {yTicks.map((tick, i) => (
-        <g key={`y${tick}`} transform={`translate(0,${y(tick)})`}>
+        <g data-axis key={`y${tick}`} transform={`translate(0,${y(tick)})`}>
           <line
             {...styles.axisYLine}
             x2={width}

--- a/src/components/Chart/ScatterPlotGroup.js
+++ b/src/components/Chart/ScatterPlotGroup.js
@@ -60,7 +60,7 @@ const ScatterPlotGroup = ({
   xUnit,
   annotations,
   contextBoxProps,
-  useCanvas
+  allowCanvasRendering
 }) => {
   const [hover, setHover] = useState([])
   const [hoverTouch, setHoverTouch] = useState()
@@ -153,7 +153,7 @@ const ScatterPlotGroup = ({
 
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
-      {useCanvas && (
+      {allowCanvasRendering && (
         <ScatterPlotCanvas
           opacity={opacity}
           symbols={symbols}
@@ -177,7 +177,7 @@ const ScatterPlotGroup = ({
             {title}
           </text>
         )}
-        {!useCanvas &&
+        {!allowCanvasRendering &&
           symbols.map(symbol => (
             <circle
               key={symbol.key}

--- a/src/components/Chart/ScatterPlotGroup.js
+++ b/src/components/Chart/ScatterPlotGroup.js
@@ -216,6 +216,7 @@ const ScatterPlotGroup = ({
         ))}
         {plotYLines.map(({ tick, label, base }, i) => (
           <g
+            data-axis
             key={tick}
             transform={`translate(${yLinesPaddingLeft},${plotY(tick)})`}
           >
@@ -248,6 +249,7 @@ const ScatterPlotGroup = ({
           }
           return (
             <g
+              data-axis
               key={`x${tick}`}
               transform={`translate(${plotX(tick)},${paddingTop +
                 height +

--- a/src/components/Chart/ScatterPlots.js
+++ b/src/components/Chart/ScatterPlots.js
@@ -83,7 +83,8 @@ const ScatterPlot = ({
   columnFilter,
   columns,
   minInnerWidth,
-  annotations
+  annotations,
+  allowCanvasRendering
 }) => {
   const data = values
     .filter(d => d[x] && d[x].length > 0 && d[y] && d[y].length > 0)
@@ -263,7 +264,7 @@ const ScatterPlot = ({
                 )}
                 contextBoxProps={contextBoxProps}
                 // canvas does not support dark mapping yet
-                useCanvas={!colorDarkMapping}
+                allowCanvasRendering={allowCanvasRendering && !colorDarkMapping}
               />
             </div>
           )

--- a/src/components/Chart/TimeBarGroup.js
+++ b/src/components/Chart/TimeBarGroup.js
@@ -87,7 +87,7 @@ const TimeBarGroup = ({
       })}
       <g transform={`translate(0,${xAxisPos})`}>{xAxis}</g>
       {yTicks.map((tick, i) => (
-        <g key={tick} transform={`translate(0,${y(tick)})`}>
+        <g data-axis key={tick} transform={`translate(0,${y(tick)})`}>
           {tick !== baseTick && (
             <line
               {...styles.axisYLine}

--- a/src/components/Chart/XAxis.js
+++ b/src/components/Chart/XAxis.js
@@ -31,7 +31,7 @@ const XAxis = ({
   const ticks = getXTicks(xTicks, xValues, xNormalizer, x)
 
   return (
-    <>
+    <g data-axis>
       {baseLines.map((line, i) => (
         <line
           key={i}
@@ -65,7 +65,7 @@ const XAxis = ({
           </text>
         </g>
       ))}
-    </>
+    </g>
   )
 }
 

--- a/src/components/Chart/docs.js
+++ b/src/components/Chart/docs.js
@@ -45,6 +45,7 @@ const props = Object.keys(baseChartPropTypes).reduce((all, chart) => {
 const IGNORE_KEYS = [
   // for react usage only
   't',
+  'tLabel',
   'children',
   'values',
   'width',

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -129,7 +129,13 @@ const Chart = props => {
 
   const [stateWidth, setWidth] = useState(ssrMode ? 290 : undefined)
 
-  const { width: fixedWidth, config, tLabel } = props
+  const {
+    width: fixedWidth,
+    config,
+    tLabel,
+    // allowCanvasRendering might be set to false when exporting SVGs
+    allowCanvasRendering = true
+  } = props
 
   const width = fixedWidth || stateWidth
   const ReactChart = ReactCharts[config.type]
@@ -191,6 +197,7 @@ const Chart = props => {
       {!!width && (
         <ReactChart
           {...config}
+          allowCanvasRendering={allowCanvasRendering}
           // make colorScheme available for class components—maps
           colorScheme={colorScheme}
           tLabel={tLabel}


### PR DESCRIPTION
Small changes for smooth SVG export:
- allow to disable canvas rendering from the outside
- mark axis groups for easy removal
  - we used to remove all line elements but annotation lines should actually not be removed