### PR TITLE
fix(Tabs): only scroll into view when not initial mount

### DIFF
--- a/src/components/Tabs/Scroller.tsx
+++ b/src/components/Tabs/Scroller.tsx
@@ -87,18 +87,27 @@ const Scroller = ({
   const [{ left, right }, setArrows] = useState({ left: false, right: false })
   const [colorScheme] = useColorContext()
 
+  const lastActiveChildIndex = useRef<Number>()
   useEffect(() => {
     const scroller = scrollRef.current
-    if (!scroller) return
-    const target = Array.from(scroller?.children)[activeChildIndex + 1] // + 1 for pad element
-    scrollIntoView(target, {
-      time: 400,
-      align: {
-        left: 0,
-        leftOffset: innerPadding,
-        ...getTop()
-      }
-    })
+    const target = Array.from(scroller.children)[activeChildIndex + 1] // + 1 for pad element
+
+    if (lastActiveChildIndex.current !== undefined && lastActiveChildIndex.current !== activeChildIndex) {
+      scrollIntoView(target, {
+        time: 400,
+        align: {
+          left: 0,
+          leftOffset: innerPadding,
+          ...getTop()
+        }
+      })
+    } else {
+      const leftEdge = scroller.getBoundingClientRect().left
+      const targetBounds = target.getBoundingClientRect()
+      const diff =  targetBounds.left - leftEdge - innerPadding
+      scroller.scrollLeft += diff
+    }
+    lastActiveChildIndex.current = activeChildIndex
   }, [activeChildIndex, innerPadding])
 
   useEffect(() => {

--- a/src/components/Tabs/docs.md
+++ b/src/components/Tabs/docs.md
@@ -8,8 +8,8 @@ A Tabs layout can be achieved with the `Scroller` and `TabButton` components The
 
 - children (React.ReactNode):
 - center? (boolean, false): Centers child nodes when there is enough space.
-- activeChildIndex? (activeChildIndex, 0): Index of the active scroll child dom node.
-- hideArrows? (boolean, false): Hides arrows
+- activeChildIndex? (number, 0): Index of the active scroll child dom node.
+- hideArrows? (boolean, false): Hides arrows.
 - arrowSize? (number, 28): Set size of the arrows.
 - innerPadding?: (number, 0): If the Scroller is in a container with negative horizontal margins, pass those as innerPadding to allow for proper padding in full width layouts.
 
@@ -26,41 +26,23 @@ A Tabs layout can be achieved with the `Scroller` and `TabButton` components The
 Default scroll behavior left aligns all the tabs and once the tab container exeeds the viewport, it allows for horizontal scrolling.
 
 ```react
-state: { activeChildIndex: 0 }
+state: { activeChildIndex: 1 }
 ---
 <div style={{ margin: '0 -20px' }} >
   <Scroller
     innerPadding={20}
     activeChildIndex={state.activeChildIndex}
   >
-    <TabButton
-      text="Child One"
-      isActive={state.activeChildIndex === 0}
-      onClick={() => {
-        setState({activeChildIndex: 0})
-      }}
-    />
-    <TabButton
-      text="Child Two"
-      isActive={state.activeChildIndex === 1}
-      onClick={() => {
-        setState({activeChildIndex: 1})
-      }}
-    />
-    <TabButton
-      text="Child Three"
-      isActive={state.activeChildIndex === 2}
-      onClick={() => {
-        setState({activeChildIndex: 2})
-      }}
-    />
-    <TabButton
-      text="Child Four"
-      isActive={state.activeChildIndex === 3}
-      onClick={() => {
-        setState({activeChildIndex: 3})
-      }}
-    />
+    {['One', 'Two', 'Three', 'Four', 'Five', 'Six'].map((n, i) => (
+      <TabButton
+        key={n}
+        text={`Child ${n}`}
+        isActive={state.activeChildIndex === i}
+        onClick={() => {
+          setState({activeChildIndex: i})
+        }}
+      />
+    ))}
   </Scroller>
 </div>
 ```
@@ -76,7 +58,7 @@ state: { activeChildIndex: 0 }
   <Scroller
     innerPadding={20}
     activeChildIndex={state.activeChildIndex}
-    center={true}
+    center
   >
     <TabButton
       text="Child One"
@@ -190,7 +172,6 @@ state: { activeChildIndex: 0 }
 <div style={{ margin: '0 -20px' }} >
   <Scroller
     innerPadding={20}
-    activeChildIndex={0}
     center={true}
   >
     <Link href="/" passHref>


### PR DESCRIPTION
Only animate in effect when `activeChildIndex` is changing.