### PR TITLE
feat(CommentComposer): Show hints while typing

### DIFF
--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -298,11 +298,11 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
-      {label ? (
+      {label && (
         <div {...styles.label}>
           <Label>{label}</Label>
         </div>
-      ) : null}
+      )}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -94,7 +94,7 @@ export const CommentComposer = props => {
   /*
    * Get the discussion metadata and action callbacks from the DiscussionContext.
    */
-  const { discussion, actions, getLabel } = React.useContext(DiscussionContext)
+  const { discussion, actions } = React.useContext(DiscussionContext)
   const { id: discussionId, tags, rules, displayAuthor, isBoard } = discussion
   const { maxLength } = rules
 
@@ -191,7 +191,9 @@ export const CommentComposer = props => {
   const onChangeText = ev => {
     const nextText = ev.target.value
     setText(nextText)
-    setLabel(getLabel(nextText))
+    if (actions.getLabel) {
+      setLabel(actions.getLabel(nextText))
+    }
     try {
       localStorage.setItem(localStorageKey, ev.target.value)
     } catch (e) {

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -49,7 +49,7 @@ const styles = {
     borderBottomStyle: 'solid'
   }),
   hints: css({
-    marginBottom: 6
+    marginTop: 6
   })
 }
 

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -13,8 +13,6 @@ import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
 import { useColorContext } from '../../Colors/useColorContext'
 import Loader from '../../Loader'
-import IconButton from '../../IconButton'
-import { CloseIcon } from '../../Icons'
 
 const styles = {
   root: css({}),

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -91,7 +91,6 @@ export const CommentComposer = props => {
     loading: false,
     comment: null
   })
-  const [showHints, setShowHints] = React.useState(true)
 
   /*
    * Get the discussion metadata, action callbacks and hinters from DiscussionContext.
@@ -302,23 +301,12 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
-      {hints.length > 0 && showHints && (
-        <div
-          style={{ marginTop: 2, padding: 8 }}
-          {...colorScheme.set('background', 'hover')}
-        >
-          {hints.map((hint, index) => (
-            <div {...styles.hints} key={`hint-${index}`}>
-              {hint}
-            </div>
-          ))}
-          <IconButton
-            Icon={CloseIcon}
-            label='Formattierungshilfe schliessen'
-            onClick={() => setShowHints(false)}
-          />
-        </div>
-      )}
+      {hints &&
+        hints.map((hint, index) => (
+          <div {...styles.hints} key={`hint-${index}`}>
+            {hint}
+          </div>
+        ))}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -43,9 +43,6 @@ const styles = {
     bottom: 6,
     left: 8
   }),
-  hint: css({
-    padding: '8px 8px 0px 8px'
-  }),
   withBorderBottom: css({
     borderBottomWidth: 1,
     borderBottomStyle: 'solid'
@@ -302,11 +299,7 @@ export const CommentComposer = props => {
       </div>
 
       {hints &&
-        hints.map((hint, index) => (
-          <div key={`hint-${index}`} {...styles.hint}>
-            <Label>{hint}</Label>
-          </div>
-        ))}
+        hints.map((hint, index) => <div key={`hint-${index}`}>{hint}</div>)}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -12,6 +12,7 @@ import { convertStyleToRem } from '../../Typography/utils'
 import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
 import { useColorContext } from '../../Colors/useColorContext'
+import { Label } from '../../Typography'
 import Loader from '../../Loader'
 
 const styles = {
@@ -41,6 +42,9 @@ const styles = {
     position: 'absolute',
     bottom: 6,
     left: 8
+  }),
+  label: css({
+    padding: '8px 8px 0px 8px'
   }),
   withBorderBottom: css({
     borderBottomWidth: 1,
@@ -80,6 +84,7 @@ export const CommentComposer = props => {
    */
   const root = React.useRef()
   const [textarea, textareaRef] = React.useState(null)
+  const [label, setLabel] = React.useState(false)
   const textRef = React.useRef()
   const [preview, setPreview] = React.useState({
     loading: false,
@@ -89,7 +94,7 @@ export const CommentComposer = props => {
   /*
    * Get the discussion metadata and action callbacks from the DiscussionContext.
    */
-  const { discussion, actions } = React.useContext(DiscussionContext)
+  const { discussion, actions, getLabel } = React.useContext(DiscussionContext)
   const { id: discussionId, tags, rules, displayAuthor, isBoard } = discussion
   const { maxLength } = rules
 
@@ -186,6 +191,7 @@ export const CommentComposer = props => {
   const onChangeText = ev => {
     const nextText = ev.target.value
     setText(nextText)
+    setLabel(getLabel(nextText))
     try {
       localStorage.setItem(localStorageKey, ev.target.value)
     } catch (e) {
@@ -292,6 +298,11 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
+      {label ? (
+        <div {...styles.label}>
+          <Label>{label}</Label>
+        </div>
+      ) : null}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -13,6 +13,8 @@ import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
 import { useColorContext } from '../../Colors/useColorContext'
 import Loader from '../../Loader'
+import IconButton from '../../IconButton'
+import { CloseIcon } from '../../Icons'
 
 const styles = {
   root: css({}),
@@ -45,6 +47,9 @@ const styles = {
   withBorderBottom: css({
     borderBottomWidth: 1,
     borderBottomStyle: 'solid'
+  }),
+  hints: css({
+    marginBottom: 6
   })
 }
 
@@ -80,12 +85,13 @@ export const CommentComposer = props => {
    */
   const root = React.useRef()
   const [textarea, textareaRef] = React.useState(null)
-  const [hints, setHints] = React.useState(false)
+  const [hints, setHints] = React.useState([])
   const textRef = React.useRef()
   const [preview, setPreview] = React.useState({
     loading: false,
     comment: null
   })
+  const [showHints, setShowHints] = React.useState(true)
 
   /*
    * Get the discussion metadata, action callbacks and hinters from DiscussionContext.
@@ -296,9 +302,23 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
-
-      {hints &&
-        hints.map((hint, index) => <div key={`hint-${index}`}>{hint}</div>)}
+      {hints.length > 0 && showHints && (
+        <div
+          style={{ marginTop: 2, padding: 8 }}
+          {...colorScheme.set('background', 'hover')}
+        >
+          {hints.map((hint, index) => (
+            <div {...styles.hints} key={`hint-${index}`}>
+              {hint}
+            </div>
+          ))}
+          <IconButton
+            Icon={CloseIcon}
+            label='Formattierungshilfe schliessen'
+            onClick={() => setShowHints(false)}
+          />
+        </div>
+      )}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -12,7 +12,6 @@ import { convertStyleToRem } from '../../Typography/utils'
 import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
 import { useColorContext } from '../../Colors/useColorContext'
-import { Label } from '../../Typography'
 import Loader from '../../Loader'
 
 const styles = {

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -43,7 +43,7 @@ const styles = {
     bottom: 6,
     left: 8
   }),
-  label: css({
+  hint: css({
     padding: '8px 8px 0px 8px'
   }),
   withBorderBottom: css({
@@ -84,7 +84,7 @@ export const CommentComposer = props => {
    */
   const root = React.useRef()
   const [textarea, textareaRef] = React.useState(null)
-  const [label, setLabel] = React.useState(false)
+  const [hints, setHints] = React.useState(false)
   const textRef = React.useRef()
   const [preview, setPreview] = React.useState({
     loading: false,
@@ -92,9 +92,11 @@ export const CommentComposer = props => {
   })
 
   /*
-   * Get the discussion metadata and action callbacks from the DiscussionContext.
+   * Get the discussion metadata, action callbacks and hinters from DiscussionContext.
    */
-  const { discussion, actions } = React.useContext(DiscussionContext)
+  const { discussion, actions, composerHints = [] } = React.useContext(
+    DiscussionContext
+  )
   const { id: discussionId, tags, rules, displayAuthor, isBoard } = discussion
   const { maxLength } = rules
 
@@ -191,9 +193,7 @@ export const CommentComposer = props => {
   const onChangeText = ev => {
     const nextText = ev.target.value
     setText(nextText)
-    if (actions.getLabel) {
-      setLabel(actions.getLabel(nextText))
-    }
+    setHints(composerHints.map(fn => fn(nextText)).filter(Boolean))
     try {
       localStorage.setItem(localStorageKey, ev.target.value)
     } catch (e) {
@@ -300,11 +300,13 @@ export const CommentComposer = props => {
           <MaxLengthIndicator maxLength={maxLength} length={textLength} />
         )}
       </div>
-      {label && (
-        <div {...styles.label}>
-          <Label>{label}</Label>
-        </div>
-      )}
+
+      {hints &&
+        hints.map((hint, index) => (
+          <div key={`hint-${index}`} {...styles.hint}>
+            <Label>{hint}</Label>
+          </div>
+        ))}
 
       <Loader
         loading={preview.loading && !(preview.comment && preview.comment.embed)}

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -70,12 +70,10 @@ export const CommentComposerPlayground = () => {
     composerHints: [
       function formattingAsteriks(text) {
         // Math where asterix is within a word (not next to whitespace) "n*n" for example
-        const hasSingleAsterix = !!text.match(/[^\s:]\*[^\s:]/)
+        const hasSingleAsterix = !!text.match(/[^*\s:]\*[^*\s:]/)
         if (hasSingleAsterix) {
           return (
-            <Label>
-              {t('styleguide/CommentComposer/hints/formattingAsteriks')}
-            </Label>
+            <Label>{t('styleguide/CommentComposer/formatting/asterisk')}</Label>
           )
         }
         return false

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -4,10 +4,10 @@ import { createFormatter } from '../../../lib/translate'
 import { Editorial } from '../../Typography'
 
 import { default as Button } from '../../Button'
-import { SecondaryAction } from '../Internal/Composer'
 import { CommentComposer } from './CommentComposer'
 import { DiscussionContext } from '../DiscussionContext'
-import { MarkdownIcon, MoodIcon, StarsIcon } from '../../Icons'
+import { MarkdownIcon, EtiquetteIcon, StarsIcon } from '../../Icons'
+import IconButton from '../../IconButton'
 import { Label, Interaction } from '../../Typography'
 import colors from '../../../theme/colors'
 
@@ -120,14 +120,10 @@ export const CommentComposerPlayground = () => {
       }
     ],
     composerSecondaryActions: (
-      <>
-        <SecondaryAction>
-          <MoodIcon size={26} />
-        </SecondaryAction>
-        <SecondaryAction>
-          <MarkdownIcon size={26} />
-        </SecondaryAction>
-      </>
+      <div style={{ display: 'flex' }}>
+        <IconButton title='Mood' Icon={EtiquetteIcon} />
+        <IconButton title='Markdown' Icon={MarkdownIcon} />
+      </div>
     )
   }
 

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -70,8 +70,8 @@ export const CommentComposerPlayground = () => {
     composerHints: [
       function formattingAsteriks(text) {
         // Math where asterix is within a word (not next to whitespace) "n*n" for example
-        const hasSingleAsterix = !!text.match(/[^\\*\s:]\*[^*\s:]/)
-        if (hasSingleAsterix) {
+        const hasUnescapedAsterix = !!text.match(/[^\\*\s:]\*[^*\s:]/)
+        if (hasUnescapedAsterix) {
           return (
             <Label>{t('styleguide/CommentComposer/formatting/asterisk')}</Label>
           )

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -66,6 +66,12 @@ export const CommentComposerPlayground = () => {
     actions: {
       openDiscussionPreferences: () => Promise.resolve({ ok: true })
     },
+    getLabel: text => {
+      if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+        return 'Label'
+      }
+      return false
+    },
     composerSecondaryActions: (
       <>
         <SecondaryAction>

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -6,10 +6,9 @@ import { Editorial } from '../../Typography'
 import { default as Button } from '../../Button'
 import { CommentComposer } from './CommentComposer'
 import { DiscussionContext } from '../DiscussionContext'
-import { MarkdownIcon, EtiquetteIcon, StarsIcon } from '../../Icons'
+import { MarkdownIcon, EtiquetteIcon } from '../../Icons'
 import IconButton from '../../IconButton'
-import { Label, Interaction } from '../../Typography'
-import colors from '../../../theme/colors'
+import { Label } from '../../Typography'
 
 export { CommentComposerPlaceholder } from './CommentComposerPlaceholder'
 
@@ -91,31 +90,39 @@ export const CommentComposerPlayground = () => {
         if (snippets.some(hasUnescapedAsterisks)) {
           return (
             <Label>
-              {t('styleguide/CommentComposer/hints/formattingAsteriks')}
+              Die Eingabe **fett** wird <strong>fett</strong>, *kursiv* wird{' '}
+              <i>kursiv</i> und aus Leser\*in wird Leser*in.
             </Label>
           )
         }
 
         return false
       },
-      function deepThought(text) {
-        if (text.indexOf('42') > -1) {
+      function strikethorugh(text) {
+        const hasSwungDash = text.indexOf('~') > -1
+        if (hasSwungDash) {
           return (
-            <div
-              style={{
-                padding: 8,
-                borderRadius: 10,
-                backgroundColor: colors.primaryBg
-              }}
-            >
-              <Interaction.P>
-                <StarsIcon />{' '}
-                {t('styleguide/CommentComposer/hints/deepThought')}
-              </Interaction.P>
-            </div>
+            <Label>
+              Die Eingabe ~~durchgestrichen~~ wird{' '}
+              <span style={{ textDecoration: 'line-through' }}>
+                durchgestrichen
+              </span>{' '}
+              .
+            </Label>
           )
         }
-
+        return false
+      },
+      function formattingLinks(text) {
+        const hasSwungDash = text.indexOf('http') > -1
+        if (hasSwungDash) {
+          return (
+            <Label>
+              Ein [Link](https://republik.ch) wird Ein{' '}
+              <a href='https://www.republik.ch'>Link</a>.
+            </Label>
+          )
+        }
         return false
       }
     ],

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -68,58 +68,13 @@ export const CommentComposerPlayground = () => {
       openDiscussionPreferences: () => Promise.resolve({ ok: true })
     },
     composerHints: [
-      // If some snippets have unescaped asterisks, return hint.
       function formattingAsteriks(text) {
-        // Split into snippets. If asteriks are more then two new lines
-        // apart, Markdown will render * instead of wrapped text
-        // in cursive.
-        const snippets = text.split('\n\n')
-
-        // It will split string by \* and glueing string back together.
-        // All the is left are unescaped astriks.
-        // Then we split string by * and count elements; length of
-        // array is 1 + "amount of astriks".
-        // If length is > 2, unescaped astriks are left which might
-        // Markdown render wrapped text in cursive.
-        const hasUnescapedAsterisks = snippet =>
-          snippet
-            .split('\\*')
-            .join('')
-            .split('*').length > 2
-
-        if (snippets.some(hasUnescapedAsterisks)) {
+        // Math where asterix is within a word (not next to whitespace) "n*n" for example
+        const hasSingleAsterix = !!text.match(/[^\s:]\*[^\s:]/)
+        if (hasSingleAsterix) {
           return (
             <Label>
-              Die Eingabe **fett** wird <strong>fett</strong>, *kursiv* wird{' '}
-              <i>kursiv</i> und aus Leser\*in wird Leser*in.
-            </Label>
-          )
-        }
-
-        return false
-      },
-      function strikethorugh(text) {
-        const hasSwungDash = text.indexOf('~') > -1
-        if (hasSwungDash) {
-          return (
-            <Label>
-              Die Eingabe ~~durchgestrichen~~ wird{' '}
-              <span style={{ textDecoration: 'line-through' }}>
-                durchgestrichen
-              </span>{' '}
-              .
-            </Label>
-          )
-        }
-        return false
-      },
-      function formattingLinks(text) {
-        const hasSwungDash = text.indexOf('http') > -1
-        if (hasSwungDash) {
-          return (
-            <Label>
-              Ein [Link](https://republik.ch) wird Ein{' '}
-              <a href='https://www.republik.ch'>Link</a>.
+              {t('styleguide/CommentComposer/hints/formattingAsteriks')}
             </Label>
           )
         }

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -87,7 +87,14 @@ export const CommentComposerPlayground = () => {
             .split('*').length > 2
 
         if (snippets.some(hasUnescapedAsterisks)) {
-          return t('styleguide/CommentComposer/formatting/asterisk')
+          return t('styleguide/CommentComposer/hints/formattingAsteriks')
+        }
+
+        return false
+      },
+      function deepThought(text) {
+        if (text.indexOf('42') > -1) {
+          return t('styleguide/CommentComposer/hints/deepThought')
         }
 
         return false

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -7,7 +7,9 @@ import { default as Button } from '../../Button'
 import { SecondaryAction } from '../Internal/Composer'
 import { CommentComposer } from './CommentComposer'
 import { DiscussionContext } from '../DiscussionContext'
-import { MarkdownIcon, MoodIcon } from '../../Icons'
+import { MarkdownIcon, MoodIcon, StarsIcon } from '../../Icons'
+import { Label, Interaction } from '../../Typography'
+import colors from '../../../theme/colors'
 
 export { CommentComposerPlaceholder } from './CommentComposerPlaceholder'
 
@@ -87,14 +89,31 @@ export const CommentComposerPlayground = () => {
             .split('*').length > 2
 
         if (snippets.some(hasUnescapedAsterisks)) {
-          return t('styleguide/CommentComposer/hints/formattingAsteriks')
+          return (
+            <Label>
+              {t('styleguide/CommentComposer/hints/formattingAsteriks')}
+            </Label>
+          )
         }
 
         return false
       },
       function deepThought(text) {
         if (text.indexOf('42') > -1) {
-          return t('styleguide/CommentComposer/hints/deepThought')
+          return (
+            <div
+              style={{
+                padding: 8,
+                borderRadius: 10,
+                backgroundColor: colors.primaryBg
+              }}
+            >
+              <Interaction.P>
+                <StarsIcon />{' '}
+                {t('styleguide/CommentComposer/hints/deepThought')}
+              </Interaction.P>
+            </div>
+          )
         }
 
         return false

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -64,14 +64,35 @@ export const CommentComposerPlayground = () => {
       tagRequired
     },
     actions: {
-      openDiscussionPreferences: () => Promise.resolve({ ok: true }),
-      getLabel: text => {
-        if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+      openDiscussionPreferences: () => Promise.resolve({ ok: true })
+    },
+    composerHints: [
+      // If some snippets have unescaped asterisks, return hint.
+      function formattingAsteriks(text) {
+        // Split into snippets. If asteriks are more then two new lines
+        // apart, Markdown will render * instead of wrapped text
+        // in cursive.
+        const snippets = text.split('\n\n')
+
+        // It will split string by \* and glueing string back together.
+        // All the is left are unescaped astriks.
+        // Then we split string by * and count elements; length of
+        // array is 1 + "amount of astriks".
+        // If length is > 2, unescaped astriks are left which might
+        // Markdown render wrapped text in cursive.
+        const hasUnescapedAsterisks = snippet =>
+          snippet
+            .split('\\*')
+            .join('')
+            .split('*').length > 2
+
+        if (snippets.some(hasUnescapedAsterisks)) {
           return t('styleguide/CommentComposer/formatting/asterisk')
         }
+
         return false
       }
-    },
+    ],
     composerSecondaryActions: (
       <>
         <SecondaryAction>

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -64,13 +64,13 @@ export const CommentComposerPlayground = () => {
       tagRequired
     },
     actions: {
-      openDiscussionPreferences: () => Promise.resolve({ ok: true })
-    },
-    getLabel: text => {
-      if (!text.includes('\\*') && text.includes('*')) {
-        return t('styleguide/CommentComposer/formatting/asterisk')
+      openDiscussionPreferences: () => Promise.resolve({ ok: true }),
+      getLabel: text => {
+        if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+          return t('styleguide/CommentComposer/formatting/asterisk')
+        }
+        return false
       }
-      return false
     },
     composerSecondaryActions: (
       <>

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -70,7 +70,7 @@ export const CommentComposerPlayground = () => {
     composerHints: [
       function formattingAsteriks(text) {
         // Math where asterix is within a word (not next to whitespace) "n*n" for example
-        const hasSingleAsterix = !!text.match(/[^*\s:]\*[^*\s:]/)
+        const hasSingleAsterix = !!text.match(/[^\\*\s:]\*[^*\s:]/)
         if (hasSingleAsterix) {
           return (
             <Label>{t('styleguide/CommentComposer/formatting/asterisk')}</Label>

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -68,7 +68,7 @@ export const CommentComposerPlayground = () => {
     },
     getLabel: text => {
       if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
-        return 'Label'
+        return t('styleguide/CommentComposer/formattingHelp')
       }
       return false
     },

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -67,7 +67,7 @@ export const CommentComposerPlayground = () => {
       openDiscussionPreferences: () => Promise.resolve({ ok: true })
     },
     getLabel: text => {
-      if (text.indexOf('*') > -1 && text.indexOf('\\*') === -1) {
+      if (!text.includes('\\*') && text.includes('*')) {
         return t('styleguide/CommentComposer/formattingHelp')
       }
       return false

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -68,10 +68,10 @@ export const CommentComposerPlayground = () => {
       openDiscussionPreferences: () => Promise.resolve({ ok: true })
     },
     composerHints: [
-      function formattingAsteriks(text) {
-        // Math where asterix is within a word (not next to whitespace) "n*n" for example
-        const hasUnescapedAsterix = !!text.match(/[^\\*\s:]\*[^*\s:]/)
-        if (hasUnescapedAsterix) {
+      function formattingAsterisk(text) {
+        // Math where asterisk is within a word (not next to whitespace) "n*n" for example
+        const hasUnescapedAsterisk = !!text.match(/[^\\*\s:]\*[^*\s:]/)
+        if (hasUnescapedAsterisk) {
           return (
             <Label>{t('styleguide/CommentComposer/formatting/asterisk')}</Label>
           )

--- a/src/components/Discussion/Composer/docs.imports.js
+++ b/src/components/Discussion/Composer/docs.imports.js
@@ -68,7 +68,7 @@ export const CommentComposerPlayground = () => {
     },
     getLabel: text => {
       if (!text.includes('\\*') && text.includes('*')) {
-        return t('styleguide/CommentComposer/formattingHelp')
+        return t('styleguide/CommentComposer/formatting/asterisk')
       }
       return false
     },

--- a/src/components/Discussion/DiscussionContext.docs.js
+++ b/src/components/Discussion/DiscussionContext.docs.js
@@ -109,6 +109,12 @@ export const createSampleDiscussionContextValue = ({
   ),
 
   /**
+   * Array of functions run while typing in the comment box. Hints are rendered above secondary
+   * actions slot of the composer.
+   */
+  composerHints: [],
+
+  /**
    * React Element that will be placed into the secondary actions slot of the
    * composer. Can be null to not show anything.
    */

--- a/src/components/Discussion/Internal/Composer/Actions.js
+++ b/src/components/Discussion/Internal/Composer/Actions.js
@@ -77,7 +77,7 @@ export const Actions = ({
   }, [colorScheme])
   return (
     <div {...styles.root}>
-      {composerSecondaryActions && composerSecondaryActions}
+      {composerSecondaryActions}
 
       <div {...styles.mainActions}>
         <button

--- a/src/components/Discussion/Internal/Composer/Actions.js
+++ b/src/components/Discussion/Internal/Composer/Actions.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { css } from 'glamor'
 import { sansSerifMedium14 } from '../../../Typography/styles'
 import { DiscussionContext } from '../../DiscussionContext'
-import { mUp } from '../../../../theme/mediaQueries'
 import { convertStyleToRem, pxToRem } from '../../../Typography/utils'
 import { useColorContext } from '../../../Colors/useColorContext'
 
@@ -26,7 +25,8 @@ const styles = {
   root: css({
     display: 'flex',
     flexFlow: 'wrap',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
+    alignItems: 'center'
   }),
   mainActions: css({
     display: 'flex'
@@ -39,19 +39,6 @@ const styles = {
     marginLeft: '16px',
     '[disabled]': {
       cursor: 'inherit'
-    }
-  }),
-  secondaryActions: css({
-    height: pxToRem(20),
-    display: 'flex',
-    minWidth: 0,
-    flexShrink: 1
-  }),
-  secondaryAction: css({
-    ...actionButtonStyle,
-    margin: '0 4px',
-    [mUp]: {
-      margin: '0 8px'
     }
   })
 }
@@ -67,14 +54,6 @@ export const Actions = ({
   const { composerSecondaryActions } = React.useContext(DiscussionContext)
   const styleRules = useMemo(() => {
     return {
-      secondaryAction: css({
-        color: colorScheme.getCSSColor('textSoft'),
-        '@media (hover)': {
-          ':hover': {
-            color: colorScheme.getCSSColor('text')
-          }
-        }
-      }),
       closeButton: css({
         color: colorScheme.getCSSColor('textSoft'),
         '@media (hover)': {
@@ -98,11 +77,7 @@ export const Actions = ({
   }, [colorScheme])
   return (
     <div {...styles.root}>
-      {composerSecondaryActions && (
-        <div {...styles.secondaryActions} {...styleRules.secondaryAction}>
-          {composerSecondaryActions}
-        </div>
-      )}
+      {composerSecondaryActions && composerSecondaryActions}
 
       <div {...styles.mainActions}>
         <button
@@ -131,8 +106,4 @@ Actions.propTypes = {
   onCloseLabel: PropTypes.string,
   onSubmit: PropTypes.func,
   onSubmitLabel: PropTypes.string
-}
-
-export const SecondaryAction = ({ as = 'button', ...props }) => {
-  return React.createElement(as, { ...styles.secondaryAction, ...props })
 }

--- a/src/lib.js
+++ b/src/lib.js
@@ -131,7 +131,6 @@ export {
   CommentComposer,
   CommentComposerPlaceholder
 } from './components/Discussion/Composer'
-export { SecondaryAction as CommentComposerSecondaryAction } from './components/Discussion/Internal/Composer'
 export { renderCommentMdast } from './components/Discussion/Internal/Comment/render'
 export { IconLink as DiscussionIconLink } from './components/Discussion/Internal/Comment/IconLink'
 

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-06-15T13:41:23.989Z",
+  "updated": "2021-07-29T14:38:46.724Z",
   "title": "live",
   "data": [
     {
@@ -29,6 +29,10 @@
     {
       "key": "styleguide/CommentComposer/wait",
       "value": "Sie können {time} wieder einen Beitrag schreiben."
+    },
+    {
+      "key": "styleguide/CommentComposer/formattingHelp",
+      "value": "Benutzen Sie ein Backslash vor dem Gendersternchen damit es nicht mit kursiv verwechselt wird:\nLeser\\*in"
     },
     {
       "key": "styleguide/CommentActions/expand",

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-07-29T14:38:46.724Z",
+  "updated": "2021-07-29T15:26:19.281Z",
   "title": "live",
   "data": [
     {
@@ -31,7 +31,7 @@
       "value": "Sie können {time} wieder einen Beitrag schreiben."
     },
     {
-      "key": "styleguide/CommentComposer/formattingHelp",
+      "key": "styleguide/CommentComposer/formatting/asterisk",
       "value": "Benutzen Sie ein Backslash vor dem Gendersternchen damit es nicht mit kursiv verwechselt wird:\nLeser\\*in"
     },
     {

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -35,14 +35,6 @@
       "value": "Damit System Gendersternchen erkennt, stellen Sie einen Backslash voran: Leser\\*in"
     },
     {
-      "key": "styleguide/CommentComposer/hints/formattingAsteriks",
-      "value": "Um * sichtbar zu machen, stellen Sie ein Backslash voran: \\*"
-    },
-    {
-      "key": "styleguide/CommentComposer/hints/deepThought",
-      "value": "You found the Answer to the Ultimate Question of Life, The Universe, and Everything"
-    },
-    {
       "key": "styleguide/CommentActions/expand",
       "value": "Kommentare anschauen"
     },

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-07-29T15:29:32.397Z",
+  "updated": "2021-07-29T19:47:30.679Z",
   "title": "live",
   "data": [
     {
@@ -33,6 +33,14 @@
     {
       "key": "styleguide/CommentComposer/formatting/asterisk",
       "value": "Damit System Gendersternchen erkennt, stellen Sie einen Backslash voran: Leser\\*in"
+    },
+    {
+      "key": "styleguide/CommentComposer/hints/formattingAsteriks",
+      "value": "Um * sichtbar zu machen, stellen Sie ein Backslash voran: \\*"
+    },
+    {
+      "key": "styleguide/CommentComposer/hints/deepThought",
+      "value": "You found the Answer to the Ultimate Question of Life, The Universe, and Everything"
     },
     {
       "key": "styleguide/CommentActions/expand",

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2021-07-29T15:26:19.281Z",
+  "updated": "2021-07-29T15:29:32.397Z",
   "title": "live",
   "data": [
     {
@@ -32,7 +32,7 @@
     },
     {
       "key": "styleguide/CommentComposer/formatting/asterisk",
-      "value": "Benutzen Sie ein Backslash vor dem Gendersternchen damit es nicht mit kursiv verwechselt wird:\nLeser\\*in"
+      "value": "Damit System Gendersternchen erkennt, stellen Sie einen Backslash voran: Leser\\*in"
     },
     {
       "key": "styleguide/CommentActions/expand",


### PR DESCRIPTION
based on https://github.com/orbiting/styleguide/pull/410

Sample predicate function – to find unescaped asteriks – is a bit more subtle now.

Curiosity led then to improve over label approach. Raising that to an array of hints. A series of predicate functions can run while typing and return one ore more hints.

Went down that rabbithole because there are several other hints we might add e.g. if text contains nothing but a link, show a hint: Posting links are best with some context.

<img width="590" alt="Bildschirmfoto 2021-07-29 um 22 22 23" src="https://user-images.githubusercontent.com/331800/127560586-55d6e5c3-faad-40bd-928d-0a58f0da7524.png">