### PR TITLE
Fix comment composer bug

### DIFF
--- a/src/components/Discussion/Composer/CommentComposer.js
+++ b/src/components/Discussion/Composer/CommentComposer.js
@@ -126,9 +126,7 @@ export const CommentComposer = props => {
     ? preview.comment.contentLength
     : text.length
 
-  const [tagValue, setTagValue] = React.useState(
-    props.tagValue || (isRoot && activeTag)
-  )
+  const [tagValue, setTagValue] = React.useState(props.tagValue)
 
   /*
    * Focus the textarea upon mount.
@@ -150,7 +148,9 @@ export const CommentComposer = props => {
   const [slowText] = useDebounce(text, 400)
   textRef.current = text
   React.useEffect(() => {
-    setTagValue(isRoot ? activeTag : null)
+    if (!tagValue) {
+      setTagValue(isRoot ? activeTag : null)
+    }
     if (!isBoard || !isRoot || !previewCommentAction) {
       return
     }


### PR DESCRIPTION
Bug: the tag radio buttons in composer revert to the active tag when user starts typing.
Now the selection stays put.