### PR TITLE
Improve method to persist draft-values for input fields inside discussions

### DIFF
--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -110,7 +110,6 @@ export const CommentComposer = props => {
       return props.initialText
     } else if (typeof localStorage !== 'undefined') {
       try {
-        //return localStorage.getItem(localStorageKey) || ''
         return readDraft(discussionId, commentId) ?? ''
       } catch (e) {
         return ''

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -13,7 +13,7 @@ import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
 import { useColorContext } from '../../Colors/ColorContext'
 import Loader from '../../Loader'
-import { deleteDraft, readDraft, saveDraft } from './CommentDraftHelper'
+import { deleteDraft, readDraft, writeDraft } from './CommentDraftHelper'
 
 const styles = {
   root: css({}),
@@ -194,7 +194,7 @@ export const CommentComposer = props => {
     setText(nextText)
     setHints(composerHints.map(fn => fn(nextText)).filter(Boolean))
     try {
-      saveDraft(discussionId, commentId, ev.target.value)
+      writeDraft(discussionId, commentId, ev.target.value)
     } catch (e) {
       /* Ignore errors */
     }

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -313,7 +313,11 @@ export const CommentComposer = props => {
 
       <Actions
         t={t}
-        onClose={onClose}
+        onClose={() => {
+          onClose()
+          // Delete the draft of the field
+          deleteDraft(discussionId, commentId)
+        }}
         onCloseLabel={onCloseLabel}
         onSubmit={
           loading || (maxLength && textLength > maxLength)

--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -11,8 +11,9 @@ import { DiscussionContext } from '../DiscussionContext'
 import { convertStyleToRem } from '../../Typography/utils'
 import { Embed } from '../Internal/Comment'
 import { useDebounce } from '../../../lib/useDebounce'
-import { useColorContext } from '../../Colors/useColorContext'
+import { useColorContext } from '../../Colors/ColorContext'
 import Loader from '../../Loader'
+import { deleteDraft, readDraft, saveDraft } from './CommentDraftHelper'
 
 const styles = {
   root: css({}),
@@ -104,13 +105,13 @@ export const CommentComposer = props => {
    * provided through props. This way the user won't lose their text if the browser
    * crashes or if they inadvertently close the composer.
    */
-  const localStorageKey = commentComposerStorageKey(discussionId)
   const [text, setText] = React.useState(() => {
     if (props.initialText) {
       return props.initialText
     } else if (typeof localStorage !== 'undefined') {
       try {
-        return localStorage.getItem(localStorageKey) || ''
+        //return localStorage.getItem(localStorageKey) || ''
+        return readDraft(discussionId, commentId) ?? ''
       } catch (e) {
         return ''
       }
@@ -194,7 +195,7 @@ export const CommentComposer = props => {
     setText(nextText)
     setHints(composerHints.map(fn => fn(nextText)).filter(Boolean))
     try {
-      localStorage.setItem(localStorageKey, ev.target.value)
+      saveDraft(discussionId, commentId, ev.target.value)
     } catch (e) {
       /* Ignore errors */
     }
@@ -229,7 +230,7 @@ export const CommentComposer = props => {
 
           if (ok) {
             try {
-              localStorage.removeItem(localStorageKey)
+              deleteDraft(discussionId, commentId)
             } catch (e) {
               /* Ignore */
             }

--- a/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -84,18 +84,14 @@ export function saveDraft(discussionID, commentID, value) {
 
   // If no draft exists instantiate a new one.
   if (!drafts) {
-    console.debug('Create a new draft object')
     drafts = createDraftsObject()
   }
 
   if (commentID) {
-    console.debug('Updating reply draft')
     drafts.replies[commentID] = value
   } else {
-    console.debug('Updating comment draft')
     drafts.text = value
   }
-  console.log('Final updated draft', JSON.stringify(drafts))
   localStorage.setItem(storageKey, JSON.stringify(drafts))
 }
 

--- a/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -112,7 +112,7 @@ export function deleteDraft(discussionID, commentID) {
   if (!drafts) return undefined
 
   if (discussionID && !commentID) {
-    delete drafts.text
+    drafts.text = null
   } else if (discussionID && commentID) {
     delete drafts.replies[commentID]
   }

--- a/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -64,16 +64,11 @@ export function readDraft(discussionID, commentID) {
  */
 export function writeDraft(discussionID, commentID, value) {
   const storageKey = commentComposerStorageKey(discussionID)
-  let drafts = loadStoredDraftsObject(storageKey)
-
-  // If no draft exists instantiate a new one.
-  if (!drafts) {
-    drafts = createDraftsObject()
-  }
+  let drafts = loadStoredDraftsObject(storageKey) ?? createDraftsObject()
 
   // If the new value is an empty string (which is falsy in JS)
   // Delete the according draft
-  if (!value) {
+  if (!value.trim()) {
     deleteDraft(discussionID, commentID)
     return
   }

--- a/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -1,0 +1,127 @@
+import { commentComposerStorageKey } from './CommentComposer'
+
+/**
+ * Load a stored draft an validate the schema.
+ * @param key
+ * @returns {{replies}|{text}|any|undefined}
+ */
+function loadStoredDraftsObject(key) {
+  if (!localStorage) return undefined
+  const storedValue = localStorage.getItem(key)
+  if (!storedValue) return undefined
+
+  // ---- Handle possible legacy drafts ----
+  // check if the stored value is not a stringified object
+  if (!storedValue.startsWith('{')) {
+    const newValue = createDraftsObject()
+    // assume the legacy-draft is a comment-draft -> save in text property
+    newValue.text = storedValue
+    localStorage.setItem(key, JSON.stringify(newValue))
+    return newValue
+  }
+
+  try {
+    const value = JSON.parse(storedValue)
+
+    // Validate that the stored value has the correct shape
+    if (
+      'text' in value &&
+      'replies' in value &&
+      typeof value.replies === 'object'
+    ) {
+      return value
+    }
+    return undefined
+  } catch (e) {
+    // if an error occurs assume it's due to an invalid drafts-object
+    localStorage.removeItem(key)
+    return undefined
+  }
+}
+
+// Create an empty drafts object
+function createDraftsObject() {
+  return {
+    text: null,
+    replies: {}
+  }
+}
+
+/**
+ * Get a saved draft for a comment or a reply from a persisted drafts-object.
+ * @param discussionID discussionID defines what drafts-object should be loaded.
+ * @param commentID optional commentId if a reply-draft should be loaded.
+ */
+export function readDraft(discussionID, commentID) {
+  const storedDrafts = loadStoredDraftsObject(
+    commentComposerStorageKey(discussionID)
+  )
+  if (!storedDrafts) return undefined
+
+  // If no reply-draft is searched, return the comment-draft (possibly null)
+  if (!commentID && 'text' in storedDrafts) return storedDrafts.text
+
+  // If a reply-draft is searched make sure the drafts-object contains the needed key
+  if (
+    'replies' in storedDrafts &&
+    typeof storedDrafts.replies === 'object' &&
+    commentID in storedDrafts.replies
+  )
+    return storedDrafts.replies[commentID]
+
+  return undefined
+}
+
+/**
+ * Save a comment- or reply-draft inside a drafts-object.
+ * @param discussionID discussion for which a draft should be saved
+ * @param commentID put null if the value should be persisted for
+ * @param value that should be saved as a draft
+ */
+export function saveDraft(discussionID, commentID, value) {
+  const storageKey = commentComposerStorageKey(discussionID)
+  let drafts = loadStoredDraftsObject(storageKey)
+
+  // If no draft exists instantiate a new one.
+  if (!drafts) {
+    console.debug('Create a new draft object')
+    drafts = createDraftsObject()
+  }
+
+  if (commentID) {
+    console.debug('Updating reply draft')
+    drafts.replies[commentID] = value
+  } else {
+    console.debug('Updating comment draft')
+    drafts.text = value
+  }
+  console.log('Final updated draft', JSON.stringify(drafts))
+  localStorage.setItem(storageKey, JSON.stringify(drafts))
+}
+
+/**
+ * Delete a comment-draft or a reply-draft from a drafts-object.
+ * If no value is present after the according value has been deleted,
+ * get rid of the drafts-object.
+ * @param discussionID discussion for which the drafts-object should be loaded.
+ * @param commentID optional commentID if a reply-draft should be deleted.
+ */
+export function deleteDraft(discussionID, commentID) {
+  const storageKey = commentComposerStorageKey(discussionID)
+  let drafts = loadStoredDraftsObject(storageKey)
+  if (!drafts) return undefined
+
+  if (discussionID && !commentID) {
+    delete drafts.text
+  } else if (discussionID && commentID) {
+    delete drafts.replies[commentID]
+  }
+
+  // If the drafts-object is empty delete it all together
+  if (!drafts.text && Object.keys(drafts.replies).length === 0) {
+    localStorage.removeItem(storageKey)
+  } else {
+    // If the drafts-object is not empty update it
+    localStorage.setItem(storageKey, JSON.stringify(drafts))
+  }
+}

--- a/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -6,7 +6,7 @@ import { commentComposerStorageKey } from './CommentComposer'
  * @returns {{replies}|{text}|any|undefined}
  */
 function loadStoredDraftsObject(key) {
-  if (!localStorage) return undefined
+  if (typeof localStorage === 'undefined') return undefined
   const storedValue = localStorage.getItem(key)
   if (!storedValue) return undefined
 

--- a/src/components/Discussion/Composer/CommentDraftHelper.js
+++ b/src/components/Discussion/Composer/CommentDraftHelper.js
@@ -62,7 +62,7 @@ export function readDraft(discussionID, commentID) {
  * @param commentID put null if the value should be persisted for
  * @param value that should be saved as a draft
  */
-export function saveDraft(discussionID, commentID, value) {
+export function writeDraft(discussionID, commentID, value) {
   const storageKey = commentComposerStorageKey(discussionID)
   let drafts = loadStoredDraftsObject(storageKey)
 
@@ -71,11 +71,19 @@ export function saveDraft(discussionID, commentID, value) {
     drafts = createDraftsObject()
   }
 
+  // If the new value is an empty string (which is falsy in JS)
+  // Delete the according draft
+  if (!value) {
+    deleteDraft(discussionID, commentID)
+    return
+  }
+
   if (commentID) {
     drafts.replies[commentID] = value
   } else {
     drafts.text = value
   }
+
   localStorage.setItem(storageKey, JSON.stringify(drafts))
 }
 

--- a/src/components/Discussion/Tree/CommentList.js
+++ b/src/components/Discussion/Tree/CommentList.js
@@ -3,12 +3,12 @@ import { css, merge } from 'glamor'
 import scrollIntoView from 'scroll-into-view'
 
 import { DiscussionContext } from '../DiscussionContext'
-import { CommentComposer } from '../Composer/CommentComposer'
+import { CommentComposer } from '../Composer'
 import { LoadMore } from './LoadMore'
 import * as Comment from '../Internal/Comment'
 import * as config from '../config'
 import { mUp } from '../../../theme/mediaQueries'
-import { useColorContext } from '../../Colors/useColorContext'
+import { useColorContext } from '../../Colors/ColorContext'
 
 const buttonStyle = {
   display: 'block',
@@ -412,6 +412,7 @@ const CommentNode = ({
               t={t}
               isRoot={false /* Replies can never be root comments */}
               parentId={comment.id}
+              commentId={comment.id}
               onClose={closeReplyComposer}
               autoFocus={replyComposerAutoFocus}
               onSubmit={({ text, tags }) =>

--- a/src/components/Discussion/Tree/CommentList.js
+++ b/src/components/Discussion/Tree/CommentList.js
@@ -9,6 +9,7 @@ import * as Comment from '../Internal/Comment'
 import * as config from '../config'
 import { mUp } from '../../../theme/mediaQueries'
 import { useColorContext } from '../../Colors/ColorContext'
+import { readDraft } from '../Composer/CommentDraftHelper'
 
 const buttonStyle = {
   display: 'block',
@@ -243,10 +244,11 @@ const CommentNode = ({
       isExpanded: true,
       replyComposerAutoFocus: false,
       showReplyComposer:
-        !!displayAuthor &&
-        isRoot &&
-        !!rootCommentOverlay &&
-        !(comments && comments.nodes && comments.nodes.length)
+        (!!displayAuthor &&
+          isRoot &&
+          !!rootCommentOverlay &&
+          !(comments && comments.nodes && comments.nodes.length)) ||
+        readDraft(discussion.id, comment.id)
     }
   )
 


### PR DESCRIPTION
## Description

This pull-request aims to solve an issue caused by a shared draft for all inputs on a discussion. Now each input is saved on it's own and can thus be saved without overlap.



## Videos


### Before

https://user-images.githubusercontent.com/30313631/134655241-377cd854-73fc-47b2-a798-78800b9a08cc.mov




### After



https://user-images.githubusercontent.com/30313631/134655493-5e14b998-908e-45f7-ac82-9ba6b660bc9d.mov

(at 6 seconds you see how previous drafts get migrated)