### PR TITLE
fix(SeriesNav): Use Link w/ label as placeholder in parent translation

### DIFF
--- a/src/components/SeriesNav/SeriesNav.js
+++ b/src/components/SeriesNav/SeriesNav.js
@@ -112,16 +112,16 @@ function SeriesNav({
             </InfoBoxTitle>
             <InfoBoxText>
               {series.description}
-              {titlePath && (
-                <>
-                  {' '}
-                  <Link href={titlePath} passHref>
-                    <Editorial.A>
-                      {t('styleguide/SeriesNav/seriesoverview')}
-                    </Editorial.A>
-                  </Link>
-                </>
-              )}
+              {titlePath &&
+                t.elements('styleguide/SeriesNav/seriesoverview/link', {
+                  link: (
+                    <Link href={titlePath} passHref>
+                      <Editorial.A>
+                        {t('styleguide/SeriesNav/seriesoverview')}
+                      </Editorial.A>
+                    </Link>
+                  )
+                })}
             </InfoBoxText>
           </InfoBox>
           {inlineAfterDescription}

--- a/src/lib/translations.json
+++ b/src/lib/translations.json
@@ -124,8 +124,12 @@
       "undefined": " "
     },
     {
+      "key": "styleguide/SeriesNav/seriesoverview/link",
+      "value": " {link}."
+    },
+    {
       "key": "styleguide/SeriesNav/seriesoverview",
-      "value": "Zur Serienübersicht"
+      "value": "Zur Übersicht"
     },
     {
       "key": "styleguide/SeriesNav/current",


### PR DESCRIPTION
Wrap Link in another translation string to allow a trailing period.

<img width="592" alt="Bildschirmfoto 2021-08-24 um 20 14 24" src="https://user-images.githubusercontent.com/331800/130668546-283abf43-b270-4936-9f90-12079934e8a7.png">
