### PR TITLE
fix(leftLabel): add boolean to align annotations on left side

### DIFF
--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -992,27 +992,28 @@ age,date,value
       "label": "Schätzung",
       "showValue": false,
       "position": "bottom",
-      textAlignment: 'right',
+      textAlignment: "right",
     },
     {
-      "x": '74',
+      "x": "704",
       "value": 90712,
       "label": "Tatsächlich",
       "showValue": false,
       "position": "bottom",
-      "textAlignment": 'right'
+      "textAlignment": "right"
 
     },
     {
-      x1: '0',
-      x2: '70',
-      value: 68139,
-      label: '70. Perzentile',
-      showValue: true,
-      unit: 'Franken',
-      position: 'bottom',
-      ghost: true,
-      leftLabel: true
+      "x1":" "0",
+      "x2": "70",
+      "value": 68139,
+      "label": "70. Perzentile",
+      "showValue": true,
+      "unit": "Franken",
+      "position": "bottom",
+      "ghost": true,
+      "textAlignment": "left",
+      "leftLabels": true
     },
   ]
 }}

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -991,15 +991,30 @@ age,date,value
       "value": 6000,
       "label": "Schätzung",
       "showValue": false,
-      "position": "bottom"
+      "position": "bottom",
+      textAlignment: 'right',
     },
     {
-      "x": 74,
+      "x": '74',
       "value": 90712,
       "label": "Tatsächlich",
       "showValue": false,
-      "position": "bottom"
-    }
+      "position": "bottom",
+      "textAlignment": 'right'
+
+    },
+    {
+      x1: '0',
+      x2: '70',
+      value: 68139,
+      label: '70. Perzentile',
+      showValue: true,
+      unit: 'Franken',
+      position: 'bottom',
+      ghost: true,
+      textAlignment: 'left',
+      leftLabel: true
+    },
   ]
 }}
     values={`

--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -1012,7 +1012,6 @@ age,date,value
       unit: 'Franken',
       position: 'bottom',
       ghost: true,
-      textAlignment: 'left',
       leftLabel: true
     },
   ]

--- a/src/components/Chart/TimeBarsAnnotations.js
+++ b/src/components/Chart/TimeBarsAnnotations.js
@@ -16,17 +16,10 @@ const labelGauger = createTextGauger(LABEL_FONT, {
   html: true
 })
 
-const convertTextAlignment = alignment => {
-  switch (alignment) {
-    case 'left':
-      return 'start'
-    case 'center':
-      return 'middle'
-    case 'right':
-      return 'end'
-    default:
-      return 'middle'
-  }
+const textAlignmentDict = {
+  left: 'start',
+  center: 'middle',
+  right: 'end'
 }
 
 const styles = {
@@ -140,9 +133,13 @@ export const XAnnotation = ({
         textAnchor = 'start'
         tx = x1
       }
+    } else {
+      textAnchor = 'middle'
     }
+  } else if (annotation.leftLabel) {
+    textAnchor = 'start'
   } else {
-    textAnchor = convertTextAlignment(annotation.textAlignment)
+    textAnchor = textAlignmentDict[annotation.textAlignment] || 'middle'
   }
 
   const isBottom = annotation.position === 'bottom'

--- a/src/components/Chart/TimeBarsAnnotations.js
+++ b/src/components/Chart/TimeBarsAnnotations.js
@@ -16,6 +16,19 @@ const labelGauger = createTextGauger(LABEL_FONT, {
   html: true
 })
 
+const convertTextAlignment = alignment => {
+  switch (alignment) {
+    case 'left':
+      return 'start'
+    case 'center':
+      return 'middle'
+    case 'right':
+      return 'end'
+    default:
+      return 'middle'
+  }
+}
+
 const styles = {
   annotationLine: css({
     strokeWidth: '1px',
@@ -91,6 +104,7 @@ export const XAnnotation = ({
     return null
   }
   const isRange = annotation.x1 !== undefined && annotation.x2 !== undefined
+
   const labelText = tLabel(annotation.label)
   const valueText =
     showAnnotationValue(annotation) &&
@@ -107,21 +121,30 @@ export const XAnnotation = ({
     labelText ? labelGauger(labelText) : 0,
     valueText ? valueGauger(valueText) : 0
   )
-  const x1 = isRange ? xCalc(annotation.x1) : xCalc(annotation.x)
+  const x1 = annotation.leftLabel
+    ? 0
+    : isRange
+    ? xCalc(annotation.x1)
+    : xCalc(annotation.x)
   const x2 = isRange
     ? xCalc(annotation.x2) + barWidth
     : x1 + Math.max(barWidth, 8)
 
   let textAnchor = 'middle'
-  let tx = x1 + (x2 - x1) / 2
-  if (x1 + (x2 - x1) / 2 + textSize / 2 > width) {
-    textAnchor = 'end'
-    tx = x2
-    if ((isRange ? x2 : x1) - textSize < 0) {
-      textAnchor = 'start'
-      tx = x1
+  let tx = annotation.leftLabel ? 0 : x1 + (x2 - x1) / 2
+  if (annotation.textAlignment === undefined) {
+    if (x1 + (x2 - x1) / 2 + textSize / 2 > width) {
+      textAnchor = 'end'
+      tx = x2
+      if ((isRange ? x2 : x1) - textSize < 0) {
+        textAnchor = 'start'
+        tx = x1
+      }
     }
+  } else {
+    textAnchor = convertTextAlignment(annotation.textAlignment)
   }
+
   const isBottom = annotation.position === 'bottom'
   return (
     <>
@@ -131,12 +154,14 @@ export const XAnnotation = ({
         {...(isRange ? styles.annotationLine : styles.annotationLineValue)}
         {...colorScheme.set('stroke', 'text')}
       />
-      <circle
-        r='3.5'
-        cx={x1}
-        {...colorScheme.set('stroke', 'text')}
-        {...colorScheme.set('fill', 'textInverted')}
-      />
+      {annotation.leftLabel === undefined && (
+        <circle
+          r='3.5'
+          cx={x1}
+          {...colorScheme.set('stroke', 'text')}
+          {...colorScheme.set('fill', 'textInverted')}
+        />
+      )}
       {isRange && (
         <circle
           r='3.5'

--- a/src/components/Chart/TimeBarsAnnotations.js
+++ b/src/components/Chart/TimeBarsAnnotations.js
@@ -139,7 +139,7 @@ export const XAnnotation = ({
   } else if (annotation.leftLabel) {
     textAnchor = 'start'
   } else {
-    textAnchor = textAlignmentDict[annotation.textAlignment] || 'middle'
+    textAnchor = textAlignmentDict[annotation.textAlignment]
   }
 
   const isBottom = annotation.position === 'bottom'


### PR DESCRIPTION
Add options for some text alignment and text labels on the left side

- Using two points (x1 and x2) the boolean leftLabel removes the x1 circle and draws a line from the YAxis to the x2 point
- The text alignment of X annotations can be modified by using textAlignment with the options left, right and center, if undefined it defaults to the previous system.

![Bildschirmfoto 2021-09-08 um 12 25 44](https://user-images.githubusercontent.com/11921821/132493133-99814629-8f0c-479c-807a-9eeec53701cc.png)
