### PR TITLE
fix(SeriesNav): hide paynote if a user has an active membership

### DIFF
--- a/src/components/Figure/Image.js
+++ b/src/components/Figure/Image.js
@@ -116,6 +116,8 @@ const Image = (props, context) => {
   return (
     <div
       {...styles.imageContainer}
+      // recreate dom for chaning src to ensure old image is not shown while new one loads
+      key={src}
       style={{
         cursor: enableGallery // during SSR context.toggleGallery and therefore onClick are not present
           ? 'zoom-in'

--- a/src/components/SeriesNav/SeriesNavTile.js
+++ b/src/components/SeriesNav/SeriesNavTile.js
@@ -72,6 +72,11 @@ const SeriesNavTile = ({
 
   return (
     <div
+      /* 
+      Hide PayNote for members by setting the hideForMember class. 
+      This class is defined in the MeContext in republik-frontend
+      */
+      className={PayNote ? 'hideIfMember' : undefined}
       {...(inline ? styles.inlineTile : styles.tile)}
       style={{
         opacity: inactiveTile ? 0.6 : 1

--- a/src/components/SeriesNav/SeriesNavTile.js
+++ b/src/components/SeriesNav/SeriesNavTile.js
@@ -73,10 +73,12 @@ const SeriesNavTile = ({
   return (
     <div
       /* 
-      Hide PayNote for members by setting the hideForMember class. 
+      Hide PayNote for members by setting the data-hide-if-member attribute. 
       This class is defined in the MeContext in republik-frontend
       */
-      className={PayNote ? 'hideIfMember' : undefined}
+      {...(PayNote && {
+        'data-hide-if-member': true
+      })}
       {...(inline ? styles.inlineTile : styles.tile)}
       style={{
         opacity: inactiveTile ? 0.6 : 1

--- a/src/components/SeriesNav/SeriesNavTile.js
+++ b/src/components/SeriesNav/SeriesNavTile.js
@@ -77,7 +77,7 @@ const SeriesNavTile = ({
       This class is defined in the MeContext in republik-frontend
       */
       {...(PayNote && {
-        'data-hide-if-member': true
+        'data-hide-if-active-membership': true
       })}
       {...(inline ? styles.inlineTile : styles.tile)}
       style={{


### PR DESCRIPTION
## Description
This change is required to hide the PayNote for members when showing statically generated sites, before React has rehydrated the page.