### PR TITLE
fix(TeaserEmbedComment): remove whitespace for multiple embeds in a row

### DIFF
--- a/src/components/TeaserEmbedComment/index.js
+++ b/src/components/TeaserEmbedComment/index.js
@@ -4,30 +4,42 @@ import DiscussionFooter from '../CommentTeaser/DiscussionFooter'
 import { DiscussionContext } from '../Discussion/DiscussionContext'
 import { useMediaQuery } from '../../lib/useMediaQuery'
 import { mUp } from '../../theme/mediaQueries'
-import { css } from 'glamor'
+import { css, merge } from 'glamor'
 import { useColorContext } from '../Colors/ColorContext'
-import { linkRule, plainLinkRule } from '../Typography'
+import { plainLinkRule } from '../Typography'
 
 const styles = {
   root: css({
     borderTopWidth: 1,
     borderTopStyle: 'solid',
-    borderBottomWidth: 1,
-    borderBottomStyle: 'solid',
     paddingTop: 10,
     paddingBottom: 10,
     textAlign: 'left',
-    margin: '36px auto',
+    margin: '0 auto',
     position: 'relative',
     maxWidth: '455px',
     whiteSpace: 'normal',
     [mUp]: {
-      margin: '45px auto'
+      margin: '0 auto'
+    }
+  }),
+  isLast: css({
+    marginBottom: 36,
+    borderBottomWidth: 1,
+    borderBottomStyle: 'solid',
+    [mUp]: {
+      marginBottom: 45
+    }
+  }),
+  isFirst: css({
+    marginTop: 36,
+    [mUp]: {
+      marginTop: 45
     }
   })
 }
 
-const TeaserEmbedComment = ({ data, liveData, t, Link }) => {
+const TeaserEmbedComment = ({ data, liveData, t, Link, isFirst, isLast }) => {
   const isDesktop = useMediaQuery(mUp)
   const [colorScheme] = useColorContext()
 
@@ -64,7 +76,15 @@ const TeaserEmbedComment = ({ data, liveData, t, Link }) => {
   }
   return (
     <DiscussionContext.Provider value={discussionContextValue}>
-      <div id={data.id} {...styles.root} {...colorScheme.set('color', 'text')}>
+      <div
+        id={data.id}
+        {...merge(
+          styles.root,
+          isFirst && styles.isFirst,
+          isLast && styles.isLast
+        )}
+        {...colorScheme.set('color', 'text')}
+      >
         <Comment.Header
           t={t}
           comment={metaDataComment}

--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -542,12 +542,22 @@ const createSchema = ({
               },
               {
                 matchMdast: matchZone('EMBEDCOMMENT'),
-                props: node => ({
-                  data: {
-                    ...node.data,
-                    url: node.children[0].children[0].url
+                props: (node, index, parent) => {
+                  const isNotComment = i => {
+                    if (i < 0 || i > parent.children.length - 1) {
+                      return true
+                    }
+                    return !matchZone('EMBEDCOMMENT')(parent.children[i])
                   }
-                }),
+                  return {
+                    isFirst: isNotComment(index - 1),
+                    isLast: isNotComment(index + 1),
+                    data: {
+                      ...node.data,
+                      url: node.children[0].children[0].url
+                    }
+                  }
+                },
                 component: TeaserEmbedCommentSwitch,
                 editorModule: 'embedComment',
                 editorOptions: {


### PR DESCRIPTION
### Before
<img width="1792" alt="Screenshot 2021-10-04 at 11 43 33" src="https://user-images.githubusercontent.com/3907984/135829646-ef80583c-0b3f-4aaf-a7be-534ff9e9440f.png">

### After
<img width="1792" alt="Screenshot 2021-10-04 at 11 42 01" src="https://user-images.githubusercontent.com/3907984/135829681-a5effe89-bf5d-4a91-816b-d36e638ab7b8.png">

