### PR TITLE
fix text-decoration in underline style mixin

### DIFF
--- a/src/lib/styleMixins.js
+++ b/src/lib/styleMixins.js
@@ -6,5 +6,5 @@ export const ellipsize = {
 
 export const underline = {
   textDecoration: 'underline',
-  textDecorationSkip: 'ink'
+  textDecorationSkipInk: 'auto'
 }


### PR DESCRIPTION
Just a tiny thing I discovered:
`text-decoration-skip: ink;` is an invalid property name. You maybe wanted:
`text-decoration-skip-ink: auto;`
No visual change expected, as `auto` seems to be the default.

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip-ink