### PR TITLE
fix(d3localeFormat): add custom format for percent and minus

### DIFF
--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -49,7 +49,9 @@ const swissNumbers = formatLocale({
   decimal: ',',
   thousands: thousandSeparator,
   grouping: [3],
-  currency: ['CHF\u00a0', '']
+  currency: ['CHF\u00a0', ''],
+  minus: '\u2212',
+  percent: '\u2009%'
 })
 
 const formatPow = (tLabel, baseValue) => {


### PR DESCRIPTION
- use small white space between number and percent
- use minus sign

![Bildschirmfoto 2021-09-14 um 15 21 38](https://user-images.githubusercontent.com/11921821/133277142-6b99df0d-d51a-404f-925d-73d140620f83.png)
