### PR TITLE
Add xUnit to Time Bar Chart

### DIFF
--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -20,7 +20,7 @@ import {
   unsafeDatumFn,
   subsup,
   getTextColor,
-  getLastItemFromArray
+  isLastItem
 } from './utils'
 import ColorLegend from './ColorLegend'
 import { createTextGauger } from '../../lib/textGauger'
@@ -333,7 +333,7 @@ const BarChart = props => {
         // snap last to last xTick if within one pixel
         if (
           xLastTick &&
-          getLastItemFromArray(bar.segments, i) &&
+          isLastItem(bar.segments, i) &&
           Math.abs(xLastTick - d.x - d.width) === 1
         ) {
           d.width += xLastTick - d.x - d.width
@@ -344,7 +344,7 @@ const BarChart = props => {
         } else {
           xPosNegative += size
         }
-        const isLast = getLastItemFromArray(bar.segments, i)
+        const isLast = isLastItem(bar.segments, i)
         d.valueTextStartAnchor =
           (d.value >= 0 && isLast) || (d.value < 0 && i !== 0)
         const isLastSegment = isLast && i !== 0
@@ -658,7 +658,7 @@ const BarChart = props => {
                 >
                   {xTicks.map((tick, i) => {
                     let textAnchor = 'middle'
-                    const isLast = getLastItemFromArray(xTicks, i)
+                    const isLast = isLastItem(xTicks, i)
                     if (isLast) {
                       textAnchor = 'end'
                     }

--- a/src/components/Chart/Bars.js
+++ b/src/components/Chart/Bars.js
@@ -19,7 +19,8 @@ import {
   deduplicate,
   unsafeDatumFn,
   subsup,
-  getTextColor
+  getTextColor,
+  getLastItemFromArray
 } from './utils'
 import ColorLegend from './ColorLegend'
 import { createTextGauger } from '../../lib/textGauger'
@@ -91,8 +92,6 @@ const BAR_STYLES = {
     }
   }
 }
-
-const last = (array, index) => array.length - 1 === index
 
 const styles = {
   groupTitle: css({
@@ -334,7 +333,7 @@ const BarChart = props => {
         // snap last to last xTick if within one pixel
         if (
           xLastTick &&
-          last(bar.segments, i) &&
+          getLastItemFromArray(bar.segments, i) &&
           Math.abs(xLastTick - d.x - d.width) === 1
         ) {
           d.width += xLastTick - d.x - d.width
@@ -345,7 +344,7 @@ const BarChart = props => {
         } else {
           xPosNegative += size
         }
-        const isLast = last(bar.segments, i)
+        const isLast = getLastItemFromArray(bar.segments, i)
         d.valueTextStartAnchor =
           (d.value >= 0 && isLast) || (d.value < 0 && i !== 0)
         const isLastSegment = isLast && i !== 0
@@ -659,7 +658,7 @@ const BarChart = props => {
                 >
                   {xTicks.map((tick, i) => {
                     let textAnchor = 'middle'
-                    const isLast = last(xTicks, i)
+                    const isLast = getLastItemFromArray(xTicks, i)
                     if (isLast) {
                       textAnchor = 'end'
                     }

--- a/src/components/Chart/TimeBarGroup.js
+++ b/src/components/Chart/TimeBarGroup.js
@@ -39,7 +39,8 @@ const TimeBarGroup = ({
   color,
   width,
   xAxisPos,
-  xAxis
+  xAxis,
+  yScaleChangeDirection
 }) => {
   const [colorScheme] = useColorContext()
   const barWidth = x.bandwidth()
@@ -101,7 +102,7 @@ const TimeBarGroup = ({
           <text
             {...styles.axisLabel}
             {...colorScheme.set('fill', 'text')}
-            dy='-3px'
+            dy={yScaleChangeDirection ? '13px' : '-3px'}
           >
             {yAxis.axisFormat(tick, last(yTicks, i))}
           </text>

--- a/src/components/Chart/TimeBarGroup.js
+++ b/src/components/Chart/TimeBarGroup.js
@@ -40,7 +40,7 @@ const TimeBarGroup = ({
   width,
   xAxisPos,
   xAxis,
-  yScaleChangeDirection
+  yScaleInvert
 }) => {
   const [colorScheme] = useColorContext()
   const barWidth = x.bandwidth()
@@ -102,7 +102,7 @@ const TimeBarGroup = ({
           <text
             {...styles.axisLabel}
             {...colorScheme.set('fill', 'text')}
-            dy={yScaleChangeDirection ? '13px' : '-3px'}
+            dy={yScaleInvert ? '13px' : '-3px'}
           >
             {yAxis.axisFormat(tick, last(yTicks, i))}
           </text>

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -920,8 +920,7 @@ year,category,value
       "xTicks": [
         0,
         100
-      ],
-      "xUnit": "Alter"
+      ]
     }}
     values={`
 age,date,value

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -971,8 +971,7 @@ age,date,value
   ],
   "yTicks": [
     100000,
-    50000,
-    0
+    50000
   ],
   "xBandPadding": 0.5,
   "height": 400,
@@ -985,20 +984,21 @@ age,date,value
   },
   "unit": "Franken",
   "xUnit": ". Perzentil",
+  "yScaleChangeDirection": true,
   "xAnnotations": [
     {
       "x": 40,
       "value": 6000,
       "label": "Schätzung",
       "showValue": false,
-      "position": "top"
+      "position": "bottom"
     },
     {
       "x": 74,
       "value": 90712,
       "label": "Tatsächlich",
       "showValue": false,
-      "position": "top"
+      "position": "bottom"
     }
   ]
 }}

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -6,7 +6,7 @@ One very physical limitation is the width of a (small) mobile screen: 320px. If 
 
 More than that and the calculated width of the bar ends up at 0, which isn't very useful at all.
 
-## Examples 
+## Examples
 
 ```react
 <div>
@@ -20,7 +20,7 @@ More than that and the calculated width of the bar ends up at 0, which isn't ver
       "numberFormat": ".3s",
       "xAnnotations": [
         {"x1": "2008","x2": "2012","value": 973619338.97,"unit": "Tonnen","label": "Kyoto-Protokoll"},
-        {"x": "2020","value": 748700000,"label": "Ziel 2020","ghost": true}, 
+        {"x": "2020","value": 748700000,"label": "Ziel 2020","ghost": true},
         {"x": "2050","value": 249600000,"label": "Ziel 2050","valuePrefix": "max: ","ghost": true}
       ],
       "padding": 18
@@ -594,7 +594,7 @@ year,typ,value
       "xInterval": "month",
       "xIntervalStep": 6,
       "xAnnotations": [
-        {"x1": "2019-07", "x2": "2019-07","value": 5, "unit": "Punkte", "label": "Ziel 2020"}, 
+        {"x1": "2019-07", "x2": "2019-07","value": 5, "unit": "Punkte", "label": "Ziel 2020"},
         {"x1": "2019-07", "x2": "2019-07","value": 4,"label": "Stand jetzt","position": "bottom","showValue": false},
         {"x": "2022-01", "value": 7, "ghost": true}
       ]
@@ -770,7 +770,7 @@ year,value,color
       "unit": "Verlegerinnen",
       "xTicks": [20, 40, 60, 80, 100],
       "xScale": "ordinal",
-      "padding": 0,  
+      "padding": 0,
     }}
     values={`
 key,value
@@ -903,7 +903,6 @@ year,category,value
 
 ### Small Multiples
 
-
 ```react
 <div>
   <ChartTitle>Das Sterben setzt später ein</ChartTitle>
@@ -947,6 +946,168 @@ age,date,value
     `.trim()} />
   <ChartLegend>
     Quelle: <Editorial.A href='https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationprojections/compendium/nationalpopulationprojections/2014basedreferencevolumeseriespp2/chapter4mortality2014basednationalpopulationprojectionsreferencevolume'>Office for National Statistics</Editorial.A>
+  </ChartLegend>
+</div>
+```
+
+### Custom Label for X Axis
+
+```react
+<div>
+  <ChartTitle>Wer alles ärmer ist als Sie...</ChartTitle>
+  <ChartLead>Vermögensverteilung in der Schweiz (Einzelpersonen)</ChartLead>
+  <CsvChart
+    config={{
+  "type": "TimeBar",
+  "x": "percentile",
+  "xScale": "linear",
+  "padding": 0,
+  "numberFormat": "(.0f",
+  "xTicks": [
+    0,
+    25,
+    50,
+    75,
+    99
+  ],
+  "yTicks": [
+    100000,
+    50000,
+    0
+  ],
+  "xBandPadding": 0.5,
+  "height": 400,
+  "color": "color",
+  "colorLegend": false,
+  "colorMap": {
+    "default": "#D5D8D7",
+    "estimate": "#00A000",
+    "reality": "#D02324"
+  },
+  "unit": "Franken",
+  "xUnit": ". Perzentil",
+  "xAnnotations": [
+    {
+      "x": 40,
+      "value": 6000,
+      "label": "Schätzung",
+      "showValue": false,
+      "position": "top"
+    },
+    {
+      "x": 74,
+      "value": 90712,
+      "label": "Tatsächlich",
+      "showValue": false,
+      "position": "top"
+    }
+  ]
+}}
+    values={`
+percentile,color,value
+0,default,0
+1,default,0
+2,default,0
+3,default,0
+4,default,0
+5,default,0
+6,default,0
+7,default,0
+8,default,0
+9,default,0
+10,default,0
+11,default,0
+12,default,0
+13,default,0
+14,default,0
+15,default,0
+16,default,0
+17,default,0
+18,default,0
+19,default,0
+20,default,0
+21,default,0
+22,default,0
+23,default,0
+24,default,0
+25,default,0
+26,default,0
+27,default,0
+28,default,0
+29,default,88
+30,default,305
+31,default,583
+32,default,920
+33,default,1317
+34,default,1775
+35,default,2292
+36,default,2870
+37,default,3507
+38,default,4203
+39,default,4958
+40,estimate,5770
+41,default,6640
+42,default,7565
+43,default,8546
+44,default,9579
+45,default,10665
+46,default,11802
+47,default,12988
+48,default,14222
+49,default,15504
+50,default,16830
+51,default,18203
+52,default,19620
+53,default,21083
+54,default,22594
+55,default,24156
+56,default,25773
+57,default,27454
+58,default,29208
+59,default,31051
+60,default,33002
+61,default,35089
+62,default,37346
+63,default,39820
+64,default,42571
+65,default,45676
+66,default,49238
+67,default,53360
+68,default,57976
+69,default,62944
+70,default,68139
+71,default,73472
+72,default,78921
+73,default,84578
+74,reality,90712
+75,default,0
+76,default,0
+77,default,0
+78,default,0
+79,default,0
+80,default,0
+81,default,0
+82,default,0
+83,default,0
+84,default,0
+85,default,0
+86,default,0
+87,default,0
+88,default,0
+89,default,0
+90,default,0
+91,default,0
+92,default,0
+93,default,0
+94,default,0
+95,default,0
+96,default,0
+97,default,0
+98,default,0
+99,default,0
+    `.trim()} />
+  <ChartLegend>
+    Quelle: <Editorial.A href='https://www.estv.admin.ch/estv/de/home.html'>ESTV</Editorial.A>
   </ChartLegend>
 </div>
 ```

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -949,7 +949,7 @@ age,date,value
 </div>
 ```
 
-### Custom Label for X Axis
+### Inverted Y Scale
 
 ```react
 <div>
@@ -984,7 +984,7 @@ age,date,value
   },
   "unit": "Franken",
   "xUnit": ". Perzentil",
-  "yScaleChangeDirection": true,
+  "yScaleInvert": true,
   "xAnnotations": [
     {
       "x": 40,

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -315,7 +315,8 @@ export const propTypes = {
     })
   ),
   columns: PropTypes.number.isRequired,
-  minInnerWidth: PropTypes.number.isRequired
+  minInnerWidth: PropTypes.number.isRequired,
+  yScaleInvert: PropTypes.bool
 }
 
 TimeBarChart.propTypes = propTypes

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -49,6 +49,7 @@ const TimeBarChart = props => {
     xTicks,
     domain,
     padding,
+    xUnit,
     height: innerHeight
   } = props
 
@@ -201,6 +202,7 @@ const TimeBarChart = props => {
       x={x}
       xDomain={xDomain}
       format={x => xFormat(xParser(x))}
+      xUnit={xUnit}
       strong={y.domain()[0] !== 0}
     />
   )
@@ -288,6 +290,7 @@ export const propTypes = {
     })
   ).isRequired,
   unit: PropTypes.string,
+  xUnit: PropTypes.string,
   numberFormat: PropTypes.string.isRequired,
   filter: PropTypes.string,
   tLabel: PropTypes.func.isRequired,
@@ -315,6 +318,7 @@ TimeBarChart.defaultProps = {
   height: 240,
   padding: 50,
   unit: '',
+  xUnit: '',
   colorLegend: true,
   xIntervalStep: 1,
   yAnnotations: [],

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -50,7 +50,7 @@ const TimeBarChart = props => {
     domain,
     padding,
     xUnit,
-    yScaleChangeDirection,
+    yScaleInvert,
     height: innerHeight
   } = props
 
@@ -100,7 +100,7 @@ const TimeBarChart = props => {
     true
   )
 
-  const barRange = yScaleChangeDirection
+  const barRange = yScaleInvert
     ? [AXIS_BOTTOM_HEIGHT + columnTitleHeight, columnHeight - PADDING_TOP]
     : [columnHeight - PADDING_TOP, AXIS_BOTTOM_HEIGHT + columnTitleHeight]
 
@@ -121,9 +121,7 @@ const TimeBarChart = props => {
       let downValue = 0
       let downPos = y(0)
       bar.segments.forEach(segment => {
-        const isPositive = yScaleChangeDirection
-          ? segment.value < 0
-          : segment.value > 0
+        const isPositive = yScaleInvert ? segment.value < 0 : segment.value > 0
         const baseValue = isPositive ? upValue : downValue
         const y0 = y(baseValue)
         const y1 = y(baseValue + segment.value)
@@ -211,7 +209,7 @@ const TimeBarChart = props => {
       format={x => xFormat(xParser(x))}
       xUnit={xUnit}
       strong={y.domain()[0] !== 0}
-      yScaleChangeDirection={yScaleChangeDirection}
+      yScaleInvert={yScaleInvert}
     />
   )
 
@@ -236,13 +234,13 @@ const TimeBarChart = props => {
                 width={innerWidth}
                 xAxis={xAxis}
                 xAxisPos={
-                  yScaleChangeDirection
+                  yScaleInvert
                     ? PADDING_TOP + columnTitleHeight
                     : innerHeight + PADDING_TOP + columnTitleHeight
                 }
                 tLabel={tLabel}
                 color={d => color(colorAccessor(d))}
-                yScaleChangeDirection={yScaleChangeDirection}
+                yScaleInvert={yScaleInvert}
               />
             </g>
           )

--- a/src/components/Chart/TimeBars.js
+++ b/src/components/Chart/TimeBars.js
@@ -50,6 +50,7 @@ const TimeBarChart = props => {
     domain,
     padding,
     xUnit,
+    yScaleChangeDirection,
     height: innerHeight
   } = props
 
@@ -99,11 +100,15 @@ const TimeBarChart = props => {
     true
   )
 
+  const barRange = yScaleChangeDirection
+    ? [AXIS_BOTTOM_HEIGHT + columnTitleHeight, columnHeight - PADDING_TOP]
+    : [columnHeight - PADDING_TOP, AXIS_BOTTOM_HEIGHT + columnTitleHeight]
+
   const y = scaleLinear()
     .domain(
       props.domain ? props.domain : [getMin(groupedData), getMax(groupedData)]
     )
-    .range([columnHeight - PADDING_TOP, AXIS_BOTTOM_HEIGHT + columnTitleHeight])
+    .range(barRange)
 
   if (!domain) {
     y.nice(3)
@@ -116,7 +121,9 @@ const TimeBarChart = props => {
       let downValue = 0
       let downPos = y(0)
       bar.segments.forEach(segment => {
-        const isPositive = segment.value > 0
+        const isPositive = yScaleChangeDirection
+          ? segment.value < 0
+          : segment.value > 0
         const baseValue = isPositive ? upValue : downValue
         const y0 = y(baseValue)
         const y1 = y(baseValue + segment.value)
@@ -204,6 +211,7 @@ const TimeBarChart = props => {
       format={x => xFormat(xParser(x))}
       xUnit={xUnit}
       strong={y.domain()[0] !== 0}
+      yScaleChangeDirection={yScaleChangeDirection}
     />
   )
 
@@ -227,9 +235,14 @@ const TimeBarChart = props => {
                 yAxis={yAxis}
                 width={innerWidth}
                 xAxis={xAxis}
-                xAxisPos={innerHeight + PADDING_TOP + columnTitleHeight}
+                xAxisPos={
+                  yScaleChangeDirection
+                    ? PADDING_TOP + columnTitleHeight
+                    : innerHeight + PADDING_TOP + columnTitleHeight
+                }
                 tLabel={tLabel}
                 color={d => color(colorAccessor(d))}
+                yScaleChangeDirection={yScaleChangeDirection}
               />
             </g>
           )

--- a/src/components/Chart/XAxis.js
+++ b/src/components/Chart/XAxis.js
@@ -3,6 +3,7 @@ import { css } from 'glamor'
 import { sansSerifRegular12 as LABEL_FONT } from '../Typography/styles'
 import { useColorContext } from '../Colors/useColorContext'
 import { getBaselines, getXTicks } from './TimeBars.utils'
+import { getLastItemFromArray } from './utils'
 
 const X_TICK_HEIGHT = 3
 
@@ -24,7 +25,8 @@ const XAxis = ({
   x,
   xDomain,
   format,
-  strong
+  strong,
+  xUnit
 }) => {
   const [colorScheme] = useColorContext()
   const baseLines = getBaselines(xDomain, x, width)
@@ -44,7 +46,7 @@ const XAxis = ({
           strokeDasharray={line.gap ? '2 2' : 'none'}
         />
       ))}
-      {ticks.map(tick => (
+      {ticks.map((tick, i) => (
         <g
           key={tick}
           transform={`translate(${x(tick) + Math.round(x.bandwidth() / 2)},0)`}
@@ -61,7 +63,9 @@ const XAxis = ({
             dy='0.6em'
             textAnchor='middle'
           >
-            {format(tick)}
+            {getLastItemFromArray(ticks, i)
+              ? format(tick) + xUnit
+              : format(tick)}
           </text>
         </g>
       ))}

--- a/src/components/Chart/XAxis.js
+++ b/src/components/Chart/XAxis.js
@@ -3,7 +3,7 @@ import { css } from 'glamor'
 import { sansSerifRegular12 as LABEL_FONT } from '../Typography/styles'
 import { useColorContext } from '../Colors/useColorContext'
 import { getBaselines, getXTicks } from './TimeBars.utils'
-import { getLastItemFromArray } from './utils'
+import { isLastItem } from './utils'
 
 const X_TICK_HEIGHT = 3
 
@@ -26,7 +26,8 @@ const XAxis = ({
   xDomain,
   format,
   strong,
-  xUnit
+  xUnit,
+  yScaleChangeDirection
 }) => {
   const [colorScheme] = useColorContext()
   const baseLines = getBaselines(xDomain, x, width)
@@ -49,23 +50,21 @@ const XAxis = ({
       {ticks.map((tick, i) => (
         <g
           key={tick}
-          transform={`translate(${x(tick) + Math.round(x.bandwidth() / 2)},0)`}
+          transform={`translate(${x(tick) + Math.round(x.bandwidth() / 2)}, 0)`}
         >
           <line
             {...styles.axisXLine}
             {...colorScheme.set('stroke', 'text')}
-            y2={X_TICK_HEIGHT}
+            y2={yScaleChangeDirection ? X_TICK_HEIGHT - 6 : X_TICK_HEIGHT}
           />
           <text
             {...styles.axisLabel}
             {...colorScheme.set('fill', 'text')}
             y={X_TICK_HEIGHT + 5}
-            dy='0.6em'
+            dy={yScaleChangeDirection ? '-1.1em' : '0.6em'}
             textAnchor='middle'
           >
-            {getLastItemFromArray(ticks, i)
-              ? format(tick) + xUnit
-              : format(tick)}
+            {isLastItem(ticks, i) ? format(tick) + xUnit : format(tick)}
           </text>
         </g>
       ))}

--- a/src/components/Chart/XAxis.js
+++ b/src/components/Chart/XAxis.js
@@ -27,7 +27,7 @@ const XAxis = ({
   format,
   strong,
   xUnit,
-  yScaleChangeDirection
+  yScaleInvert
 }) => {
   const [colorScheme] = useColorContext()
   const baseLines = getBaselines(xDomain, x, width)
@@ -55,13 +55,13 @@ const XAxis = ({
           <line
             {...styles.axisXLine}
             {...colorScheme.set('stroke', 'text')}
-            y2={yScaleChangeDirection ? X_TICK_HEIGHT - 6 : X_TICK_HEIGHT}
+            y2={yScaleInvert ? X_TICK_HEIGHT - 6 : X_TICK_HEIGHT}
           />
           <text
             {...styles.axisLabel}
             {...colorScheme.set('fill', 'text')}
             y={X_TICK_HEIGHT + 5}
-            dy={yScaleChangeDirection ? '-1.1em' : '0.6em'}
+            dy={yScaleInvert ? '-1.1em' : '0.6em'}
             textAnchor='middle'
           >
             {isLastItem(ticks, i) ? format(tick) + xUnit : format(tick)}

--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -380,4 +380,4 @@ export const getColumnLayout = (
 }
 
 // get last item from array
-export const getLastItemFromArray = (array, index) => array.length - 1 === index
+export const isLastItem = (array, index) => array.length - 1 === index

--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -378,3 +378,6 @@ export const getColumnLayout = (
 
   return { height, innerWidth, innerHeight, gx, gy }
 }
+
+// get last item from array
+export const getLastItemFromArray = (array, index) => array.length - 1 === index


### PR DESCRIPTION
Add the option to add an xUnit to a Time Bar. In the config file, one can add an xUnit and then the unit will rendered at the last available bar.
![Bildschirmfoto 2021-09-07 um 11 57 49](https://user-images.githubusercontent.com/11921821/132325977-3731d2f8-2d1d-4bdc-af78-02b037c5d59c.png)


