### PR TITLE
fix(hasValues): convert numbers to string to evaluate length

### DIFF
--- a/src/components/Chart/utils.js
+++ b/src/components/Chart/utils.js
@@ -264,7 +264,7 @@ export const xAccessor = d => d.x
 
 export const yAccessor = d => d.y
 
-export const hasValues = d => d.value && d.value.length > 0
+export const hasValues = d => d.value && d.value.toString().length > 0
 
 export const identityFn = x => x
 


### PR DESCRIPTION
Currently, if we use the chart components in a dynamic component, the value column of the data has to be a string. With this fix, we can also use number data without converting it to strings.