### PR TITLE
fix(BlockQuoteParagraph): no longer rely on inherited text-color

### DIFF
--- a/src/components/BlockQuote/BlockQuoteParagraph.js
+++ b/src/components/BlockQuote/BlockQuoteParagraph.js
@@ -33,6 +33,7 @@ const BlockQuoteParagraph = ({ children, attributes }) => {
     <p
       {...attributes}
       {...styles.quote}
+      {...colorScheme.set('color', 'text')}
       {...colorScheme.set('backgroundColor', 'hover')}
       {...fontRule}
     >


### PR DESCRIPTION
## Description
The color of the blockquote-paragraph is now defined on the component level, so that the text-color is no longer based on the inherited style.

## Screenshot
<img width="802" alt="Screenshot 2021-09-15 at 17 39 58" src="https://user-images.githubusercontent.com/30313631/133464896-88476261-9064-469f-8830-272d8e40a1e5.png">