### PR TITLE
Improve Social Preview

### DIFF
--- a/src/components/ShareImage/ShareImagePreview.js
+++ b/src/components/ShareImage/ShareImagePreview.js
@@ -1,7 +1,10 @@
 import React, { useRef, useEffect, useState } from 'react'
 import { css } from 'glamor'
 import { fontStyles } from '../../theme/fonts'
-import { imageStyle, TWITTER_CARD_PREVIEW_WIDTH } from './SharePreviewTwitter'
+import {
+  previewImageStyle,
+  TWITTER_CARD_PREVIEW_WIDTH
+} from './SharePreviewTwitter'
 import { FACEBOOK_CARD_PREVIEW_WIDTH } from './SharePreviewFacebook'
 import { Label } from '../Typography'
 import colors from '../../theme/colors'
@@ -12,10 +15,10 @@ export const SHARE_IMAGE_HEIGHT = 628
 export const SHARE_IMAGE_PADDING = 48
 
 export const socialPreviewStyles = {
-  twitter: imageStyle
+  twitter: previewImageStyle
 }
 
-const socialPreviewWidth = {
+export const socialPreviewWidth = {
   twitter: TWITTER_CARD_PREVIEW_WIDTH,
   facebook: FACEBOOK_CARD_PREVIEW_WIDTH
 }

--- a/src/components/ShareImage/ShareImagePreview.js
+++ b/src/components/ShareImage/ShareImagePreview.js
@@ -1,7 +1,8 @@
 import React, { useRef, useEffect, useState } from 'react'
 import { css } from 'glamor'
 import { fontStyles } from '../../theme/fonts'
-import { imageStyle } from './SharePreviewTwitter'
+import { imageStyle, TWITTER_CARD_PREVIEW_WIDTH } from './SharePreviewTwitter'
+import { FACEBOOK_CARD_PREVIEW_WIDTH } from './SharePreviewFacebook'
 import { Label } from '../Typography'
 import colors from '../../theme/colors'
 import { PLACEHOLDER_TEXT } from './index'
@@ -12,6 +13,11 @@ export const SHARE_IMAGE_PADDING = 48
 
 export const socialPreviewStyles = {
   twitter: imageStyle
+}
+
+const socialPreviewWidth = {
+  twitter: TWITTER_CARD_PREVIEW_WIDTH,
+  facebook: FACEBOOK_CARD_PREVIEW_WIDTH
 }
 
 const styles = {
@@ -26,11 +32,6 @@ const styles = {
     padding: SHARE_IMAGE_PADDING,
     overflow: 'hidden',
     wordWrap: 'break-word'
-  }),
-  containerHalfSize: css({
-    transform: `scale(${0.5})`,
-    transformOrigin: '0 0',
-    marginBottom: -SHARE_IMAGE_HEIGHT / 2
   }),
   kolumnenContainer: css({
     alignItems: 'flex-end'
@@ -116,6 +117,8 @@ const ShareImagePreview = ({
     )
   }, [text, fontSize])
 
+  const previewWidth = socialPreviewWidth[preview]
+
   return (
     <>
       {preview && textContainerOverflow ? (
@@ -125,7 +128,13 @@ const ShareImagePreview = ({
       ) : null}
       <div
         {...styles.container}
-        {...(preview && styles.containerHalfSize)}
+        {...(previewWidth &&
+          css({
+            transform: `scale(${previewWidth / SHARE_IMAGE_WIDTH})`,
+            transformOrigin: '0 0',
+            marginBottom:
+              -SHARE_IMAGE_HEIGHT * (1 - previewWidth / SHARE_IMAGE_WIDTH)
+          }))}
         {...socialPreview}
         {...(shareImage && styles.kolumnenContainer)}
         style={{

--- a/src/components/ShareImage/ShareImagePreview.js
+++ b/src/components/ShareImage/ShareImagePreview.js
@@ -117,7 +117,7 @@ const ShareImagePreview = ({
     )
   }, [text, fontSize])
 
-  const previewWidth = socialPreviewWidth[preview]
+  const previewWidth = socialPreviewWidth[preview] || (preview && 600)
 
   return (
     <>

--- a/src/components/ShareImage/SharePreviewFacebook.js
+++ b/src/components/ShareImage/SharePreviewFacebook.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import { css } from 'glamor'
 
+export const FACEBOOK_CARD_PREVIEW_WIDTH = 590
+
 const styles = {
   container: css({
     backgroundColor: '#fff',
     color: '#000',
-    width: 600,
+    width: FACEBOOK_CARD_PREVIEW_WIDTH,
     padding: '10px 12px',
     maxHeight: 120,
     overflow: 'hidden'

--- a/src/components/ShareImage/SharePreviewFacebook.js
+++ b/src/components/ShareImage/SharePreviewFacebook.js
@@ -1,49 +1,54 @@
 import React from 'react'
 import { css } from 'glamor'
+import { Editorial } from '../Typography'
 
 export const FACEBOOK_CARD_PREVIEW_WIDTH = 590
 
 const styles = {
   container: css({
-    backgroundColor: '#fff',
-    color: '#000',
+    backgroundColor: 'rgb(240, 242, 245)',
+    color: 'rgb(28, 30, 33)',
     width: FACEBOOK_CARD_PREVIEW_WIDTH,
     padding: '10px 12px',
     maxHeight: 120,
-    overflow: 'hidden'
+    overflow: 'hidden',
+    fontFamily:
+      'system-ui, -apple-system, system-ui, ".SFNSText-Regular", sans-serif'
   }),
   title: css({
-    fontFamily: 'Georgia, serif',
-    fontSize: 18,
-    fontWeight: 500,
-    lineHeight: '22px',
+    fontSize: 16,
+    fontWeight: 600,
+    lineHeight: '1.17em',
     maxHeight: 110,
     overflow: 'hidden',
-    marginBottom: 5,
-    wordWrap: 'break-word'
+    marginBottom: 3,
+    wordWrap: 'break-word',
+    color: 'rgb(5, 5, 5)'
   }),
   description: css({
     fontFamily: 'sans-serif',
-    fontSize: 12,
-    lineHeight: '16px',
-    maxHeight: 80,
-    overflow: 'hidden'
+    fontSize: 14,
+    lineHeight: '1.33em',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    color: 'rgb(101, 103, 107)'
   }),
   domain: css({
     fontFamily: 'sans-serif',
-    fontSize: 11,
-    lineHeight: '11px',
+    fontSize: 12,
+    lineHeight: '1.23em',
     textTransform: 'uppercase',
-    color: '#90949c',
-    paddingTop: 9
+    color: 'rgb(101, 103, 107)',
+    paddingBottom: 4
   })
 }
 
 const SharePreviewFacebook = ({ title, description }) => (
   <div {...styles.container}>
+    <div {...styles.domain}>republik.ch</div>
     <div {...styles.title}>{title}</div>
     <div {...styles.description}>{description}</div>
-    <div {...styles.domain}>republik.ch</div>
   </div>
 )
 

--- a/src/components/ShareImage/SharePreviewFacebook.js
+++ b/src/components/ShareImage/SharePreviewFacebook.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { css } from 'glamor'
-import { Editorial } from '../Typography'
 
 export const FACEBOOK_CARD_PREVIEW_WIDTH = 590
 

--- a/src/components/ShareImage/SharePreviewTwitter.js
+++ b/src/components/ShareImage/SharePreviewTwitter.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { css } from 'glamor'
+import { fontStyles } from '../../theme/fonts'
 
 export const imageStyle = css({
   borderTopLeftRadius: 15,
@@ -9,43 +10,47 @@ export const imageStyle = css({
   boxShadow: '0px 0px 2px 2px rgb(204, 214, 221)'
 })
 
+export const TWITTER_CARD_PREVIEW_WIDTH = 504
+
 const styles = {
   container: css({
-    fontSize: 14,
     backgroundColor: '#fff',
     color: '#000',
-    width: 600,
+    width: TWITTER_CARD_PREVIEW_WIDTH,
     borderBottomRightRadius: 15,
     borderBottomLeftRadius: 15,
     boxShadow: '0px 0px 1px 1px rgb(204, 214, 221)',
     padding: '10.5px 14px',
-    fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
     maxHeight: 120,
-    overflow: 'hidden'
+    overflow: 'hidden',
+    ...fontStyles.sansSerifRegular,
+    fontSize: 15,
+    lineHeight: '1.33em'
   }),
   title: css({
-    maxHeight: '1.3em',
+    maxHeight: '1.33em',
     fontSize: '1em',
-    lineHeight: '1.3em',
-    margin: '0 0 .15em',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
-    fontWeight: 'bold'
+    color: '#000'
   }),
   description: css({
     fontSize: '1em',
-    lineHeight: '1.3em',
-    marginTop: '.32333em',
+    marginTop: '.2em',
     overflow: 'hidden',
-    maxHeight: '2.6em'
+    textOverflow: 'ellipsis',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 2,
+    maxHeight: '2.66em',
+    color: 'rgb(83, 100, 113)'
   }),
   domain: css({
     fontSize: '1em',
-    lineHeight: '1.3em',
-    marginTop: '.32333em',
+    marginTop: '.2em',
     textTransform: 'lowercase',
-    color: '#8899A6',
+    color: 'rgb(83, 100, 113)',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap'

--- a/src/components/ShareImage/SharePreviewTwitter.js
+++ b/src/components/ShareImage/SharePreviewTwitter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { css } from 'glamor'
 import { fontStyles } from '../../theme/fonts'
 
-export const imageStyle = css({
+export const previewImageStyle = css({
   borderTopLeftRadius: 15,
   borderTopRightRadius: 15,
   // boxshadow of image is 2x that of text container beacuse

--- a/src/components/ShareImage/docs.md
+++ b/src/components/ShareImage/docs.md
@@ -63,6 +63,22 @@ Supported props:
 </div>
 ```
 
+### Max Text Length Test
+
+```react
+<div>
+<SharePreviewTwitter
+  title='«Viele Pflegende brauchen jetzt noch mehr Kraft, weil sie wissen: Es müsste nicht sein»' 
+  description='Bericht aus den Intensiv­stationen des Uni­spitals Zürich: Pflege­expertin Carmen Karde erzählt, wie sich die vierte Corona-Welle auf den Alltag der Pflege­fachkräfte auswirkt.' 
+/>
+<br />
+<SharePreviewFacebook
+  title='«Viele Pflegende brauchen jetzt noch mehr Kraft, weil sie wissen: Es müsste nicht sein»' 
+  description='Bericht aus den Intensiv­stationen des Unispitals Zürich: Pflege­expertin Carmen Karde erzählt, wie sich die vierte Corona-Welle auf den Alltag der Pflege­fachkräfte auswirkt.'
+/>
+</div>
+```
+
 # Share Image Generator
 
 A `<ShareImageGenerator />` takes a format type and returns a form to create a share image for that specific format type style.

--- a/src/components/ShareImage/docs.md
+++ b/src/components/ShareImage/docs.md
@@ -63,21 +63,23 @@ Supported props:
 </div>
 ```
 
-### Max Text Length Test
+### Text Length Test
 
 ```react
 <div>
-<SharePreviewTwitter
-  title='«Viele Pflegende brauchen jetzt noch mehr Kraft, weil sie wissen: Es müsste nicht sein»' 
-  description='Bericht aus den Intensiv­stationen des Uni­spitals Zürich: Pflege­expertin Carmen Karde erzählt, wie sich die vierte Corona-Welle auf den Alltag der Pflege­fachkräfte auswirkt.' 
-/>
-<br />
-<SharePreviewFacebook
-  title='«Viele Pflegende brauchen jetzt noch mehr Kraft, weil sie wissen: Es müsste nicht sein»' 
-  description='Bericht aus den Intensiv­stationen des Unispitals Zürich: Pflege­expertin Carmen Karde erzählt, wie sich die vierte Corona-Welle auf den Alltag der Pflege­fachkräfte auswirkt.'
-/>
+  <SharePreviewTwitter
+    title='«Viele Pflegende brauchen jetzt noch mehr Kraft, weil sie wissen: Es müsste nicht sein»' 
+    description='Bericht aus den Intensiv­stationen des Uni­spitals Zürich: Pflege­expertin Carmen Karde erzählt, wie sich die vierte Corona-Welle auf den Alltag der Pflege­fachkräfte auswirkt.' 
+  />
+  <br />
+  <SharePreviewFacebook
+    title='Schweizer Firmen im Klimacheck' 
+    description='Die Finanzwelt muss beim Klimaschutz mithelfen. Doch das ist kniffliger, als man denkt. Wie wählt man die richtigen Aktien aus? Erster Teil einer Serie über klimafreundliche Investments.'
+  />
 </div>
 ```
+
+Facebook hides the description if the title spans two lines.
 
 # Share Image Generator
 

--- a/src/components/TeaserEmbedComment/index.js
+++ b/src/components/TeaserEmbedComment/index.js
@@ -6,7 +6,7 @@ import { useMediaQuery } from '../../lib/useMediaQuery'
 import { mUp } from '../../theme/mediaQueries'
 import { css } from 'glamor'
 import { useColorContext } from '../Colors/ColorContext'
-import { linkRule, plainLinkRule } from '../Typography'
+import { plainLinkRule } from '../Typography'
 
 const styles = {
   root: css({

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,8 @@ const Styleguide = () => {
                         ...require('./components/Typography'),
                         ShareImageGenerator: require('./components/ShareImage'),
                         ShareImagePreview: require('./components/ShareImage/ShareImagePreview'),
-                        SharePreviewTwitter: require('./components/ShareImage/SharePreviewTwitter')
+                        SharePreviewTwitter: require('./components/ShareImage/SharePreviewTwitter'),
+                        SharePreviewFacebook: require('./components/ShareImage/SharePreviewFacebook')
                       }
                     }
                   ]

--- a/src/lib.js
+++ b/src/lib.js
@@ -156,6 +156,7 @@ export { default as ShareImageGenerator } from './components/ShareImage'
 export {
   default as ShareImagePreview,
   socialPreviewStyles,
+  socialPreviewWidth,
   SHARE_IMAGE_DEFAULTS,
   SHARE_IMAGE_HEIGHT,
   SHARE_IMAGE_WIDTH


### PR DESCRIPTION
The production team asked for an update of the social previews. With special attention to how much text is realistically shown.

Twitter and Facebook are quite responsive nowadays so it's hard to settle on a width. The width I've used are from post feeds on my laptop with 1440x. Mobile usually skips the description on both services.

Also updated fonts and other styles.

<img width="855" alt="Screenshot 2021-09-30 at 17 51 32" src="https://user-images.githubusercontent.com/410211/135489104-d4a5c6ee-7e94-435a-b9c5-b68b9a72bcac.png">
