### PR TITLE
feat(CommentComposer): Allows a label to be displayed 

### DIFF
--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -298,11 +298,11 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
-      {label ? (
+      {label && (
         <div {...styles.label}>
           <Label>{label}</Label>
         </div>
-      ) : null}
+      )}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -94,7 +94,7 @@ export const CommentComposer = props => {
   /*
    * Get the discussion metadata and action callbacks from the DiscussionContext.
    */
-  const { discussion, actions, getLabel } = React.useContext(DiscussionContext)
+  const { discussion, actions } = React.useContext(DiscussionContext)
   const { id: discussionId, tags, rules, displayAuthor, isBoard } = discussion
   const { maxLength } = rules
 
@@ -191,7 +191,9 @@ export const CommentComposer = props => {
   const onChangeText = ev => {
     const nextText = ev.target.value
     setText(nextText)
-    setLabel(getLabel(nextText))
+    if (actions.getLabel) {
+      setLabel(actions.getLabel(nextText))
+    }
     try {
       localStorage.setItem(localStorageKey, ev.target.value)
     } catch (e) {

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -12,6 +12,7 @@ import { convertStyleToRem } from '../../Typography/utils'
 import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
 import { useColorContext } from '../../Colors/useColorContext'
+import { Label } from '../../Typography'
 import Loader from '../../Loader'
 
 const styles = {
@@ -41,6 +42,9 @@ const styles = {
     position: 'absolute',
     bottom: 6,
     left: 8
+  }),
+  label: css({
+    padding: '8px 8px 0px 8px'
   }),
   withBorderBottom: css({
     borderBottomWidth: 1,
@@ -80,6 +84,7 @@ export const CommentComposer = props => {
    */
   const root = React.useRef()
   const [textarea, textareaRef] = React.useState(null)
+  const [label, setLabel] = React.useState(false)
   const textRef = React.useRef()
   const [preview, setPreview] = React.useState({
     loading: false,
@@ -89,7 +94,7 @@ export const CommentComposer = props => {
   /*
    * Get the discussion metadata and action callbacks from the DiscussionContext.
    */
-  const { discussion, actions } = React.useContext(DiscussionContext)
+  const { discussion, actions, getLabel } = React.useContext(DiscussionContext)
   const { id: discussionId, tags, rules, displayAuthor, isBoard } = discussion
   const { maxLength } = rules
 
@@ -186,6 +191,7 @@ export const CommentComposer = props => {
   const onChangeText = ev => {
     const nextText = ev.target.value
     setText(nextText)
+    setLabel(getLabel(nextText))
     try {
       localStorage.setItem(localStorageKey, ev.target.value)
     } catch (e) {
@@ -292,6 +298,11 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
+      {label ? (
+        <div {...styles.label}>
+          <Label>{label}</Label>
+        </div>
+      ) : null}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -66,6 +66,12 @@ export const CommentComposerPlayground = () => {
     actions: {
       openDiscussionPreferences: () => Promise.resolve({ ok: true })
     },
+    getLabel: text => {
+      if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+        return 'Label'
+      }
+      return false
+    },
     composerSecondaryActions: (
       <>
         <SecondaryAction>

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -64,13 +64,13 @@ export const CommentComposerPlayground = () => {
       tagRequired
     },
     actions: {
-      openDiscussionPreferences: () => Promise.resolve({ ok: true })
-    },
-    getLabel: text => {
-      if (!text.includes('\\*') && text.includes('*')) {
-        return t('styleguide/CommentComposer/formatting/asterisk')
+      openDiscussionPreferences: () => Promise.resolve({ ok: true }),
+      getLabel: text => {
+        if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+          return t('styleguide/CommentComposer/formatting/asterisk')
+        }
+        return false
       }
-      return false
     },
     composerSecondaryActions: (
       <>

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -68,7 +68,7 @@ export const CommentComposerPlayground = () => {
     },
     getLabel: text => {
       if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
-        return 'Label'
+        return t('styleguide/CommentComposer/formattingHelp')
       }
       return false
     },

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -67,7 +67,7 @@ export const CommentComposerPlayground = () => {
       openDiscussionPreferences: () => Promise.resolve({ ok: true })
     },
     getLabel: text => {
-      if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+      if (!text.includes('\\*') && text.includes('*')) {
         return t('styleguide/CommentComposer/formattingHelp')
       }
       return false

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -68,7 +68,7 @@ export const CommentComposerPlayground = () => {
     },
     getLabel: text => {
       if (!text.includes('\\*') && text.includes('*')) {
-        return t('styleguide/CommentComposer/formattingHelp')
+        return t('styleguide/CommentComposer/formatting/asterisk')
       }
       return false
     },

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-06-15T13:41:23.989Z",
+  "updated": "2021-07-29T14:38:46.724Z",
   "title": "live",
   "data": [
     {
@@ -29,6 +29,10 @@
     {
       "key": "styleguide/CommentComposer/wait",
       "value": "Sie können {time} wieder einen Beitrag schreiben."
+    },
+    {
+      "key": "styleguide/CommentComposer/formattingHelp",
+      "value": "Benutzen Sie ein Backslash vor dem Gendersternchen damit es nicht mit kursiv verwechselt wird:\nLeser\\*in"
     },
     {
       "key": "styleguide/CommentActions/expand",

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-07-29T14:38:46.724Z",
+  "updated": "2021-07-29T15:26:19.281Z",
   "title": "live",
   "data": [
     {
@@ -31,7 +31,7 @@
       "value": "Sie können {time} wieder einen Beitrag schreiben."
     },
     {
-      "key": "styleguide/CommentComposer/formattingHelp",
+      "key": "styleguide/CommentComposer/formatting/asterisk",
       "value": "Benutzen Sie ein Backslash vor dem Gendersternchen damit es nicht mit kursiv verwechselt wird:\nLeser\\*in"
     },
     {

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-07-29T15:26:19.281Z",
+  "updated": "2021-07-29T15:29:32.397Z",
   "title": "live",
   "data": [
     {
@@ -32,7 +32,7 @@
     },
     {
       "key": "styleguide/CommentComposer/formatting/asterisk",
-      "value": "Benutzen Sie ein Backslash vor dem Gendersternchen damit es nicht mit kursiv verwechselt wird:\nLeser\\*in"
+      "value": "Damit System Gendersternchen erkennt, stellen Sie einen Backslash voran: Leser\\*in"
     },
     {
       "key": "styleguide/CommentActions/expand",


### PR DESCRIPTION
Uses the DiscussionContext, wich has been expanded in the example (and will be expanded in the frontend) to include a `getLabel` function. The function accepts the input value and can include arbitrarily complex logic to return warning labels, which will be displayed at the bottom of the text input. In the example, it warns the user to escape the "*-character" if it detects it in the text input field.