### PR TITLE
fix(leftLabel): get the if else clauses right

### DIFF
--- a/src/components/Chart/TimeBars.docs.md
+++ b/src/components/Chart/TimeBars.docs.md
@@ -987,7 +987,7 @@ age,date,value
   "yScaleInvert": true,
   "xAnnotations": [
     {
-      "x": 40,
+      "x": "40",
       "value": 6000,
       "label": "Schätzung",
       "showValue": false,
@@ -995,7 +995,7 @@ age,date,value
       textAlignment: "right",
     },
     {
-      "x": "704",
+      "x": "74",
       "value": 90712,
       "label": "Tatsächlich",
       "showValue": false,
@@ -1004,7 +1004,7 @@ age,date,value
 
     },
     {
-      "x1":" "0",
+      "x1": "0",
       "x2": "70",
       "value": 68139,
       "label": "70. Perzentile",
@@ -1012,8 +1012,7 @@ age,date,value
       "unit": "Franken",
       "position": "bottom",
       "ghost": true,
-      "textAlignment": "left",
-      "leftLabels": true
+      "leftLabel": true
     },
   ]
 }}

--- a/src/components/Chart/TimeBarsAnnotations.js
+++ b/src/components/Chart/TimeBarsAnnotations.js
@@ -125,7 +125,9 @@ export const XAnnotation = ({
 
   let textAnchor = 'middle'
   let tx = annotation.leftLabel ? 0 : x1 + (x2 - x1) / 2
-  if (annotation.textAlignment === undefined) {
+  if (annotation.leftLabel) {
+    textAnchor = 'start'
+  } else if (annotation.textAlignment === undefined) {
     if (x1 + (x2 - x1) / 2 + textSize / 2 > width) {
       textAnchor = 'end'
       tx = x2
@@ -136,8 +138,6 @@ export const XAnnotation = ({
     } else {
       textAnchor = 'middle'
     }
-  } else if (annotation.leftLabel) {
-    textAnchor = 'start'
   } else {
     textAnchor = textAlignmentDict[annotation.textAlignment]
   }


### PR DESCRIPTION
An error in the markdown and if else for leftLabel was false.

Time bars is currently not loading correctly, in time bars it should look like this instead:

<img width="1042" alt="Bildschirmfoto 2021-09-09 um 11 35 01" src="https://user-images.githubusercontent.com/11921821/132661952-2e12067d-9f69-41a0-a243-d2e5a60bb794.png">
