### PR TITLE
Improve slug

### DIFF
--- a/src/lib/slug.js
+++ b/src/lib/slug.js
@@ -23,6 +23,7 @@ export const slug = string =>
     .toLowerCase()
     // eslint-disable-next-line no-control-regex
     .replace(/[^\u0000-\u007E]/g, a => diacriticsMap[a] || a)
+    .replace(/&shy;/g, '')
     .replace(/[^0-9a-z]+/g, ' ')
     .trim()
     .replace(/\s+/g, '-')

--- a/src/lib/slug.js
+++ b/src/lib/slug.js
@@ -23,7 +23,7 @@ export const slug = string =>
     .toLowerCase()
     // eslint-disable-next-line no-control-regex
     .replace(/[^\u0000-\u007E]/g, a => diacriticsMap[a] || a)
-    .replace(/&shy;/g, '')
+    .replace(/\u00ad/g, '')
     .replace(/[^0-9a-z]+/g, ' ')
     .trim()
     .replace(/\s+/g, '-')

--- a/src/lib/slug.test.js
+++ b/src/lib/slug.test.js
@@ -23,4 +23,8 @@ describe('lib.utils.slug - test suite', function() {
   test('umlaut french', function() {
     expect(slug('âàçéêèëîïôùû')).toEqual('aaceeeeiiouu')
   })
+
+  test('shy element', function() {
+    expect(slug('um&shy;welt&shy;schmerz')).toEqual('umweltschmerz')
+  })
 })

--- a/src/lib/slug.test.js
+++ b/src/lib/slug.test.js
@@ -24,7 +24,7 @@ describe('lib.utils.slug - test suite', function() {
     expect(slug('âàçéêèëîïôùû')).toEqual('aaceeeeiiouu')
   })
 
-  test('shy element', function() {
-    expect(slug('um&shy;welt&shy;schmerz')).toEqual('umweltschmerz')
+  test('soft hyphen', function() {
+    expect(slug('um\u00adwelt\u00adschmerz')).toEqual('umweltschmerz')
   })
 })


### PR DESCRIPTION
**Context:** in Publikator, we watch the document title and adjust the slug accordingly. Having a `&shy;` entity be interpreted as a `-` in the slug is confusing behaviour. We now filter them out.

_Tested_ with Publikator