### PR TITLE
fix(EditorialNewsletter): Use 3rd wave logo

### DIFF
--- a/src/templates/EditorialNewsletter/email/Header.js
+++ b/src/templates/EditorialNewsletter/email/Header.js
@@ -21,13 +21,13 @@ export default ({ meta }) => {
           >
             <img
               height='79'
-              width={isCovid19 ? 226 : 178}
+              width={isCovid19 ? 234 : 178}
               src={`https://www.republik.ch/static/logo_republik_newsletter${
-                isCovid19 ? '_covid19_wave2' : ''
+                isCovid19 ? '_covid19_wave3' : ''
               }.png`}
               style={{
                 border: 0,
-                width: `${isCovid19 ? 226 : 178}px !important`,
+                width: `${isCovid19 ? 234 : 178}px !important`,
                 height: '79px !important',
                 margin: 0,
                 maxWidth: '100% !important'


### PR DESCRIPTION
<img width="998" alt="Bildschirmfoto 2021-09-17 um 15 27 53" src="https://user-images.githubusercontent.com/331800/133792564-fc7276b8-38a5-4ca2-9713-29b30978a910.png">

(uses assets provided in https://github.com/orbiting/republik-frontend/pull/635)