### PR TITLE
Gallery fixes

### DIFF
--- a/src/components/Figure/Caption.js
+++ b/src/components/Figure/Caption.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { sansSerifRegular12, sansSerifRegular15 } from '../Typography/styles'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
 import { mUp } from '../../theme/mediaQueries'
 import { PADDING } from '../Center'
 import { convertStyleToRem, pxToRem } from '../Typography/utils'
@@ -17,16 +17,20 @@ const styles = {
       ...convertStyleToRem(sansSerifRegular15),
       lineHeight: pxToRem('18px')
     }
+  }),
+  groupCaption: css({
+    marginTop: -10,
+    marginBottom: 15
   })
 }
 
-export const Caption = ({ children, attributes }) => {
+export const Caption = ({ children, attributes, groupCaption }) => {
   const [colorScheme] = useColorContext()
 
   return (
     <figcaption
       {...attributes}
-      {...styles.caption}
+      {...merge(styles.caption, groupCaption && styles.groupCaption)}
       {...colorScheme.set('color', 'text')}
     >
       {children}
@@ -36,7 +40,8 @@ export const Caption = ({ children, attributes }) => {
 
 Caption.propTypes = {
   children: PropTypes.node.isRequired,
-  attributes: PropTypes.object
+  attributes: PropTypes.object,
+  groupCaption: PropTypes.bool
 }
 
 export default Caption

--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -9,6 +9,8 @@ import { sansSerifRegular12, sansSerifRegular15 } from '../Typography/styles'
 import { mUp } from '../../theme/mediaQueries'
 import SwitchImage from './SwitchImage'
 
+export const MIN_GALLERY_IMG_WIDTH = 600
+
 const styles = {
   image: css({
     width: '100%'

--- a/src/components/Figure/docs.md
+++ b/src/components/Figure/docs.md
@@ -186,7 +186,7 @@ A `<FigureGroup />` containing two side-by-side `<Figure>` elements, with one sh
   <Figure>
     <FigureImage src='/static/landscape.jpg' alt='' />
   </Figure>
-  <FigureCaption>
+  <FigureCaption groupCaption>
     This is an image caption stretching beautifully over both images as you can see above.{' '}
     <FigureByline>Photos: Laurent Burst</FigureByline>
   </FigureCaption>
@@ -277,7 +277,7 @@ A `<FigureGroup />` containing four `<Figure>` elements in two columns:
       <FigureByline>Photo: Laurent Burst</FigureByline>
     </FigureCaption>
   </Figure>
-  <FigureCaption>
+  <FigureCaption groupCaption>
     This is a caption stretching beautifully across the group of all images as you can see above.
   </FigureCaption>
 </FigureGroup>
@@ -297,7 +297,7 @@ Supports `breakout` sizes:
     <Figure>
       <FigureImage src='/static/landscape.jpg' alt='' />
     </Figure>
-    <FigureCaption>
+    <FigureCaption groupCaption>
       This is an image caption stretching beautifully over both images as you can see above.{' '}
       <FigureByline>Photos: Laurent Burst</FigureByline>
     </FigureCaption>

--- a/src/components/Figure/index.js
+++ b/src/components/Figure/index.js
@@ -15,7 +15,7 @@ import {
 
 import { plainButtonRule } from '../Button'
 
-export { default as FigureImage } from './Image'
+export { default as FigureImage, MIN_GALLERY_IMG_WIDTH } from './Image'
 export { default as FigureCaption } from './Caption'
 export { default as FigureByline } from './Byline'
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -64,7 +64,8 @@ export {
   FigureGroup,
   FigureByline,
   FigureCaption,
-  FigureImage
+  FigureImage,
+  MIN_GALLERY_IMG_WIDTH
 } from './components/Figure'
 export { Tweet } from './components/Social'
 export { Video } from './components/Video'

--- a/src/templates/Article/base.js
+++ b/src/templates/Article/base.js
@@ -21,7 +21,8 @@ import {
   matchHeading,
   matchType,
   matchZone,
-  matchParagraph
+  matchParagraph,
+  imageSizeInfo
 } from 'mdast-react-render/lib/utils'
 
 import {
@@ -33,6 +34,7 @@ import {
   extractImages,
   matchImagesParagraph
 } from './utils'
+import { MIN_GALLERY_IMG_WIDTH } from '../../components/Figure/Image'
 
 const createBase = ({ metaBody, metaHeadlines }) => {
   const link = {
@@ -181,7 +183,9 @@ const createBase = ({ metaBody, metaHeadlines }) => {
       const displayWidth = getDisplayWidth(ancestors)
       const enableGallery =
         meta.gallery !== false &&
-        (parent.data ? !parent.data.excludeFromGallery : true)
+        (parent.data ? !parent.data.excludeFromGallery : true) &&
+        imageSizeInfo(src) &&
+        imageSizeInfo(src).width > MIN_GALLERY_IMG_WIDTH
 
       const group = ancestors.find(matchZone('FIGUREGROUP'))
 

--- a/src/templates/Article/base.js
+++ b/src/templates/Article/base.js
@@ -235,6 +235,9 @@ const createBase = ({ metaBody, metaHeadlines }) => {
   const figureCaption = {
     matchMdast: matchParagraph,
     component: FigureCaption,
+    props: (node, index, parent, { ancestors }) => ({
+      groupCaption: parent.identifier === 'FIGUREGROUP'
+    }),
     editorModule: 'figureCaption',
     editorOptions: {
       isStatic: true,


### PR DESCRIPTION
- export gallery min width requirement 
- bring group caption up so they match with regular captions

_before_
<img width="1920" alt="Screenshot 2021-09-21 at 16 26 06" src="https://user-images.githubusercontent.com/3907984/134190399-23a0d081-92a9-4f39-8a27-908b73ab1536.png">

_after_
<img width="1920" alt="Screenshot 2021-09-21 at 16 25 48" src="https://user-images.githubusercontent.com/3907984/134190377-79710b20-921b-4904-978c-331f930de3d3.png">

Note: while it would have technically been possible to avoid using negative margins, this would require the more convoluted process of getting all the images in a group, checking which ones are in the last row and removing the bottom margin for those.
