### PR TITLE
fix(TabButton): fix borderColor bug in TabButton

### DIFF
--- a/src/components/Tabs/TabButton.tsx
+++ b/src/components/Tabs/TabButton.tsx
@@ -8,7 +8,7 @@ import { mUp } from '../../theme/mediaQueries'
 
 export type TabItemType = {
   text: string
-  children: ReactNode
+  children?: ReactNode
   isActive?: boolean
   onClick?: () => void
   href?: string
@@ -20,7 +20,6 @@ const styles = {
     padding: '8px 16px',
     borderBottomWidth: '1px',
     borderBottomStyle: 'solid',
-    borderColor: 'transparent',
     whiteSpace: 'nowrap',
     ...sansSerifRegular16,
     [mUp]: {
@@ -78,8 +77,10 @@ const TabButton = React.forwardRef(
         {...css(styles.default, isActive && styles.active, href && styles.link)}
         {...plainButtonRule}
         {...(!isActive && hoverRule)}
-        {...(border &&
-          colorScheme.set('borderColor', isActive ? 'text' : 'divider'))}
+        {...colorScheme.set(
+          'borderColor',
+          !border ? 'transparent' : isActive ? 'text' : 'divider'
+        )}
         title={text}
       >
         {text}


### PR DESCRIPTION
The borderColor: 'trasparent' was overwriting the bordercolor applied to the tabitem component
This fixes the issue:

before:
<img width="537" alt="Screenshot 2021-12-15 at 13 33 24" src="https://user-images.githubusercontent.com/20746301/146187844-a67cb7d3-7c40-4b6d-bf21-af04d5149d4a.png">

after:
<img width="374" alt="Screenshot 2021-12-15 at 13 36 56" src="https://user-images.githubusercontent.com/20746301/146187837-550df764-c0fc-419b-822f-c4dfa3df2ec3.png">

